### PR TITLE
⚡ Fix MutationObserver Memory Leak in StreetView.tsx

### DIFF
--- a/src/components/StreetView.tsx
+++ b/src/components/StreetView.tsx
@@ -15,19 +15,25 @@ const StreetView: React.FC<StreetViewProps> = ({ onCanvasReady, apiKey, initialP
     const startLocation = initialPosition ?? { lat: 39.2575004, lng: -121.021821 };
 
     useEffect(() => {
+        let isMounted = true;
+        let cleanup: (() => void) | null = null;
+
         if (!(window as any).google?.maps) {  // Stricter check to prevent double-load
             const script = document.createElement('script');
             script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&v=weekly&libraries=marker`;  // Stable v=weekly + marker lib
             script.async = true;
             script.defer = true;
-            script.onload = initialize;
+            script.onload = () => {
+                if (!isMounted) return;
+                cleanup = initialize();
+            };
             document.head.appendChild(script);  // Use head, not body
         } else {
-            initialize();
+            cleanup = initialize();
         }
 
         function initialize() {
-            if (!panoRef.current) return;
+            if (!panoRef.current) return null;
 
             // Setup Google Maps services
             const mapDiv = document.createElement('div');
@@ -98,6 +104,13 @@ const StreetView: React.FC<StreetViewProps> = ({ onCanvasReady, apiKey, initialP
                 observer.disconnect();
             };
         }
+
+        return () => {
+            isMounted = false;
+            if (cleanup) {
+                cleanup();
+            }
+        };
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [apiKey]);
 


### PR DESCRIPTION
The StreetView component was leaking MutationObserver instances because the cleanup function returned by the initialize function was being ignored by the useEffect hook. This resulted in observers persisting indefinitely, consuming memory and CPU.

The fix involves:
1. Capturing the return value of the initialize function (which contains the observer.disconnect() call).
2. Returning a cleanup function from useEffect that executes the captured initialize cleanup.
3. Introducing an isMounted guard to safely handle the asynchronous script loading process, ensuring that the observer is only created if the component is still mounted and that no resources are leaked if it unmounts early.

While automated benchmarks were impractical due to environment limitations, this change follows standard React performance patterns for resource management.

---
*PR created automatically by Jules for task [12156743934075808456](https://jules.google.com/task/12156743934075808456) started by @ford442*