### PR TITLE
feat: Hyper-Realism Pass — weather shaders, spring gauges, ambient dashboard

### DIFF
--- a/public/shaders/weather-post.wgsl
+++ b/public/shaders/weather-post.wgsl
@@ -50,8 +50,9 @@ struct WeatherParams {
     _pad0             : f32,  // padding to maintain alignment
     // 36: sunrise
     sunrise           : f32,  // 0.0 = no sunrise, 1.0 = full sunrise
-    // 37-39: padding to reach 40 floats (160 bytes total)
-    _pad1             : f32,
+    // 37: anamorphic lens flare streak width (0 = off, 0.5 = moderate)
+    anamorphicStreak  : f32,
+    // 38-39: padding to reach 40 floats (160 bytes total)
     _pad2             : f32,
     _pad3             : f32,
 }
@@ -246,7 +247,12 @@ fn rain(uv: vec2<f32>, t: f32, panX: f32, panY: f32) -> vec3<f32> {
         st.x = fract(st.x * 42.0) - 0.5 + (seed - 0.5) * 0.8;
         st.y = fract(st.y);
 
-        let streak = smoothstep(0.96, 1.0, 1.0 - length(st * vec2<f32>(0.45, 3.2)));
+        // Rotate streak axis to match wind direction — aggressive slant at high wind
+        let tiltAngle = atan(p.wind * 1.2);
+        let cosT = cos(tiltAngle);
+        let sinT = sin(tiltAngle);
+        let stTilted = vec2<f32>(st.x * cosT - st.y * sinT, st.x * sinT + st.y * cosT);
+        let streak = smoothstep(0.96, 1.0, 1.0 - length(stTilted * vec2<f32>(0.45, 3.2)));
         c = c + streak * (0.7 + seed * 0.8);
     }
     return c * 0.75;
@@ -273,7 +279,12 @@ fn snow(uv: vec2<f32>, t: f32, panX: f32, panY: f32) -> vec3<f32> {
         let rnd = hash(id + vec2<f32>(layer));
         st = fract(st) - vec2<f32>(0.5);
 
-        let flake = smoothstep(0.18 + rnd * 0.07, 0.0, length(st));
+        // Gently tilt snowflake placement with wind — softer factor than rain
+        let snowTilt = atan(p.wind * 0.6);
+        let cosST = cos(snowTilt);
+        let sinST = sin(snowTilt);
+        let stTilted = vec2<f32>(st.x * cosST - st.y * sinST, st.x * sinST + st.y * cosST);
+        let flake = smoothstep(0.18 + rnd * 0.07, 0.0, length(stTilted));
         c = c + flake * (0.85 + rnd * 0.6);
     }
     return c * 1.35;
@@ -305,9 +316,14 @@ fn applyFog(col: vec3<f32>, uv: vec2<f32>, intensity: f32, density: f32, height:
     
     var fogAmount = density * groundProximity;
     fogAmount = fogAmount + intensity * (0.2 + groundProximity * 0.8);
-    
-    let noise = noise2D(uv * 8.0 + p.time * 0.1) * 0.1;
-    fogAmount = fogAmount * (0.9 + noise);
+
+    // Animated fractal fog: two fbm layers scrolling at different speeds/directions
+    // create a "rolling" volumetric appearance instead of a static wash
+    let t = p.time * p.speed;
+    let fogUV1 = vec3<f32>(uv * 4.0 + vec2<f32>(t * 0.07, t * 0.04), t * 0.05);
+    let fogUV2 = vec3<f32>(uv * 8.0 - vec2<f32>(t * 0.05, t * 0.03), t * 0.08);
+    let roll = fbm(fogUV1, 2) * 0.18 + fbm(fogUV2, 2) * 0.08;
+    fogAmount = fogAmount * (0.75 + roll);
     
     // Day fog: #b5c1c8, Night fog: dark blue
     let dayFog = vec3<f32>(0.71, 0.76, 0.78);
@@ -345,14 +361,19 @@ fn applyVolumetricLightShafts(col: vec3<f32>, uv: vec2<f32>, intensity: f32, t: 
     
     var rayMod = sin(rayAngle) * 0.5 + 0.5;
     rayMod = rayMod * rayMod * (3.0 - 2.0 * rayMod);
-    
+
+    // Near-horizon enhancement: second harmonic intensifies crepuscular rays at low sun angles
+    let altitudeFactor = 1.0 - clamp(p.sunAltitude / 0.3, 0.0, 1.0);
+    let rayMod2 = sin(rayAngle * 2.0 + t * 0.3) * 0.5 + 0.5;
+    let combinedRay = mix(rayMod, rayMod * rayMod2, altitudeFactor * 0.4);
+
     let rayFalloff = exp(-distFromSun * 3.0) * (1.0 - distFromSun * 0.5);
     
     let dustUV = uv * 30.0 + vec2<f32>(t * 0.2, t * 0.1);
     let dust = noise2D(dustUV) * noise2D(dustUV * 2.0 + 10.0);
     let dustParticle = pow(dust, 2.0) * 2.0;
     
-    let shaftIntensity = intensity * sunAbove * lookingAtSun * rayFalloff * (0.6 + rayMod * 0.4);
+    let shaftIntensity = intensity * sunAbove * lookingAtSun * rayFalloff * (0.6 + combinedRay * 0.4);
     let dustIntensity = intensity * sunAbove * lookingAtSun * rayFalloff * dustParticle * 0.3;
     
     let lightColor = vec3<f32>(1.0, 0.85, 0.6);
@@ -434,7 +455,15 @@ fn applyLensFlare(col: vec3<f32>, uv: vec2<f32>, intensity: f32) -> vec3<f32> {
     
     let streak = exp(-abs(dSunY) * 10.0) * exp(-dSunX * dSunX * 2.0) * 0.08;
     flare = flare + vec3<f32>(1.0, 0.9, 0.7) * streak;
-    
+
+    // Anamorphic horizontal streak — characteristic blue bar of cinema lenses
+    if (p.anamorphicStreak > 0.001) {
+        let anamorphicY = exp(-dSunY * dSunY * 800.0);    // extremely thin vertically
+        let anamorphicX = exp(-dSunX * dSunX * 0.3);       // wide horizontal spread
+        let anamorphicColor = vec3<f32>(0.3, 0.5, 1.0);    // blue-tinted anamorphic character
+        flare = flare + anamorphicColor * anamorphicY * anamorphicX * p.anamorphicStreak * sunVisible * 0.4;
+    }
+
     return col + flare * intensity * sunVisible;
 }
 
@@ -732,6 +761,57 @@ fn directionalMoonlight(col: vec3<f32>, uv: vec2<f32>, moonAz: f32, moonAlt: f32
 }
 
 // ============================================================================
+// REFRACTIVE LENS DROPLETS
+// ============================================================================
+
+// Simulates water droplets accumulated on the camera lens / windshield glass.
+// Each droplet acts as a tiny convex lens: it refracts (distorts) the background
+// behind it, creating a magnified and inverted patch of the scene.
+// Triggered by rainIntensity — no additional uniform required.
+fn applyLensDroplets(col: vec3<f32>, uv: vec2<f32>, t: f32, intensity: f32) -> vec3<f32> {
+    if (intensity < 0.05) { return col; }
+    var result = col;
+    let aspect = 16.0 / 9.0; // correct circular distortion for widescreen
+
+    for (var i: i32 = 0; i < 8; i = i + 1) {
+        let fi = f32(i);
+        // Stable unique seed per droplet
+        let seed  = hash(vec2<f32>(fi * 17.3, fi * 5.7 + 3.1));
+        let seed2 = hash(vec2<f32>(fi * 29.1, fi * 11.3));
+        let seed3 = hash(vec2<f32>(fi * 43.7, fi * 7.9 + 1.5));
+
+        // Horizontal position is fixed; vertical drifts downward slowly (gravity)
+        let cx = seed * 0.8 + 0.1;
+        let cy = fract(seed2 + t * (0.015 + seed3 * 0.01));
+        let dropPos = vec2<f32>(cx, cy);
+        let r = 0.03 + seed * 0.04; // radius: 3–7% of screen height
+
+        // Aspect-corrected distance so droplets appear circular
+        let dist = length((uv - dropPos) * vec2<f32>(aspect, 1.0));
+
+        if (dist < r) {
+            // Radial refraction: bend sample UVs outward from droplet centre
+            // The (1 - dist/r) makes distortion strongest at the centre
+            let refractDir = normalize((uv - dropPos) * vec2<f32>(aspect, 1.0));
+            let refractStr = (1.0 - dist / r) * 0.03 * intensity;
+            let lensUV = clamp(uv + refractDir * refractStr, vec2<f32>(0.001), vec2<f32>(0.999));
+
+            // textureSampleLevel with explicit LOD avoids derivative issues in loops
+            let refracted = textureSampleLevel(sceneTex, linearSampler, lensUV, 0.0).rgb;
+
+            // Smooth interior blend
+            let interior = smoothstep(r, r * 0.5, dist);
+            result = mix(result, refracted, interior * 0.65);
+
+            // Bright specular rim — light catches the droplet edge
+            let rim = smoothstep(r, r * 0.88, dist) - smoothstep(r * 0.88, r * 0.70, dist);
+            result = result + vec3<f32>(0.9, 0.95, 1.0) * rim * 0.35 * intensity;
+        }
+    }
+    return result;
+}
+
+// ============================================================================
 // HDR TONEMAPPING
 // ============================================================================
 
@@ -836,6 +916,12 @@ fn fs_main(@builtin(position) fragCoord: vec4<f32>) -> @location(0) vec4<f32> {
     if (p.snowIntensity > 0.001) {
         let s = snow(uv, t, panX, panY) * p.snowIntensity;
         col = col + s * vec3<f32>(1.15, 1.18, 1.22);
+    }
+
+    // === REFRACTIVE LENS DROPLETS ===
+    // Applied after rain streaks so droplets sit "on top" of streaks on the lens
+    if (p.rainIntensity > 0.05) {
+        col = applyLensDroplets(col, uv, t, clamp(p.rainIntensity * 0.8, 0.0, 1.0));
     }
 
     // === HDR TONEMAPPING ===

--- a/src/car/DashboardUI.tsx
+++ b/src/car/DashboardUI.tsx
@@ -74,6 +74,10 @@ export interface DashboardUIProps {
     timeOfDay: string;
     audioElement?: HTMLAudioElement | null;
     analyser?: AnalyserNode | null;
+    /** 0–1 night intensity — drives gauge bloom and ambient panel tint. */
+    nightIntensity?: number;
+    /** CSS rgba string from useEnvironmentSettings for dashboard glass tinting. */
+    ambientLightColor?: string;
 }
 
 // ============================================================================
@@ -108,6 +112,8 @@ export const DashboardUI: React.FC<DashboardUIProps> = ({
     timeOfDay,
     audioElement,
     analyser,
+    nightIntensity = 0,
+    ambientLightColor = 'rgba(255, 255, 255, 0.0)',
 }) => {
 
     // Gauge simulation state
@@ -206,22 +212,39 @@ export const DashboardUI: React.FC<DashboardUIProps> = ({
             role="region"
             aria-label="Car Dashboard Controls"
         >
-            <DashboardContainer>
+            <DashboardContainer style={{
+                boxShadow: `inset 0 0 60px ${ambientLightColor}`,
+            }}>
+                {/* Screen glare and subtle imperfection overlay — mimics LCD infotainment glass */}
+                <div style={{
+                    position: 'absolute',
+                    inset: 0,
+                    borderRadius: '16px',
+                    pointerEvents: 'none',
+                    zIndex: 1,
+                    background: `
+                        radial-gradient(ellipse 120% 40% at 30% 20%,
+                            rgba(255,255,255,0.04) 0%, transparent 70%),
+                        radial-gradient(ellipse 60% 80% at 70% 60%,
+                            rgba(255,255,255,0.015) 0%, transparent 60%)
+                    `,
+                }} />
+
                 {/* ============================================================================
                     ZONE LEFT - Driving HUD
                     Contains speedometer, gear indicator, and RPM gauge
                 ============================================================================ */}
                 <ZoneLeft>
-                    <div style={{ 
-                        display: 'flex', 
-                        alignItems: 'center', 
-                        gap: '8px', 
+                    <div style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '8px',
                         justifyContent: 'center',
                         height: '100%'
                     }}>
-                        <SpeedGauge value={Math.round(simulatedSpeed)} size={120} unit="MPH" />
+                        <SpeedGauge value={Math.round(simulatedSpeed)} size={120} unit="MPH" nightGlow={nightIntensity} />
                         <GearIndicator gear={gear} size={36} />
-                        <RpmGauge value={Math.round(simulatedRpm)} size={120} />
+                        <RpmGauge value={Math.round(simulatedRpm)} size={120} nightGlow={nightIntensity} />
                     </div>
                 </ZoneLeft>
 

--- a/src/car/Gauges.tsx
+++ b/src/car/Gauges.tsx
@@ -22,12 +22,19 @@ export interface CircularGaugeProps {
     useGradient?: boolean;
     /** Value at which color transitions to warning (for RPM redline) */
     warningThreshold?: number;
+    /** Spring stiffness (higher = faster, more overshoot). Default 150. */
+    stiffness?: number;
+    /** Spring damping (higher = less overshoot). Default 16. */
+    damping?: number;
+    /** Night glow intensity 0–1: scales the digital-readout bloom at night. */
+    nightGlow?: number;
 }
 
 export interface SpeedGaugeProps {
     value: number;
     size?: number;
     unit?: 'MPH' | 'KPH';
+    nightGlow?: number;
 }
 
 export interface RpmGaugeProps {
@@ -35,6 +42,7 @@ export interface RpmGaugeProps {
     size?: number;
     maxRpm?: number;
     redline?: number;
+    nightGlow?: number;
 }
 
 export interface GearIndicatorProps {
@@ -145,56 +153,64 @@ const interpolateColor = (
 };
 
 // ============================================================================
-// Hook for Animated Values
+// Hook for Spring-Physics Animated Values
 // ============================================================================
 
 /**
- * Hook for smooth number animation with easing
+ * Hook for spring-physics animation with overshoot and settle behaviour.
+ * Uses semi-implicit Euler integration: acceleration → velocity → position.
+ * The needle overshoots and bounces like a real physical instrument.
  */
-const useAnimatedValue = (
+const useSpringValue = (
     targetValue: number,
-    duration: number = 300
+    stiffness: number = 150,
+    damping: number = 16
 ): number => {
+    const posRef = useRef(targetValue);
+    const velRef = useRef(0);
     const [displayValue, setDisplayValue] = useState(targetValue);
-    const animationRef = useRef<number | null>(null);
-    const startValueRef = useRef(targetValue);
-    const startTimeRef = useRef<number>(0);
+    const rafRef = useRef<number | null>(null);
+    const lastTimeRef = useRef<number>(0);
 
     useEffect(() => {
-        // Cancel any existing animation
-        if (animationRef.current) {
-            cancelAnimationFrame(animationRef.current);
+        if (rafRef.current) {
+            cancelAnimationFrame(rafRef.current);
         }
+        lastTimeRef.current = performance.now();
 
-        startValueRef.current = displayValue;
-        startTimeRef.current = performance.now();
+        const step = (now: number) => {
+            const dt = Math.min((now - lastTimeRef.current) / 1000, 0.05); // cap at 50 ms
+            lastTimeRef.current = now;
 
-        const animate = (currentTime: number) => {
-            const elapsed = currentTime - startTimeRef.current;
-            const progress = Math.min(elapsed / duration, 1);
+            const acc =
+                -stiffness * (posRef.current - targetValue) -
+                damping * velRef.current;
+            velRef.current += acc * dt;
+            posRef.current += velRef.current * dt;
 
-            // Ease out cubic
-            const easeProgress = 1 - Math.pow(1 - progress, 3);
+            setDisplayValue(posRef.current);
 
-            const currentValue =
-                startValueRef.current +
-                (targetValue - startValueRef.current) * easeProgress;
-
-            setDisplayValue(currentValue);
-
-            if (progress < 1) {
-                animationRef.current = requestAnimationFrame(animate);
+            if (
+                Math.abs(velRef.current) > 0.01 ||
+                Math.abs(posRef.current - targetValue) > 0.05
+            ) {
+                rafRef.current = requestAnimationFrame(step);
+            } else {
+                // Settled — snap to target to avoid floating-point drift
+                posRef.current = targetValue;
+                velRef.current = 0;
+                setDisplayValue(targetValue);
             }
         };
 
-        animationRef.current = requestAnimationFrame(animate);
+        rafRef.current = requestAnimationFrame(step);
 
         return () => {
-            if (animationRef.current) {
-                cancelAnimationFrame(animationRef.current);
+            if (rafRef.current) {
+                cancelAnimationFrame(rafRef.current);
             }
         };
-    }, [targetValue, duration]);
+    }, [targetValue, stiffness, damping]);
 
     return displayValue;
 };
@@ -217,8 +233,11 @@ export const CircularGauge: React.FC<CircularGaugeProps> = ({
     arcSweep = 240,
     useGradient = false,
     warningThreshold,
+    stiffness = 150,
+    damping = 16,
+    nightGlow = 0,
 }) => {
-    const animatedValue = useAnimatedValue(clamp(value, min, max), 200);
+    const animatedValue = useSpringValue(clamp(value, min, max), stiffness, damping);
 
     // Calculate derived values
     const center = 50;
@@ -380,7 +399,9 @@ export const CircularGauge: React.FC<CircularGaugeProps> = ({
                         fontSize: size * 0.24,
                         fontWeight: 700,
                         color: '#ffffff',
-                        textShadow: '0 0 10px rgba(0, 212, 255, 0.5)',
+                        textShadow: nightGlow > 0.3
+                            ? `0 0 ${8 + nightGlow * 16}px rgba(0, 212, 255, ${Math.min(0.3 + nightGlow * 0.5, 0.9)})`
+                            : '0 0 10px rgba(0, 212, 255, 0.5)',
                         letterSpacing: '0.05em',
                         lineHeight: 1,
                     }}
@@ -429,6 +450,7 @@ export const SpeedGauge: React.FC<SpeedGaugeProps> = ({
     value,
     size = 200,
     unit = 'MPH',
+    nightGlow = 0,
 }) => {
     const maxSpeed = unit === 'MPH' ? 200 : 300;
 
@@ -446,6 +468,9 @@ export const SpeedGauge: React.FC<SpeedGaugeProps> = ({
             startAngle={120}
             arcSweep={240}
             useGradient={true}
+            stiffness={120}
+            damping={14}
+            nightGlow={nightGlow}
         />
     );
 };
@@ -459,6 +484,7 @@ export const RpmGauge: React.FC<RpmGaugeProps> = ({
     size = 200,
     maxRpm = 8000,
     redline = 6500,
+    nightGlow = 0,
 }) => {
     return (
         <CircularGauge
@@ -475,6 +501,9 @@ export const RpmGauge: React.FC<RpmGaugeProps> = ({
             arcSweep={240}
             useGradient={true}
             warningThreshold={redline}
+            stiffness={200}
+            damping={18}
+            nightGlow={nightGlow}
         />
     );
 };

--- a/src/components/WebGPUCanvas.tsx
+++ b/src/components/WebGPUCanvas.tsx
@@ -237,9 +237,11 @@ const WebGPUCanvas: React.FC<WebGPUCanvasProps> = ({ onWebGPUStatus }) => {
                 params[23] = e.fogDensity / 100.0;        // fog density (0-1)
                 params[24] = 0.0;                         // fog height
                 params[25] = 0.0;                         // fog color index
-                params[26] = 0.0;                         // light shafts intensity
+                // Light shafts and lens flare activate when the sun is above the horizon
+                const sunVisible = e.sunAltitude > 0 ? Math.min(e.sunAltitude / 0.3, 1.0) : 0.0;
+                params[26] = sunVisible * 0.5;            // light shafts intensity
                 params[27] = 0.0;                         // heat shimmer intensity
-                params[28] = 0.0;                         // lens flare intensity
+                params[28] = sunVisible * 0.4;            // lens flare intensity
                 params[29] = 0.0;                         // chromatic aberration
                 params[30] = 0.0;                         // dust intensity
                 params[31] = 0.0;                         // humidity haze
@@ -255,8 +257,9 @@ const WebGPUCanvas: React.FC<WebGPUCanvasProps> = ({ onWebGPUStatus }) => {
                 // [36]: Sunrise flag
                 params[36] = e.timeOfDay === 'sunrise' ? 1.0 : 0.0;
 
-                // [37-39]: padding
-                params[37] = 0.0;
+                // [37]: anamorphicStreak — activates with lens flare when sun is visible
+                params[37] = sunVisible * 0.5;
+                // [38-39]: padding
                 params[38] = 0.0;
                 params[39] = 0.0;
 

--- a/src/hooks/useEnvironmentSettings.tsx
+++ b/src/hooks/useEnvironmentSettings.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useCallback, useEffect } from 'react';
+import React, { createContext, useContext, useState, useCallback, useEffect, useMemo } from 'react';
 import {
   toggleWipers,
   setCarWipers,
@@ -83,6 +83,10 @@ export interface EnvironmentSettingsState {
   // Presets
   applyTimeOfDayPreset: (preset: TimeOfDay) => void;
   applyColorGradingPreset: (preset: string) => void;
+
+  // Derived
+  /** CSS rgba string for the current ambient light color — used to tint dashboard glass panels. */
+  ambientLightColor: string;
 }
 
 const EnvironmentSettingsContext = createContext<EnvironmentSettingsState | null>(null);
@@ -294,6 +298,20 @@ export const EnvironmentSettingsProvider: React.FC<EnvironmentSettingsProviderPr
     }
   }, []);
   
+  // Compute ambient light color for dashboard tinting based on time of day
+  const ambientLightColor = useMemo(() => {
+    switch (timeOfDay) {
+      case 'sunset':
+        return `rgba(255, 120, 40, ${(0.1 + nightIntensity * 0.1).toFixed(3)})`;
+      case 'sunrise':
+        return 'rgba(255, 160, 80, 0.08)';
+      case 'night':
+        return `rgba(20, 40, 100, ${(nightIntensity * 0.25).toFixed(3)})`;
+      default:
+        return 'rgba(255, 255, 255, 0.0)';
+    }
+  }, [timeOfDay, nightIntensity]);
+
   const value: EnvironmentSettingsState = {
     // Weather
     rainIntensity,
@@ -361,6 +379,9 @@ export const EnvironmentSettingsProvider: React.FC<EnvironmentSettingsProviderPr
     // Presets
     applyTimeOfDayPreset,
     applyColorGradingPreset,
+
+    // Derived
+    ambientLightColor,
   };
   
   return (

--- a/src/views/CarModeView.tsx
+++ b/src/views/CarModeView.tsx
@@ -65,7 +65,8 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
     timeOfDay,
     setTimeOfDay,
     nightIntensity,
-    applyTimeOfDayPreset
+    applyTimeOfDayPreset,
+    ambientLightColor,
   } = useEnvironmentSettings();
   
   const containerRef = useRef<HTMLDivElement>(null);
@@ -364,6 +365,8 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
         timeOfDay={timeOfDay}
         audioElement={audioElement}
         analyser={analyserNode}
+        nightIntensity={nightIntensity}
+        ambientLightColor={ambientLightColor}
       />
       
       {/* Control Mode Indicator (small overlay) */}


### PR DESCRIPTION
Closes #45

## Summary

- **Phase 1 — `weather-post.wgsl`**: Wind-advected rain/snow tilt, refractive lens droplets, animated rolling fog, enhanced god rays, and anamorphic blue lens flare streak
- **Phase 2 — Dashboard UI**: Spring-physics gauge animations (overshoot + settle), ambient light tinting on glass panels, screen glare overlay, night bloom on gauge readouts
- **Phase 3 — Alignment**: WeatherParams struct stays at 40 floats (160 bytes); no pipeline changes needed

## Detailed Changes

### `public/shaders/weather-post.wgsl`

- **Wind-Advected Tilt**: `rain()` and `snow()` now apply a 2D rotation to the streak/flake coordinate frame using `atan(p.wind * 1.2)`. Rain slants ~50° at full wind; snow uses a gentler `0.6` factor.
- **Refractive Lens Droplets** (`applyLensDroplets`): 8 screen-space water blobs, each refracting the background via radial UV displacement. Uses `textureSampleLevel(..., 0.0)` to avoid implicit LOD derivative divergence inside the loop. Triggered by `rainIntensity > 0.05`, no new uniform needed.
- **Animated Rolling Fog**: Replaced the single static `noise2D` call in `applyFog()` with two animated `fbm(..., 2)` layers scrolling at different speeds/directions, producing volumetric density variation that rolls across the scene.
- **God Ray Enhancement**: Added a near-horizon second harmonic in `applyVolumetricLightShafts()` — `sin(2×rayAngle)` blended by `altitudeFactor` — intensifying crepuscular rays when the sun is low on the horizon.
- **Anamorphic Lens Flare**: Renamed `_pad1` (index 37) to `anamorphicStreak`. Added a horizontal blue streak (`exp(-dSunY² × 800) × exp(-dSunX² × 0.3)`) inside `applyLensFlare()`. Buffer layout unchanged at 160 bytes.
- **Light shafts + lens flare defaults**: `params[26]` and `params[28]` now use `sunVisible × 0.5/0.4` instead of being hardcoded to `0.0`, so cinematic effects appear at sunrise/sunset without UI intervention.

### `src/car/Gauges.tsx`

- Replaced `useAnimatedValue` (cubic ease-out) with `useSpringValue` — semi-implicit Euler spring integration with configurable `stiffness` and `damping`. Needles overshoot the target and oscillate before settling, matching physical instrument behaviour.
  - `SpeedGauge`: `stiffness=120, damping=14` (moderate overshoot, ~400 ms settle)
  - `RpmGauge`: `stiffness=200, damping=18` (stiffer, faster engine response)
- Added `nightGlow?: number` prop to `CircularGauge`/`SpeedGauge`/`RpmGauge`. When `nightGlow > 0.3` the digital readout `textShadow` bloom scales up proportionally.

### `src/hooks/useEnvironmentSettings.tsx`

- Added `ambientLightColor: string` to `EnvironmentSettingsState` — a `useMemo`-computed CSS `rgba()` string derived from `timeOfDay` + `nightIntensity`:
  - `sunset` → warm orange `rgba(255, 120, 40, …)`
  - `sunrise` → soft gold `rgba(255, 160, 80, 0.08)`
  - `night` → deep blue `rgba(20, 40, 100, …)` (scales with `nightIntensity`)
  - `day` → transparent

### `src/car/DashboardUI.tsx`

- Added `nightIntensity` and `ambientLightColor` props.
- `DashboardContainer` receives an `inset 0 0 60px <ambientLightColor>` box-shadow — glass panels subtly reflect the environment colour.
- Added a `pointer-events: none` screen glare overlay with two radial gradients, mimicking LCD infotainment glass reflections and fingerprint scatter.
- `SpeedGauge` and `RpmGauge` receive `nightGlow={nightIntensity}` for night bloom.

### `src/views/CarModeView.tsx`

- Destructures `ambientLightColor` from `useEnvironmentSettings()` and passes `nightIntensity` + `ambientLightColor` to `<DashboardUI>`.

### `src/components/WebGPUCanvas.tsx`

- Sets `params[37]` (anamorphicStreak) to `sunVisible × 0.5` alongside the light-shaft and lens-flare defaults.

## Test plan

- [ ] Rain + high wind: `rainIntensity=1.5, wind=1.0` — streaks should slant ~50°; lens droplets visible as refractive blobs
- [ ] Snow + wind: `snowIntensity=1.5, wind=1.0` — flakes drift diagonally
- [ ] Fog: `fogIntensity=0.8, fogDensity=1.5` — fog visibly rolls/animates over time
- [ ] Sunrise/sunset: horizontal blue anamorphic streak + intensified god rays near horizon
- [ ] Gauge spring: rapidly change simulated speed — needle overshoots then settles
- [ ] `timeOfDay=sunset` — dashboard glass takes on warm orange inset tint
- [ ] `timeOfDay=night` — speedometer digits emit stronger cyan bloom
- [ ] TypeScript: `npx tsc --noEmit` — no new errors

https://claude.ai/code/session_01LPaUHkzxpWorZj48UdAdEd