### PR TITLE
feat: GPU panorama transition shader pack

### DIFF
--- a/public/shaders/transition-fade.wgsl
+++ b/public/shaders/transition-fade.wgsl
@@ -1,0 +1,57 @@
+// transition-fade.wgsl
+// Smooth cross-dissolve between two equirectangular panoramas.
+//
+// Outputs to rgba16float intermediate — weather-post.wgsl applies
+// color grading and ACES tonemapping on top.
+//
+// Bind group layout:
+//   @binding(0) uTextureFrom  — snapshot of the departing panorama
+//   @binding(1) uTextureTo    — live Google Maps canvas (incoming)
+//   @binding(2) uSampler      — linear filtering
+//   @binding(3) uniforms      — TransitionUniforms (16 bytes)
+//
+// Recommended defaults: duration = 350ms
+
+struct TransitionUniforms {
+    progress : f32,   // 0.0 = fully from, 1.0 = fully to
+    param1   : f32,   // unused for fade
+    param2   : f32,   // unused for fade
+    _pad     : f32,
+}
+
+@group(0) @binding(0) var uTextureFrom : texture_2d<f32>;
+@group(0) @binding(1) var uTextureTo   : texture_2d<f32>;
+@group(0) @binding(2) var uSampler     : sampler;
+@group(0) @binding(3) var<uniform> uniforms : TransitionUniforms;
+
+struct VertexOutput {
+    @builtin(position) pos : vec4<f32>,
+    @location(0)       uv  : vec2<f32>,
+}
+
+// Full-screen triangle — more GPU cache-efficient than a 6-vertex quad.
+// UV is passed through with Y-flip to match WebGPU texture coordinate conventions.
+@vertex
+fn vs_main(@builtin(vertex_index) i : u32) -> VertexOutput {
+    let x = f32(i == 1u) * 4.0 - 1.0;
+    let y = f32(i == 2u) * 4.0 - 1.0;
+    return VertexOutput(
+        vec4<f32>(x, y, 0.0, 1.0),
+        vec2<f32>((x + 1.0) * 0.5, (1.0 - y) * 0.5),
+    );
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let colorFrom = textureSample(uTextureFrom, uSampler, in.uv);
+    let colorTo   = textureSample(uTextureTo,   uSampler, in.uv);
+
+    // Cubic ease-in-out via smoothstep
+    let t = smoothstep(0.0, 1.0, uniforms.progress);
+
+    // Subtle brightness dip at midpoint — adds perceived smoothness
+    // at max 12% darker when t = 0.5 (sin(π/2) = 1)
+    let brightness = 1.0 - 0.12 * sin(t * 3.14159265);
+
+    return mix(colorFrom, colorTo, t) * brightness;
+}

--- a/public/shaders/transition-zoom-blur.wgsl
+++ b/public/shaders/transition-zoom-blur.wgsl
@@ -1,0 +1,72 @@
+// transition-zoom-blur.wgsl
+// Zoom + 5-tap blur on the outgoing panorama — dreamy departure feel.
+//
+// The blur radius is resolution-normalized so it looks consistent at all
+// canvas sizes (calibrated to a 1280-wide reference).
+//
+// Bind group layout:
+//   @binding(0) uTextureFrom  — snapshot of the departing panorama
+//   @binding(1) uTextureTo    — live Google Maps canvas (incoming)
+//   @binding(2) uSampler      — linear filtering
+//   @binding(3) uniforms      — TransitionUniforms (16 bytes)
+//
+// Recommended defaults: duration = 500ms, param1 (zoomAmount) = 2.5,
+//                       param2 (blurStrength) = 1.1
+
+struct TransitionUniforms {
+    progress : f32,
+    param1   : f32,   // zoomAmount    — recommended: 2.5
+    param2   : f32,   // blurStrength  — recommended: 1.1
+    _pad     : f32,
+}
+
+@group(0) @binding(0) var uTextureFrom : texture_2d<f32>;
+@group(0) @binding(1) var uTextureTo   : texture_2d<f32>;
+@group(0) @binding(2) var uSampler     : sampler;
+@group(0) @binding(3) var<uniform> uniforms : TransitionUniforms;
+
+struct VertexOutput {
+    @builtin(position) pos : vec4<f32>,
+    @location(0)       uv  : vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) i : u32) -> VertexOutput {
+    let x = f32(i == 1u) * 4.0 - 1.0;
+    let y = f32(i == 2u) * 4.0 - 1.0;
+    return VertexOutput(
+        vec4<f32>(x, y, 0.0, 1.0),
+        vec2<f32>((x + 1.0) * 0.5, (1.0 - y) * 0.5),
+    );
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let center   = vec2<f32>(0.5, 0.5);
+    let baseDist = length(in.uv - center);
+
+    let push   = (in.uv - center) * baseDist * 0.18 * uniforms.progress;
+    let zoom   = 1.0 + (uniforms.param1 - 1.0) * uniforms.progress;
+    let uvFrom = (in.uv + push - center) / zoom + center;
+
+    let colorTo = textureSample(uTextureTo, uSampler, in.uv);
+
+    // Resolution-normalized blur radius — consistent look at all canvas sizes
+    // (0.008 * 1280 / res.x gives ~10px at 1280w, ~5px at 2560w)
+    let res  = vec2<f32>(textureDimensions(uTextureFrom));
+    let blur = uniforms.param2 * uniforms.progress * (0.008 * 1280.0 / res.x);
+
+    // 5-tap diagonal Gaussian-approximation blur on the outgoing panorama
+    var colorFrom  = textureSample(uTextureFrom, uSampler, uvFrom + vec2<f32>(-blur, -blur));
+        colorFrom += textureSample(uTextureFrom, uSampler, uvFrom + vec2<f32>( blur, -blur));
+        colorFrom += textureSample(uTextureFrom, uSampler, uvFrom + vec2<f32>(-blur,  blur));
+        colorFrom += textureSample(uTextureFrom, uSampler, uvFrom + vec2<f32>( blur,  blur));
+        colorFrom += textureSample(uTextureFrom, uSampler, uvFrom);   // center sample
+    colorFrom *= 0.2;
+
+    let fade  = pow(uniforms.progress, 1.35);
+    var color = mix(colorFrom, colorTo, fade);
+    color     = color * (1.0 - baseDist * 0.6 * uniforms.progress);
+
+    return color;
+}

--- a/public/shaders/transition-zoom-chromatic.wgsl
+++ b/public/shaders/transition-zoom-chromatic.wgsl
@@ -1,0 +1,68 @@
+// transition-zoom-chromatic.wgsl
+// Zoom + chromatic aberration — filmic / dreamy departure.
+//
+// R, G, and B channels of the outgoing panorama are sampled at slightly
+// offset UVs.  The blue channel receives a small vertical offset as well as
+// horizontal for a more optical-lens-like look.
+//
+// Bind group layout:
+//   @binding(0) uTextureFrom  — snapshot of the departing panorama
+//   @binding(1) uTextureTo    — live Google Maps canvas (incoming)
+//   @binding(2) uSampler      — linear filtering
+//   @binding(3) uniforms      — TransitionUniforms (16 bytes)
+//
+// Recommended defaults: duration = 500ms, param1 (zoomAmount) = 2.5,
+//                       param2 (aberrationStrength) = 1.0
+
+struct TransitionUniforms {
+    progress : f32,
+    param1   : f32,   // zoomAmount         — recommended: 2.5
+    param2   : f32,   // aberrationStrength — recommended: 1.0
+    _pad     : f32,
+}
+
+@group(0) @binding(0) var uTextureFrom : texture_2d<f32>;
+@group(0) @binding(1) var uTextureTo   : texture_2d<f32>;
+@group(0) @binding(2) var uSampler     : sampler;
+@group(0) @binding(3) var<uniform> uniforms : TransitionUniforms;
+
+struct VertexOutput {
+    @builtin(position) pos : vec4<f32>,
+    @location(0)       uv  : vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) i : u32) -> VertexOutput {
+    let x = f32(i == 1u) * 4.0 - 1.0;
+    let y = f32(i == 2u) * 4.0 - 1.0;
+    return VertexOutput(
+        vec4<f32>(x, y, 0.0, 1.0),
+        vec2<f32>((x + 1.0) * 0.5, (1.0 - y) * 0.5),
+    );
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let center   = vec2<f32>(0.5, 0.5);
+    let baseDist = length(in.uv - center);
+
+    let push   = (in.uv - center) * baseDist * 0.2 * uniforms.progress;
+    let zoom   = 1.0 + (uniforms.param1 - 1.0) * uniforms.progress;
+    let uvFrom = (in.uv + push - center) / zoom + center;
+
+    let colorTo = textureSample(uTextureTo, uSampler, in.uv);
+
+    // RGB channel split with diagonal B-channel offset for optical-lens realism
+    let aberr = uniforms.param2 * uniforms.progress * 0.012;
+    let r = textureSample(uTextureFrom, uSampler, uvFrom + vec2<f32>( aberr,           0.0)).r;
+    let g = textureSample(uTextureFrom, uSampler, uvFrom).g;
+    let b = textureSample(uTextureFrom, uSampler, uvFrom - vec2<f32>(aberr * 0.8, aberr * 0.3)).b;
+
+    var colorFrom = vec4<f32>(r, g, b, 1.0);
+
+    let fade  = pow(uniforms.progress, 1.3);
+    var color = mix(colorFrom, colorTo, fade);
+    color     = color * (1.0 - baseDist * 0.65 * uniforms.progress);
+
+    return color;
+}

--- a/public/shaders/transition-zoom.wgsl
+++ b/public/shaders/transition-zoom.wgsl
@@ -1,0 +1,67 @@
+// transition-zoom.wgsl
+// Zoom-forward + fade — gives the feeling of stepping into the next panorama.
+//
+// The outgoing panorama zooms in (magnifies) as progress increases, while
+// the incoming panorama fades in at normal scale.  A subtle radial push is
+// applied to the BASE UV before the zoom division so the distortion and zoom
+// are independent transforms with no double-warp artefact.
+//
+// Bind group layout:
+//   @binding(0) uTextureFrom  — snapshot of the departing panorama
+//   @binding(1) uTextureTo    — live Google Maps canvas (incoming)
+//   @binding(2) uSampler      — linear filtering
+//   @binding(3) uniforms      — TransitionUniforms (16 bytes)
+//
+// Recommended defaults: duration = 450ms, param1 (zoomAmount) = 2.4
+
+struct TransitionUniforms {
+    progress : f32,
+    param1   : f32,   // zoomAmount — how far to zoom in by progress=1 (e.g. 2.4)
+    param2   : f32,   // unused
+    _pad     : f32,
+}
+
+@group(0) @binding(0) var uTextureFrom : texture_2d<f32>;
+@group(0) @binding(1) var uTextureTo   : texture_2d<f32>;
+@group(0) @binding(2) var uSampler     : sampler;
+@group(0) @binding(3) var<uniform> uniforms : TransitionUniforms;
+
+struct VertexOutput {
+    @builtin(position) pos : vec4<f32>,
+    @location(0)       uv  : vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) i : u32) -> VertexOutput {
+    let x = f32(i == 1u) * 4.0 - 1.0;
+    let y = f32(i == 2u) * 4.0 - 1.0;
+    return VertexOutput(
+        vec4<f32>(x, y, 0.0, 1.0),
+        vec2<f32>((x + 1.0) * 0.5, (1.0 - y) * 0.5),
+    );
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let center   = vec2<f32>(0.5, 0.5);
+    let baseDist = length(in.uv - center);
+
+    // Radial push on base UV BEFORE zoom to avoid double-warp at high zoom values
+    let push   = (in.uv - center) * baseDist * 0.15 * uniforms.progress;
+
+    // Zoom the outgoing panorama toward the vanishing point
+    let zoom   = 1.0 + (uniforms.param1 - 1.0) * uniforms.progress;
+    let uvFrom = (in.uv + push - center) / zoom + center;
+
+    let colorFrom = textureSample(uTextureFrom, uSampler, uvFrom);
+    let colorTo   = textureSample(uTextureTo,   uSampler, in.uv);
+
+    // Slightly accelerated fade — fast start, smooth landing
+    let fade  = pow(uniforms.progress, 1.4);
+    var color = mix(colorFrom, colorTo, fade);
+
+    // Soft vignette focuses attention on the center during the zoom
+    color = color * (1.0 - baseDist * 0.55 * uniforms.progress);
+
+    return color;
+}

--- a/src/components/WebGPUCanvas.tsx
+++ b/src/components/WebGPUCanvas.tsx
@@ -46,6 +46,14 @@ const WebGPUCanvas: React.FC<WebGPUCanvasProps> = ({ onWebGPUStatus }) => {
     const sourceChangeFlagRef = useRef<boolean>(true);
     const FRAME_SKIP = 2; // Render every 2nd frame (30fps base) when source unchanged, 60fps when changed
 
+    // Transition animation state — updated on every render so the RAF loop always
+    // sees the latest React state without re-creating the animation closure.
+    const isTransitioningRef = useRef(isStreetViewTransitioning);
+    isTransitioningRef.current = isStreetViewTransitioning;
+    const prevTransitioningRef  = useRef(false);
+    const transitionActiveRef   = useRef(false);
+    const transitionStartRef    = useRef<number | null>(null);
+
     // Performance: Debounced resize
     const resizeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -182,10 +190,40 @@ const WebGPUCanvas: React.FC<WebGPUCanvasProps> = ({ onWebGPUStatus }) => {
         const animate = () => {
             if (!active) return;
 
+            // --- GPU Transition animation ---
+            const renderer = currentRendererRef.current;
+            const nowTransitioning = isTransitioningRef.current;
+
+            if (nowTransitioning && !prevTransitioningRef.current &&
+                !transitionActiveRef.current && renderer) {
+                // Leading edge: snapshot current frame and arm the transition
+                renderer.beginTransition('zoom');
+                transitionStartRef.current = performance.now();
+                transitionActiveRef.current = true;
+            }
+            prevTransitioningRef.current = nowTransitioning;
+
+            if (transitionActiveRef.current && transitionStartRef.current !== null && renderer) {
+                const elapsed  = performance.now() - transitionStartRef.current;
+                const duration = renderer.getTransitionDuration();
+                const progress = Math.min(1.0, elapsed / duration);
+                renderer.updateTransitionProgress(progress);
+                if (progress >= 1.0) {
+                    renderer.endTransition();
+                    transitionActiveRef.current = false;
+                    transitionStartRef.current  = null;
+                }
+            }
+
             // Performance: Adaptive frame skipping based on quality
             const skipFrame = shouldSkipFrame();
-            
-            const shouldRender = !skipFrame && (sourceChangeFlagRef.current || (frameCountRef.current % FRAME_SKIP === 0));
+
+            // Force full-fps while a GPU transition is animating
+            const shouldRender = !skipFrame && (
+                transitionActiveRef.current ||
+                sourceChangeFlagRef.current ||
+                (frameCountRef.current % FRAME_SKIP === 0)
+            );
 
             // Calculate camera params based on current view mode
             const isCarMode = viewMode === 'car';
@@ -305,9 +343,8 @@ const WebGPUCanvas: React.FC<WebGPUCanvasProps> = ({ onWebGPUStatus }) => {
                 border: 'none',
                 marginTop: 0,
                 borderRadius: 0,
-                // Cruise pause: brief fade-to-black during panorama transitions
-                opacity: isStreetViewTransitioning ? 0 : 1,
-                transition: 'opacity 0.2s ease-in-out'
+                // GPU transition shader handles visual continuity — always opaque
+                opacity: 1
             }}
         />
     );

--- a/src/hooks/useStreetView.tsx
+++ b/src/hooks/useStreetView.tsx
@@ -192,13 +192,13 @@ export const StreetViewProvider: React.FC<StreetViewProviderProps> = ({
         setPositionState(pos);
       }
       
-      // Ensure transition pause - minimum 1200ms between location changes
-      // This allows Street View panorama to fully load before accepting next advance
+      // Transition pause: GPU animation completes in ~450ms; 700ms gives tiles
+      // time to load while remaining snappier than the old 1200ms black screen.
       if (pauseTimer) clearTimeout(pauseTimer);
       pauseTimer = setTimeout(() => {
         console.log('[StreetView] Transition pause complete, ready for next advance');
         setIsTransitioning(false);
-      }, 1200);
+      }, 700);
     };
     
     const listener = pano.addListener('pano_changed', handlePanoChanged);

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -49,6 +49,26 @@ export class Renderer {
     // [37-39]: padding
     private weatherParams: Float32Array = new Float32Array(40);
 
+    // === TRANSITION SYSTEM ===
+    // Dual-texture post-process pass inserted before Pass 2 (weather).
+    // prevTexture holds a GPU snapshot of the departing panorama; videoTexture
+    // continues to receive live Google Maps canvas pixels as the new scene loads.
+    private transitionPipelines: Map<string, GPURenderPipeline> = new Map();
+    private transitionBindGroupLayout?: GPUBindGroupLayout;
+    private transitionUniformBuffer?: GPUBuffer;   // 16 bytes: [progress, param1, param2, pad]
+    private prevTexture?: GPUTexture;              // rgba8unorm-srgb snapshot of departing frame
+    private activeTransition: string | null = null;
+    private transitionProgress: number = 0.0;
+
+    // Default parameters per transition mode
+    // param1 = zoomAmount, param2 = blurStrength | aberrationStrength
+    public readonly transitionDefaults: Record<string, { duration: number; param1: number; param2: number }> = {
+        'fade':           { duration: 350, param1: 0.0, param2: 0.0 },
+        'zoom':           { duration: 450, param1: 2.4, param2: 0.0 },
+        'zoom-blur':      { duration: 500, param1: 2.5, param2: 1.1 },
+        'zoom-chromatic': { duration: 500, param1: 2.5, param2: 1.0 },
+    };
+
     private onLostCallback?: (info: GPUDeviceLostInfo) => void;
     private isDestroyed: boolean = false;
 
@@ -173,6 +193,13 @@ export class Renderer {
 
             await this.createPipeline();
             await this.createWeatherPipeline();
+
+            // Non-fatal: transitions degrade gracefully if shaders fail to load
+            try {
+                await this.initTransitionPipelines();
+            } catch (e) {
+                console.warn('[Renderer] Transition pipelines failed to initialize — transitions disabled:', e);
+            }
 
             return true;
         } catch (e) {
@@ -439,6 +466,9 @@ export class Renderer {
             if (this.uniformBuffer) this.uniformBuffer.destroy();
             if (this.effectsBuffer) this.effectsBuffer.destroy();
             if (this.weatherParamsBuffer) this.weatherParamsBuffer.destroy();
+            if (this.prevTexture) this.prevTexture.destroy();
+            if (this.transitionUniformBuffer) this.transitionUniformBuffer.destroy();
+            this.transitionPipelines.clear();
             this.device?.destroy();
         } catch (e) {
             // ignore cleanup errors
@@ -449,6 +479,9 @@ export class Renderer {
         this.uniformBuffer = undefined as any;
         this.effectsBuffer = undefined as any;
         this.weatherParamsBuffer = undefined as any;
+        this.prevTexture = undefined;
+        this.transitionUniformBuffer = undefined;
+        this.activeTransition = null;
         this.pipeline = undefined as any;
         this.weatherPipeline = undefined as any;
         this.bindGroup = undefined as any;
@@ -521,6 +554,146 @@ export class Renderer {
 
     public getCanvasDataURL(): string {
         return this.canvas.toDataURL('image/png', 1.0);
+    }
+
+    // =========================================================================
+    // TRANSITION SYSTEM
+    // =========================================================================
+
+    /**
+     * Load all transition shaders and create their GPU pipelines.
+     * Called non-fatally at the end of init() — failure is logged and transitions
+     * degrade to the normal panorama render without affecting other features.
+     */
+    private async initTransitionPipelines(): Promise<void> {
+        const baseUrl = process.env.PUBLIC_URL || '/';
+
+        // Shared bind group layout for all 4 transition shaders
+        this.transitionBindGroupLayout = this.device.createBindGroupLayout({
+            label: 'Transition Bind Group Layout',
+            entries: [
+                { binding: 0, visibility: GPUShaderStage.FRAGMENT,
+                  texture: { sampleType: 'float' as GPUTextureSampleType } },   // uTextureFrom
+                { binding: 1, visibility: GPUShaderStage.FRAGMENT,
+                  texture: { sampleType: 'float' as GPUTextureSampleType } },   // uTextureTo
+                { binding: 2, visibility: GPUShaderStage.FRAGMENT,
+                  sampler: { type: 'filtering' as GPUSamplerBindingType } },
+                { binding: 3, visibility: GPUShaderStage.FRAGMENT,
+                  buffer: { type: 'uniform' as GPUBufferBindingType } },
+            ],
+        });
+
+        // Shared 16-byte uniform buffer: [progress, param1, param2, pad]
+        this.transitionUniformBuffer = this.device.createBuffer({
+            label: 'Transition Uniforms',
+            size: 16,
+            usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+        });
+
+        const pipelineLayout = this.device.createPipelineLayout({
+            bindGroupLayouts: [this.transitionBindGroupLayout],
+        });
+
+        const names = ['fade', 'zoom', 'zoom-blur', 'zoom-chromatic'] as const;
+        for (const name of names) {
+            const url = `${baseUrl}/shaders/transition-${name}.wgsl`;
+            const response = await fetch(url);
+            if (!response.ok) throw new Error(`Failed to fetch ${url}: ${response.status}`);
+            const code = await response.text();
+
+            const shaderModule = this.device.createShaderModule({
+                label: `Transition ${name}`,
+                code,
+            });
+
+            const pipeline = this.device.createRenderPipeline({
+                label: `Transition Pipeline ${name}`,
+                layout: pipelineLayout,
+                vertex:   { module: shaderModule, entryPoint: 'vs_main' },
+                fragment: {
+                    module: shaderModule,
+                    entryPoint: 'fs_main',
+                    targets: [{ format: 'rgba16float' as GPUTextureFormat }],
+                },
+                primitive: { topology: 'triangle-list' },
+            });
+
+            this.transitionPipelines.set(name, pipeline);
+        }
+
+        console.log('[Renderer] Transition pipelines ready:', [...this.transitionPipelines.keys()].join(', '));
+    }
+
+    /**
+     * Snapshot the current videoTexture into prevTexture and arm the transition.
+     * Must be called while videoTexture is valid (i.e. at least one frame has rendered).
+     */
+    public beginTransition(mode: string = 'zoom'): void {
+        if (!this.device || !this.videoTexture) return;
+        if (!this.transitionPipelines.has(mode)) {
+            console.warn(`[Renderer] Unknown transition mode "${mode}" — skipping`);
+            return;
+        }
+
+        // Ensure prevTexture exists and matches videoTexture dimensions/format
+        if (!this.prevTexture ||
+            this.prevTexture.width  !== this.videoTexture.width ||
+            this.prevTexture.height !== this.videoTexture.height) {
+            if (this.prevTexture) this.prevTexture.destroy();
+            this.prevTexture = this.device.createTexture({
+                label: 'Previous Panorama Snapshot',
+                size: { width: this.videoTexture.width, height: this.videoTexture.height },
+                format: this.videoTexture.format,
+                usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
+            });
+        }
+
+        // GPU → GPU copy: zero CPU cost, ordered by the WebGPU queue
+        const encoder = this.device.createCommandEncoder({ label: 'Snapshot encoder' });
+        encoder.copyTextureToTexture(
+            { texture: this.videoTexture },
+            { texture: this.prevTexture  },
+            { width: this.videoTexture.width, height: this.videoTexture.height },
+        );
+        this.device.queue.submit([encoder.finish()]);
+
+        this.activeTransition  = mode;
+        this.transitionProgress = 0.0;
+    }
+
+    /**
+     * Update the transition blend each frame.
+     * progress: 0.0 = fully departing panorama, 1.0 = fully incoming panorama.
+     */
+    public updateTransitionProgress(progress: number): void {
+        this.transitionProgress = Math.max(0.0, Math.min(1.0, progress));
+        if (!this.transitionUniformBuffer || !this.device || !this.activeTransition) return;
+
+        const defaults = this.transitionDefaults[this.activeTransition];
+        const data = new Float32Array([
+            this.transitionProgress,
+            defaults?.param1 ?? 0.0,
+            defaults?.param2 ?? 0.0,
+            0.0,
+        ]);
+        this.device.queue.writeBuffer(this.transitionUniformBuffer, 0, data);
+    }
+
+    /** Disarm the transition (called after progress reaches 1.0). */
+    public endTransition(): void {
+        this.activeTransition   = null;
+        this.transitionProgress = 0.0;
+    }
+
+    /** Returns true while a GPU transition is in progress. */
+    public isInTransition(): boolean {
+        return this.activeTransition !== null;
+    }
+
+    /** Duration (ms) for the given transition mode (or the active mode if omitted). */
+    public getTransitionDuration(mode?: string): number {
+        const key = mode ?? this.activeTransition ?? 'zoom';
+        return this.transitionDefaults[key]?.duration ?? 450;
     }
 
     /**
@@ -633,10 +806,15 @@ export class Renderer {
     ): void {
         if (this.isDestroyed || !this.device || !this.pipeline || !this.weatherPipeline) return;
 
-        // If no source but we want to keep weather animating, render weather only
+        // If no source: fall back to weather-only unless a GPU transition is active
+        // (during an active transition prevTexture + videoTexture carry the blend)
         if (!source) {
-            this.renderWeatherOnly();
-            return;
+            if (this.activeTransition && this.prevTexture && this.videoTexture) {
+                // continue — transition pipeline will use cached GPU textures
+            } else {
+                this.renderWeatherOnly();
+                return;
+            }
         }
 
         let srcWidth = 0;
@@ -703,6 +881,7 @@ export class Renderer {
             const commandEncoder = this.device.createCommandEncoder();
 
             // === PASS 1: Panorama → Intermediate HDR texture ===
+            // During a transition, swap in the dual-texture transition pipeline.
             const mainPass = commandEncoder.beginRenderPass({
                 colorAttachments: [{
                     view: this.intermediateTextureView,
@@ -712,9 +891,33 @@ export class Renderer {
                 }],
             });
 
-            mainPass.setPipeline(this.pipeline);
-            mainPass.setBindGroup(0, this.bindGroup);
-            mainPass.draw(4, 1, 0, 0);
+            const transitionPipeline = this.activeTransition
+                ? this.transitionPipelines.get(this.activeTransition)
+                : undefined;
+
+            if (transitionPipeline && this.prevTexture && this.videoTexture &&
+                this.transitionBindGroupLayout && this.transitionUniformBuffer) {
+                // Rebuild bind group each frame (videoTexture pixels update live)
+                const tBindGroup = this.device.createBindGroup({
+                    label: 'Transition Bind Group',
+                    layout: this.transitionBindGroupLayout,
+                    entries: [
+                        { binding: 0, resource: this.prevTexture.createView() },
+                        { binding: 1, resource: this.videoTexture.createView() },
+                        { binding: 2, resource: this.sampler },
+                        { binding: 3, resource: { buffer: this.transitionUniformBuffer } },
+                    ],
+                });
+                mainPass.setPipeline(transitionPipeline);
+                mainPass.setBindGroup(0, tBindGroup);
+                mainPass.draw(3); // full-screen triangle
+            } else {
+                // Normal panorama pass
+                mainPass.setPipeline(this.pipeline);
+                mainPass.setBindGroup(0, this.bindGroup);
+                mainPass.draw(4, 1, 0, 0); // triangle strip
+            }
+
             mainPass.end();
 
             // === PASS 2: Intermediate + Weather → Canvas ===


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Replaces the 1200ms opacity-to-black screen with a real dual-texture WebGPU transition system. Four cinematic WGSL shaders blend the departing panorama snapshot into the live incoming canvas, with weather effects (rain, fog, tonemapping) continuing to work on top via the existing `weather-post.wgsl` pass.

- **`transition-fade.wgsl`** — smoothstep cross-dissolve with subtle midpoint brightness dip (350ms)
- **`transition-zoom.wgsl`** — zoom-forward with radial push on base UV before zoom division (450ms, default)
- **`transition-zoom-blur.wgsl`** — zoom + resolution-normalized 5-tap departure blur (500ms)
- **`transition-zoom-chromatic.wgsl`** — zoom + diagonal RGB channel split for optical-lens aberration (500ms)

## Architecture

Transitions slot in as a modified Pass 1 in the existing dual-pass pipeline:

```
[NORMAL]     videoTexture → streetview.wgsl → rgba16float → weather-post → canvas
[TRANSITION] prevTexture + videoTexture → transition-*.wgsl → rgba16float → weather-post → canvas
```

`prevTexture` is captured via `copyTextureToTexture` (GPU-side, zero CPU cost) at the moment `advance()` fires. As Google Maps loads the new panorama into `videoTexture`, the transition shader blends from the clean snapshot to the live canvas.

## Key changes

| File | Change |
|------|--------|
| `public/shaders/transition-*.wgsl` | 4 new transition shaders |
| `src/renderer/Renderer.ts` | `initTransitionPipelines()`, `beginTransition()`, `updateTransitionProgress()`, `endTransition()`, conditional Pass 1, `dispose()` cleanup |
| `src/components/WebGPUCanvas.tsx` | Edge-detects `isTransitioning` rising edge, drives RAF progress animation, forces full-fps during transition, removes CSS `opacity:0` hack |
| `src/hooks/useStreetView.tsx` | Reduces guard timeout 1200ms → 700ms |

## Test plan

- [ ] Navigate forward in normal mode — zoom transition fires and completes cleanly
- [ ] Enable cruise mode — transitions fire on every auto-advance without flicker
- [ ] Enable rain/snow — weather effects render correctly on top of the transition
- [ ] Resize browser window mid-transition — no WebGPU validation errors
- [ ] Check browser console on load — `[Renderer] Transition pipelines ready: fade, zoom, zoom-blur, zoom-chromatic`
- [ ] Test on a slow connection — graceful fallback if tiles are slow to load

https://claude.ai/code/session_019Gf41U7VB6CNuCQWdEw63j
EOF
)