### PR TITLE
Fix TS2802: Compilation error on spread operator with IterableIterator

### DIFF
--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -621,7 +621,7 @@ export class Renderer {
             this.transitionPipelines.set(name, pipeline);
         }
 
-        console.log('[Renderer] Transition pipelines ready:', [...this.transitionPipelines.keys()].join(', '));
+        console.log('[Renderer] Transition pipelines ready:', Array.from(this.transitionPipelines.keys()).join(', '));
     }
 
     /**


### PR DESCRIPTION
This change fixes a TypeScript compilation error (`TS2802: Type 'IterableIterator<string>' can only be iterated through when using the '--downlevelIteration' flag or with a '--target' of 'es2015' or higher`) by converting the spread operator usage on a Map's `.keys()` iterator to use `Array.from()`. This allows the project to continue targeting `es5` without requiring changes to the TypeScript configuration.

---
*PR created automatically by Jules for task [10581065218762109239](https://jules.google.com/task/10581065218762109239) started by @ford442*