### PR TITLE
Fix czm_infinity GLSL precision

### DIFF
--- a/public/cesium/index.js
+++ b/public/cesium/index.js
@@ -179,7 +179,7 @@ const float czm_epsilon7 = 0.0000001;
  * @name czm_infinity
  * @glslConstant
  */
-const float czm_infinity = 5906376272000.0;  // Distance from the Sun to Pluto in meters.  TODO: What is best given lowp, mediump, and highp?
+const highp float czm_infinity = 5906376272000.0;  // Distance from the Sun to Pluto in meters.  TODO: What is best given lowp, mediump, and highp?
 `;var WM=`/**
  * A built-in GLSL floating-point constant for <code>1/pi</code>.
  *


### PR DESCRIPTION
This fix enforces `highp` precision on the `czm_infinity` constant within the compiled Cesium artifact (`public/cesium/index.js`). The constant value of `5906376272000.0` is large and can overflow when the shader uses `mediump` precision as a default, leading to depth buffering issues and z-fighting on some devices. By explicitly declaring it as `const highp float czm_infinity`, we ensure it remains safe from precision loss in all contexts.

---
*PR created automatically by Jules for task [17445629542286142692](https://jules.google.com/task/17445629542286142692) started by @ford442*