### PR TITLE
Fix car interior pivoting in freeLook mode

### DIFF
--- a/src/views/CarModeView.tsx
+++ b/src/views/CarModeView.tsx
@@ -182,8 +182,8 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
       // rotates with the car (rigid coupling) or freely (free coupling).
       updateCarMode(
         carHeadingRef.current,
-        headYawOffset,
-        headPitch,
+        controlMode === 'freeLook' ? 0 : headYawOffset,
+        controlMode === 'freeLook' ? 0 : headPitch,
         carSpeedRef.current,
         nightIntensity,
         headlightsOn,


### PR DESCRIPTION
## Summary

- In `freeLook` mode, `headYawOffset` and `headPitch` were unconditionally passed to `updateCarMode`, which rotates the Three.js camera as a child of `interiorGroup` — causing the dashboard and interior geometry to swing left/right/up/down as the user pans.
- Fix: pass `0` for both values when `controlMode === 'freeLook'`, keeping the interior camera fixed while `panorama.setPov()` continues to pan the street view behind it.

## Test plan

- [ ] Enter car mode, switch to **freeLook**, drag to pan — dashboard should stay stationary while the panorama changes
- [ ] Switch to **uiMouse** or **carSteer** — head tracking should still work (interior rotates with look direction)
- [ ] Verify pitch dragging in freeLook no longer makes the dashboard rise/fall

https://claude.ai/code/session_01PexxFYyLCtmdb2yq4VBbrg

---
_Generated by [Claude Code](https://claude.ai/code/session_01PexxFYyLCtmdb2yq4VBbrg)_