### PR TITLE
fix(maps): Phase 1 follow-ups — MiniMap crash + working circuit-breaker

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -258,22 +258,30 @@ function InnerApp() {
         setIsCruiseMode(false);
         return;
       }
-      // Safe advance — waits for current pano to be ready before moving
+      // Snapshot the panoId before the hop. `advanceSafe` doesn't throw on
+      // no-coverage / no-link — it just no-ops — so we detect a stuck hop by
+      // checking whether the panorama actually moved.
+      const panoIdBefore = panorama.getPano();
       setNavPending(true);
       try {
         await advanceSafe('forward', undefined, cruiseHeadingRef.current);
-        // Successful hop — reset failure counter
+      } finally {
+        setNavPending(false);
+      }
+      // Give `pano.setPano(...)` a moment to fire `pano_changed` before we
+      // judge the hop. 1.5s ≈ half the cruise interval.
+      await new Promise(r => setTimeout(r, 1500));
+      const panoIdAfter = panorama.getPano();
+      if (panoIdAfter && panoIdAfter !== panoIdBefore) {
         cruiseFailCountRef.current = 0;
-      } catch (err) {
+      } else {
         cruiseFailCountRef.current += 1;
-        console.warn(`[CruiseMode] Advance failed (${cruiseFailCountRef.current}/3):`, err);
+        console.warn(`[CruiseMode] Hop did not advance (${cruiseFailCountRef.current}/3)`);
         if (cruiseFailCountRef.current >= 3) {
-          console.error('[CruiseMode] 3 consecutive failures — auto-disabling cruise mode');
+          console.error('[CruiseMode] 3 consecutive stuck hops — auto-disabling cruise mode');
           setIsCruiseMode(false);
           cruiseFailCountRef.current = 0;
         }
-      } finally {
-        setNavPending(false);
       }
     };
     cruiseIntervalRef.current = setInterval(hop, 3000);

--- a/src/components/MiniMap.tsx
+++ b/src/components/MiniMap.tsx
@@ -384,9 +384,12 @@ const MiniMap: React.FC<MiniMapProps> = ({
 
     // Add/Remove Crypto Company Markers
     useEffect(() => {
-        // Clear existing crypto markers
+        // Clear existing crypto markers. Guard the AdvancedMarkerElement access:
+        // the `marker` library is no longer requested at load time, so
+        // `google.maps.marker` is undefined and a direct property access throws.
+        const AdvancedMarker = window.google?.maps?.marker?.AdvancedMarkerElement;
         cryptoMarkersRef.current.forEach(marker => {
-            if (marker instanceof google.maps.marker.AdvancedMarkerElement) {
+            if (AdvancedMarker && marker instanceof AdvancedMarker) {
                 marker.map = null;
             } else if (cesiumViewer && marker instanceof Cesium.Entity) {
                 cesiumViewer.entities.remove(marker);


### PR DESCRIPTION
Two follow-ups to PR #76 (Phase 1 of issue #75). Both are small and self-contained.

## 1. `MiniMap.tsx:389` — TypeError on crypto-marker cleanup

After #76, the Maps API is loaded without `libraries=marker`, so `window.google.maps.marker` is `undefined`. The crypto-marker cleanup path did a direct property access:

```ts
if (marker instanceof google.maps.marker.AdvancedMarkerElement) { ... }
```

That throws `TypeError: Cannot read properties of undefined (reading 'AdvancedMarkerElement')` every time the effect re-runs with previously-rendered markers (e.g. toggling `showCryptoMarkers`, or switching `viewMode`). Other call sites in the file already guarded with `window.google?.maps?.marker?.AdvancedMarkerElement`; this one was missed.

Fix: read the constructor via optional chaining once, then `instanceof` against the resolved reference.

## 2. Cruise-mode circuit-breaker was inert

`advanceSafe` (`src/hooks/useAdvanceSafe.ts:42-47`) swallows the only failure path (`panoCache.fetch` rejection) with `console.warn`, then calls `advance(...)`, which itself is fire-and-forget and silently no-ops when no link is found. So the `try { await advanceSafe(...) } catch { count++ }` block introduced in #76 could never increment the counter on real failures (no-coverage dead spots).

The auth-failure listener (`onMapsAuthFailure`) still works — that path is unaffected. This PR fixes the *stuck-cruise* signal so it can also auto-disable.

New approach: snapshot `panorama.getPano()` before the hop, wait ~1.5 s after `advanceSafe` resolves (so `pano.setPano(...)` has time to fire `pano_changed`), then compare. If the panoId hasn't changed, that's a failed hop. 3 in a row still calls `setIsCruiseMode(false)`.

## Diff

```
 src/App.tsx                | 22 +++++++++++++++-------
 src/components/MiniMap.tsx |  7 +++++--
 2 files changed, 20 insertions(+), 9 deletions(-)
```

## Test plan

- [ ] `npx tsc --noEmit` — clean (verified locally).
- [ ] Toggle the crypto-markers panel in MiniMap; confirm no `TypeError` in console.
- [ ] Enable cruise mode on a known dead-end road (or temporarily revoke link finding); confirm cruise auto-disables after 3 stuck hops with the new console message.
- [ ] Enable cruise mode on a normal street; confirm normal advance still works and counter resets.

Refs #75. Builds on #76.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ud3kd8GSKVmLcThPSzd8CD)_