### PR TITLE
Fix toggleHeadlights return-type mismatch and typed-array for-of in test

### DIFF
--- a/src/hooks/useAppKeyboardShortcuts.ts
+++ b/src/hooks/useAppKeyboardShortcuts.ts
@@ -28,7 +28,7 @@ export interface UseAppKeyboardShortcutsOptions {
   wipersEnabled: boolean;
   toggleWipers: () => void;
   headlightsOn: boolean;
-  toggleHeadlights: () => void;
+  toggleHeadlights: () => boolean;
   toggleDomeLight: () => boolean;
   isRoofOpen: boolean;
   toggleRoof: () => void;

--- a/src/wasm/__tests__/wasm.test.ts
+++ b/src/wasm/__tests__/wasm.test.ts
@@ -70,9 +70,9 @@ describe('fillNoiseBuffer', () => {
     wasm.seed(7);
     const buf = new Float32Array(8 * 8);
     wasm.fillNoiseBuffer(buf, 8, 8, 50, 0, 0);
-    for (const v of buf) {
-      expect(v).toBeGreaterThanOrEqual(-1);
-      expect(v).toBeLessThanOrEqual(1);
+    for (let i = 0; i < buf.length; i++) {
+      expect(buf[i]).toBeGreaterThanOrEqual(-1);
+      expect(buf[i]).toBeLessThanOrEqual(1);
     }
   });
 


### PR DESCRIPTION
## Summary

- **`useAppKeyboardShortcuts.ts`**: The interface typed `toggleHeadlights` as `() => void`, but the caller at line 200 uses its return value in a ternary (`newState ? 'on' : 'off'`). The actual implementation in `useEnvironmentSettings.tsx` returns `boolean`, so the interface type is corrected to `() => boolean`.
- **`wasm.test.ts`**: `for...of` over a `Float32Array` requires either `downlevelIteration: true` or a target of `ES2015+`. The project targets `ES5` without that flag, so the loop was replaced with a standard indexed `for` loop.

## Test plan

- [ ] `npx tsc --noEmit` passes with no new errors
- [ ] Headlights toggle announcement correctly says "on" or "off" in car mode
- [ ] WASM noise buffer test compiles and runs without type errors

https://claude.ai/code/session_01REJtD51mP7rANFvA8hzWkC

---
_Generated by [Claude Code](https://claude.ai/code/session_01REJtD51mP7rANFvA8hzWkC)_