### PR TITLE
Refactor Google Maps API loader

### DIFF
--- a/src/services/maps/loader.test.ts
+++ b/src/services/maps/loader.test.ts
@@ -1,0 +1,77 @@
+import { loadMapsApi, onMapsAuthFailure } from './loader';
+
+const resetMapsGlobals = () => {
+  document.head.innerHTML = '';
+  document.body.innerHTML = '';
+  delete (window as any).google;
+  delete (window as any).gm_authFailure;
+  delete (window as any).__mapsApiLoadState;
+  delete (window as any).__initWebGpuStreetviewMaps;
+};
+
+describe('loadMapsApi', () => {
+  beforeEach(() => {
+    resetMapsGlobals();
+    jest.useRealTimers();
+  });
+
+  afterEach(() => {
+    resetMapsGlobals();
+    jest.restoreAllMocks();
+  });
+
+  it('rejects empty and placeholder API keys without injecting a script', async () => {
+    await expect(loadMapsApi('')).rejects.toThrow('key is empty');
+    await expect(loadMapsApi('YOUR_MAPS_API_KEY')).rejects.toThrow('placeholder value detected');
+
+    expect(document.querySelector('script[src*="maps.googleapis.com/maps/api/js"]')).toBeNull();
+  });
+
+  it('injects the async dynamic-library bootstrap and imports app libraries once', async () => {
+    const importedLibraries: string[] = [];
+    const appendSpy = jest.spyOn(document.head, 'appendChild');
+
+    appendSpy.mockImplementation((node: Node) => {
+      const script = node as HTMLScriptElement;
+      setTimeout(() => {
+        (window as any).google = {
+          maps: {
+            importLibrary: jest.fn((libraryName: string) => {
+              importedLibraries.push(libraryName);
+              return Promise.resolve({});
+            }),
+          },
+        };
+        (window as any).__initWebGpuStreetviewMaps?.();
+      }, 0);
+      return script;
+    });
+
+    const promise = loadMapsApi('AIzaSyCleanConnectionTestKey');
+    const secondPromise = loadMapsApi('AIzaSyCleanConnectionTestKey');
+
+    expect(secondPromise).toBe(promise);
+
+    await promise;
+
+    const script = appendSpy.mock.calls[0][0] as HTMLScriptElement;
+    const url = new URL(script.src);
+    expect(url.origin).toBe('https://maps.googleapis.com');
+    expect(url.pathname).toBe('/maps/api/js');
+    expect(url.searchParams.get('loading')).toBe('async');
+    expect(url.searchParams.get('v')).toBe('weekly');
+    expect(url.searchParams.get('callback')).toBe('__initWebGpuStreetviewMaps');
+    expect(importedLibraries.sort()).toEqual(['maps', 'marker', 'streetView']);
+  });
+
+  it('notifies registered listeners when Google reports an auth failure', () => {
+    const listener = jest.fn();
+    const unsubscribe = onMapsAuthFailure(listener);
+
+    loadMapsApi('AIzaSyCleanConnectionTestKey').catch(() => undefined);
+    window.gm_authFailure?.();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+});

--- a/src/services/maps/loader.ts
+++ b/src/services/maps/loader.ts
@@ -1,12 +1,10 @@
 /**
- * Singleton Google Maps JavaScript API loader.
+ * Clean Google Maps JavaScript API connection layer.
  *
- * - Idempotent: subsequent calls return the same Promise.
- * - URL matches the deployed working version: ?key=<KEY>&v=3.56
- *   (no `callback` param, no `libraries`).
- * - Uses `script.onload` for initialization rather than a global callback.
- * - Installs `window.gm_authFailure` to surface key / referrer issues.
- * - Rejects immediately if the key is empty.
+ * Uses Google's current dynamic-library loading model instead of the older
+ * "direct script + onload" flow.  The loader installs a tiny bootstrap once,
+ * asks Maps for only the libraries this app needs, and exposes a single
+ * idempotent Promise to React components.
  */
 
 declare global {
@@ -14,8 +12,13 @@ declare global {
     /** Called by Google Maps SDK when the key is invalid or referrer-blocked. */
     gm_authFailure?: () => void;
     google?: typeof google;
-    /** Internal: cached in-flight load promise. */
-    __mapsApiPromise?: Promise<void>;
+    /** Internal: cached in-flight load promise and key metadata. */
+    __mapsApiLoadState?: {
+      apiKey: string;
+      promise: Promise<void>;
+    };
+    /** Internal: callback name used by the dynamic Maps bootstrap. */
+    __initWebGpuStreetviewMaps?: () => void;
     /**
      * Runtime API key injected by public/config.js before the React bundle
      * loads. Takes precedence over the build-time REACT_APP_MAPS_API_KEY env var.
@@ -38,6 +41,10 @@ const PLACEHOLDER_KEY_PATTERNS: RegExp[] = [
   /^AIzaSy-placeholder/i,
 ];
 
+const MAPS_SCRIPT_ID = 'webgpu-streetview-google-maps-js';
+const MAPS_CALLBACK_NAME = '__initWebGpuStreetviewMaps';
+const AUTH_ERROR_SCAN_DELAY_MS = 1200;
+
 /** Registered auth-failure callbacks */
 const authFailureListeners: Array<() => void> = [];
 
@@ -55,120 +62,140 @@ export function onMapsAuthFailure(cb: () => void): () => void {
   };
 }
 
-/**
- * Load the Google Maps JavaScript API.
- *
- * Subsequent calls with the same (or any) key return the same Promise — the
- * script is injected at most once per page.
- *
- * @param apiKey  Maps API key.  If empty the promise rejects immediately.
- */
-export function loadMapsApi(apiKey: string): Promise<void> {
-  // Guard: empty key or obvious placeholder — reject immediately with a clear
-  // message rather than passing the value to Google Maps and triggering the
-  // "This page can't load Google Maps correctly" error overlay.
-  const isPlaceholder = PLACEHOLDER_KEY_PATTERNS.some(re => re.test(apiKey?.trim() || ''));
-  if (!apiKey || isPlaceholder) {
+function notifyAuthFailure(source: string): void {
+  console.error(`[Maps Loader] ${source} — API key invalid, referrer-blocked, billing disabled, or API not enabled`);
+  authFailureListeners.forEach(cb => {
+    try {
+      cb();
+    } catch (e) {
+      console.error('[Maps Loader] Auth failure listener error:', e);
+    }
+  });
+}
+
+function installAuthFailureHandler(): void {
+  window.gm_authFailure = () => notifyAuthFailure('gm_authFailure');
+}
+
+function scanForAuthErrorOverlay(): void {
+  const bodyText = (document.body && document.body.innerText) || '';
+  const hasClassicError =
+    /This page can['’]t load Google Maps correctly/i.test(bodyText) ||
+    /无法正确加载 Google 地图/i.test(bodyText) ||
+    /Do you own this website/i.test(bodyText);
+
+  if (hasClassicError) {
+    notifyAuthFailure('Detected Google Maps authentication error UI in DOM after script load');
+  }
+}
+
+function getKeyConfigurationError(apiKey: string): string | null {
+  const trimmed = apiKey?.trim() || '';
+  const isPlaceholder = PLACEHOLDER_KEY_PATTERNS.some(re => re.test(trimmed));
+
+  if (!trimmed || isPlaceholder) {
     const reason = isPlaceholder ? 'placeholder value detected' : 'key is empty';
-    const msg =
+    return (
       `[Maps Loader] Google Maps API key not configured (${reason}). ` +
       'Set window.MAPS_API_KEY in public/config.js (runtime, no rebuild needed) ' +
       'or set REACT_APP_MAPS_API_KEY in .env.local and rebuild. ' +
-      'The Maps API will not load.';
-    console.warn(msg);
-    return Promise.reject(new Error(msg));
-  }
-
-  // Already fully loaded.
-  if (window.google?.maps) {
-    return Promise.resolve();
-  }
-
-  // Return the existing in-flight promise (singleton).
-  if (window.__mapsApiPromise) {
-    return window.__mapsApiPromise;
-  }
-
-  // Install the auth-failure handler exactly once, before injecting the script.
-  if (!window.gm_authFailure) {
-    window.gm_authFailure = () => {
-      console.error(
-        '[Maps Loader] gm_authFailure — API key invalid, referrer-blocked, or billing disabled'
-      );
-      authFailureListeners.forEach(cb => {
-        try { cb(); } catch (e) { console.error('[Maps Loader] Auth failure listener error:', e); }
-      });
-    };
-  }
-
-  window.__mapsApiPromise = new Promise<void>((resolve, reject) => {
-    // If a Maps script tag was already injected (e.g. by SSR or another bundle),
-    // wait for it rather than injecting a second one.
-    const existing = document.querySelector<HTMLScriptElement>(
-      'script[src*="maps.googleapis.com/maps/api/js"]'
+      'The Maps API will not load.'
     );
+  }
+
+  return null;
+}
+
+function removeFailedBootstrap(): void {
+  const script = document.getElementById(MAPS_SCRIPT_ID);
+  if (script?.parentElement) {
+    script.parentElement.removeChild(script);
+  }
+  delete window.__mapsApiLoadState;
+  delete window.__initWebGpuStreetviewMaps;
+}
+
+function createBootstrapScript(apiKey: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const existing = document.getElementById(MAPS_SCRIPT_ID) as HTMLScriptElement | null;
+
     if (existing) {
-      if (window.google?.maps) {
-        resolve();
-        return;
-      }
-      existing.addEventListener('load', () => {
-        if (window.google?.maps) resolve();
-        else reject(new Error('[Maps Loader] Existing script tag loaded but google.maps is undefined'));
-      });
-      existing.addEventListener('error', () =>
-        reject(new Error('[Maps Loader] Existing script tag failed to load'))
-      );
+      existing.addEventListener('load', () => resolve(), { once: true });
+      existing.addEventListener('error', () => reject(new Error('[Maps Loader] Existing Maps bootstrap failed to load')), { once: true });
       return;
     }
 
+    window.__initWebGpuStreetviewMaps = () => resolve();
+
+    const params = new URLSearchParams({
+      key: apiKey.trim(),
+      v: 'weekly',
+      loading: 'async',
+      callback: MAPS_CALLBACK_NAME,
+    });
+
     const script = document.createElement('script');
-    // Match the deployed working bundle: v=3.56, no callback, no libraries.
-    script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&v=3.56`;
+    script.id = MAPS_SCRIPT_ID;
+    script.src = `https://maps.googleapis.com/maps/api/js?${params.toString()}`;
     script.async = true;
-
-    script.onload = () => {
-      if (window.google?.maps) {
-        // Schedule a verification pass. Google sometimes injects a visible error
-        // overlay into map containers (or the body) asynchronously even after the
-        // script "loads", especially for referrer/billing/auth failures.
-        // If we detect the classic error text, treat it as an auth failure so the
-        // app can show a clear actionable message instead of the confusing Google UI.
-        setTimeout(() => {
-          const bodyText = (document.body && document.body.innerText) || '';
-          const hasClassicError =
-            /This page can['’]t load Google Maps correctly/i.test(bodyText) ||
-            /无法正确加载 Google 地图/i.test(bodyText) ||
-            /Do you own this website/i.test(bodyText);
-
-          if (hasClassicError) {
-            console.error(
-              '[Maps Loader] Detected Google Maps authentication error UI in DOM after script load. ' +
-              'This almost always means: (1) HTTP referrer restriction on the key does not include the current origin, ' +
-              '(2) billing is not enabled / payment method issue on the GCP project, or (3) Maps JavaScript API is disabled for the key.'
-            );
-            // Fire the same listeners that gm_authFailure would have triggered.
-            authFailureListeners.forEach(cb => {
-              try { cb(); } catch (e) { console.error('[Maps Loader] Auth failure listener error (post-load scan):', e); }
-            });
-            // Do not resolve as success; downstream code (StreetView) will surface via onError + banners.
-            // We resolve here only to avoid double-rejection in the promise chain, but the listeners have already
-            // notified the app which will disable cruise and show the prominent banner.
-          }
-        }, 1200);
-
-        resolve();
-      } else {
-        reject(new Error('[Maps Loader] Script loaded but google.maps is undefined'));
-      }
-    };
-
-    script.onerror = () => {
-      reject(new Error('[Maps Loader] Failed to load Google Maps API script'));
-    };
-
+    script.onerror = () => reject(new Error('[Maps Loader] Failed to load Google Maps API script'));
     document.head.appendChild(script);
   });
+}
 
-  return window.__mapsApiPromise;
+async function importRequiredLibraries(): Promise<void> {
+  const importLibrary = window.google?.maps?.importLibrary;
+  if (!importLibrary) {
+    throw new Error('[Maps Loader] google.maps.importLibrary is unavailable after script load');
+  }
+
+  await Promise.all([
+    importLibrary('maps'),
+    importLibrary('streetView'),
+    importLibrary('marker'),
+  ]);
+}
+
+/**
+ * Load the Google Maps JavaScript API and the app's required libraries.
+ *
+ * Subsequent calls with the same key return the same Promise.  If a previous
+ * load failed, the failed bootstrap is removed so a later runtime-key update can
+ * retry without a full page refresh.
+ *
+ * @param apiKey Maps API key. If empty the promise rejects immediately.
+ */
+export function loadMapsApi(apiKey: string): Promise<void> {
+  const keyError = getKeyConfigurationError(apiKey);
+  if (keyError) {
+    console.warn(keyError);
+    return Promise.reject(new Error(keyError));
+  }
+
+  if (window.google?.maps?.Map && window.google.maps.StreetViewPanorama) {
+    return Promise.resolve();
+  }
+
+  const trimmedKey = apiKey.trim();
+  if (window.__mapsApiLoadState) {
+    if (window.__mapsApiLoadState.apiKey !== trimmedKey) {
+      console.warn('[Maps Loader] Maps API is already loading with a different runtime key; reusing the in-flight connection.');
+    }
+    return window.__mapsApiLoadState.promise;
+  }
+
+  installAuthFailureHandler();
+
+  const promise = createBootstrapScript(trimmedKey)
+    .then(importRequiredLibraries)
+    .then(() => {
+      setTimeout(scanForAuthErrorOverlay, AUTH_ERROR_SCAN_DELAY_MS);
+    })
+    .catch(err => {
+      removeFailedBootstrap();
+      throw err;
+    });
+
+  window.__mapsApiLoadState = { apiKey: trimmedKey, promise };
+  return promise;
 }


### PR DESCRIPTION
### Motivation
- The app is having intermittent Google Maps failures and confusing Google error overlays when the API key is missing, placeholder, or referrer-restricted, so the loader was rewritten to be more robust and modern. 
- Move from an ad-hoc `script.onload` flow to Google’s dynamic-library model to explicitly import only the libraries the app needs and make retry/cleanup behavior safer.

### Description
- Replaced the old loader with a clean async bootstrap that injects a single script using `loading=async`, the `weekly` channel, and a runtime callback, then calls `google.maps.importLibrary` for `maps`, `streetView`, and `marker`.
- Added stronger API key validation that rejects empty/placeholder keys before injection and preserves the runtime `window.MAPS_API_KEY` override behavior.
- Implemented a singleton `window.__mapsApiLoadState` to track in-flight loads, remove failing bootstraps so a later runtime key can retry, and installed `gm_authFailure` + a post-load DOM scan to surface auth/referrer/billing issues to the app.
- Added unit tests `src/services/maps/loader.test.ts` covering key validation, singleton injection behavior, bootstrap URL parameters, import calls, and auth-failure listener notifications.

### Testing
- Ran the new unit tests with `npm test -- --watchAll=false --runInBand src/services/maps/loader.test.ts` and they passed.
- Ran the full test suite with `npm test -- --watchAll=false --runInBand` which exposed unrelated environment limits (jsdom lacks canvas `getContext` and Jest needs transform config for Three.js ESM examples), causing other suites to fail; these failures pre-existed and are not caused by the loader refactor.
- Ran `npm run build`; CRA compilation completed (with lint warnings) but the build pipeline failed during the `build:wasm` step because the environment lacks the emscripten toolchain referenced by `scripts/build-wasm.sh` (`/content/buil*/emsdk/emsdk_env.sh` not present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a209504d6a0832fb26a88559bc3a640)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Maps API key validation with clearer error feedback
  * Enhanced authentication failure detection and recovery
  * More robust Google Maps library loading mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->