### PR TITLE
Fix build failure that produced a black/empty StreetView page

### DIFF
--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -21,7 +21,29 @@
 #   --wat-only   Always use the WAT→WASM path, even if emcc is available.
 
 set -euo pipefail
-source /content/buil*/emsdk/emsdk_env.sh
+
+# Activate Emscripten if an emsdk environment is available, but never let a
+# missing/relocated emsdk abort the build — the script falls back to the
+# wabt (WAT → WASM) path below when emcc is not present. Honour EMSDK_ENV if
+# set, otherwise probe a couple of common locations.
+activate_emsdk() {
+  local candidate
+  for candidate in \
+    "${EMSDK_ENV:-}" \
+    "${EMSDK:-}/emsdk_env.sh" \
+    /content/buil*/emsdk/emsdk_env.sh \
+    "$HOME"/emsdk/emsdk_env.sh; do
+    [ -n "$candidate" ] || continue
+    for resolved in $candidate; do
+      if [ -f "$resolved" ]; then
+        # shellcheck disable=SC1090
+        source "$resolved" && return 0
+      fi
+    done
+  done
+  return 0
+}
+activate_emsdk
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CPP_DIR="$REPO_ROOT/cpp"


### PR DESCRIPTION
## Problem

StreetView loaded as a black, empty page. Root cause was in the build, not the app code.

`scripts/build-wasm.sh` started with:

```bash
set -euo pipefail
source /content/buil*/emsdk/emsdk_env.sh
```

That `source` of a hardcoded emsdk path runs unconditionally. On any machine that doesn't have that exact path (i.e. anything but the original author's box / CI), `set -e` aborts the script with a non-zero exit **before** it can reach the wabt (WAT→WASM) fallback it was designed to use.

Because `npm run build` is:

```
react-scripts build && npm run build:wasm && ./scripts/verify-build.sh
```

the failing `build:wasm` step fails the entire production build, so deploys ship stale/incomplete artifacts → black empty page.

## Fix

Source the emsdk environment only when an env script actually exists (honouring `EMSDK_ENV` / `EMSDK`, then common locations), and otherwise fall through to the existing wabt path. No more hard abort.

## Verification

- `bash scripts/build-wasm.sh` → falls back to wabt, exits 0
- `npm run build` → exits 0, `verify-build.sh` passes
- `npx tsc --noEmit` → clean

https://claude.ai/code/session_01Pg7MKCwEDqaiqaQGFVbxe3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pg7MKCwEDqaiqaQGFVbxe3)_