### PR TITLE
Bake Maps API key into JS bundle like go.1ink.us (drop config.js)

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -60,8 +60,6 @@ def _validate_build_index(build_path: Path) -> None:
         problems.append("contains unprocessed %PUBLIC_URL% (public/index.html was deployed instead of build/index.html)")
     if "static/js/main" not in content:
         problems.append("does not reference static/js/main.*.js (React bundle will never load)")
-    if "config.js" not in content:
-        problems.append("does not reference config.js (runtime MAPS_API_KEY override will not work)")
 
     if problems:
         print("\n" + "!" * 70)
@@ -72,7 +70,7 @@ def _validate_build_index(build_path: Path) -> None:
         print("!" * 70 + "\n")
         sys.exit(1)
 
-    print("  build/index.html looks valid (bundle + config.js present, no %PUBLIC_URL%).")
+    print("  build/index.html looks valid (main JS bundle present, no %PUBLIC_URL%).")
 
 
 def _validate_maps_key(key: str) -> None:
@@ -133,23 +131,27 @@ DEPLOY_TOKEN: Optional[str] = "6de44dca5425348f2e2ef9456fc820bfe56a5ace68bddeb6d
 # even with the current bundle-upload mechanism). This directly addresses repeated
 # map loading failures after deploys (see #89, #84).
 MAPS_API_KEY: Optional[str] = os.environ.get("MAPS_API_KEY", "").strip() or None
+# Sentinel string in src/App.tsx — deploy.py replaces it inside static/js/*.js bundles
+# (same delivery model as go.1ink.us, which bakes the key into main.js).
+MAPS_KEY_SENTINEL = "__RUNTIME_MAPS_KEY_SENTINEL__"
 # ============================================================
 
 
-def _inject_maps_key(data: bytes, key: str) -> bytes:
-    """Return a JS config snippet setting window.MAPS_API_KEY safely."""
-    import json
-    safe = json.dumps(key)
-    return f"// Injected by deploy.py (MAPS_API_KEY env)\nwindow.MAPS_API_KEY = {safe};\n".encode("utf-8")
+def _inject_maps_key_into_bundle(data: bytes, key: str) -> bytes:
+    """Replace the deploy sentinel with the real Maps API key in a JS bundle."""
+    needle = MAPS_KEY_SENTINEL.encode("utf-8")
+    if needle not in data:
+        return data
+    return data.replace(needle, key.encode("utf-8"))
 
 
 def build_zip(build_path: Path) -> bytes:
     """Zip the contents of build_path into an in-memory archive.
-    If MAPS_API_KEY env is set, patch build/config.js inside the archive
-    (no need to have baked the key or edited after deploy).
+    If MAPS_API_KEY env is set, bake it into static/js/*.js by replacing
+    __RUNTIME_MAPS_KEY_SENTINEL__ (go.1ink.us style — key lives in main.js).
     """
     buf = io.BytesIO()
-    injected = False
+    bundle_patched = False
     with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         for file in sorted(build_path.rglob("*")):
             if file.is_dir():
@@ -160,22 +162,33 @@ def build_zip(build_path: Path) -> bytes:
             if any(p in (".git", "node_modules", "__pycache__") for p in parts):
                 continue
 
-            if MAPS_API_KEY and str(rel) == "config.js":
-                print("  + config.js (with MAPS_API_KEY injected at deploy time)")
-                zf.writestr(str(rel), _inject_maps_key(file.read_bytes(), MAPS_API_KEY))
-                injected = True
-                continue
+            file_data = file.read_bytes()
+            if (
+                MAPS_API_KEY
+                and len(parts) >= 2
+                and parts[0] == "static"
+                and parts[1] == "js"
+                and str(rel).endswith(".js")
+            ):
+                patched = _inject_maps_key_into_bundle(file_data, MAPS_API_KEY)
+                if patched != file_data:
+                    print(f"  + {rel} (Maps API key baked into bundle)")
+                    zf.writestr(str(rel), patched)
+                    bundle_patched = True
+                    continue
 
-            zf.write(file, str(rel))
+            zf.writestr(str(rel), file_data)
             print(f"  + {rel}")
 
-        if MAPS_API_KEY and not injected:
-            # No config.js in the build tree? Still provide one (defensive).
-            print("  + config.js (synthesized with MAPS_API_KEY)")
-            zf.writestr("config.js", _inject_maps_key(b"", MAPS_API_KEY))
-
     if MAPS_API_KEY:
-        print(f"\n[deploy] Maps key injected for runtime use (length {len(MAPS_API_KEY)}).")
+        if not bundle_patched:
+            print("\n" + "!" * 70)
+            print(f"  ERROR: MAPS_API_KEY provided but '{MAPS_KEY_SENTINEL}' was not found")
+            print("  in build/static/js/*.js. Run 'npm run build' first, then deploy again.")
+            print("!" * 70 + "\n")
+            sys.exit(1)
+        print(f"\n[deploy] Maps API key baked into JS bundle (length {len(MAPS_API_KEY)}).")
+        print("         Same delivery as go.1ink.us — no config.js required.")
         print("         Ensure the key's referrer allowlist covers test.1ink.us and go.1ink.us.")
     return buf.getvalue()
 
@@ -190,9 +203,9 @@ def deploy_bundle(build_path: Path) -> bool:
 
     print("Building zip archive...")
     if MAPS_API_KEY:
-        print(f"  MAPS_API_KEY provided (masked: {MAPS_API_KEY[:8]}...{MAPS_API_KEY[-4:]}) — will patch config.js")
+        print(f"  MAPS_API_KEY provided (masked: {MAPS_API_KEY[:8]}...{MAPS_API_KEY[-4:]}) — will bake into JS bundle")
     else:
-        print("  No MAPS_API_KEY env — shipping with whatever is in build/config.js (may be empty)")
+        print("  No MAPS_API_KEY env — bundle must already contain a key (REACT_APP_MAPS_API_KEY at build time)")
     zip_bytes = build_zip(build_path)
     print(f"Archive size: {len(zip_bytes) / 1024:.1f} KB\n")
 
@@ -251,7 +264,7 @@ def main():
     print(f"\n=== {'Deployment complete' if success else 'Deployment finished with errors'} ===")
     if success:
         print("Post-deploy verification (do this now):")
-        print("  1. curl https://test.1ink.us/streetview/config.js  (or go.1ink.us) — expect your key")
+        print("  1. curl -s https://test.1ink.us/streetview/static/js/main.*.js | grep -o 'AIzaSy[^\"]*' | head -1")
         print("  2. Hard refresh the demo; no 'This page can't load Google Maps correctly'")
         print("  3. Check GCP: key has referrers for both hosts + billing + JS API + Directions enabled")
         print("  4. curl -sI https://test.1ink.us/streetview/ | grep -i cross-origin-embedder")

--- a/public/index.html
+++ b/public/index.html
@@ -9,16 +9,8 @@
       body { margin: 0; background-color: #000; overflow: hidden; }
     </style>
   </head>
-  <!-- Runtime configuration: set window.MAPS_API_KEY without rebuilding the app -->
-  <script src="./config.js"></script>
-  <script>
-    // Notify the app that a (possibly late) runtime key may now be present.
-    // This helps recover from config.js / bundle eval races (see issues #84, #85).
-    try { window.dispatchEvent(new CustomEvent('maps-api-key-ready')); } catch (e) {}
-  </script>
   <script>
     // Recover when build/index.html was not deployed (public/index.html uploaded by mistake).
-    // Loads main.js + main.css from asset-manifest.json so test.1ink.us can self-heal.
     (function recoverMissingBundle() {
       function hasMainBundle() {
         return !!document.querySelector('script[src*="static/js/main"]');

--- a/scripts/verify-build.sh
+++ b/scripts/verify-build.sh
@@ -56,8 +56,11 @@ if [ -n "$MAIN_JS" ]; then
     echo "ℹ️  Note: Main bundle contains an 'AIzaSy...' string (this is the build-time fallback key)."
     echo "    This is acceptable only if you intentionally built with REACT_APP_MAPS_API_KEY set."
     echo "    For the safest deploys, build without it and rely on deploy.py MAPS_API_KEY override."
+  elif grep -q '__RUNTIME_MAPS_KEY_SENTINEL__' "$MAIN_JS"; then
+    echo "✅ Deploy sentinel present in main bundle (deploy.py will bake MAPS_API_KEY)"
   else
-    echo "✅ No API key pattern found in main bundle (pure runtime config path)"
+    echo "❌ ERROR: main bundle has no API key and no deploy sentinel — Maps will not load"
+    ERRORS=$((ERRORS+1))
   fi
 fi
 
@@ -81,11 +84,10 @@ else
     echo "✅ index.html references the main JS bundle"
   fi
 
-  if ! grep -q 'config.js' "$INDEX_HTML"; then
-    echo "❌ ERROR: build/index.html does not reference config.js"
-    ERRORS=$((ERRORS+1))
+  if grep -q 'config.js' "$INDEX_HTML"; then
+    echo "ℹ️  index.html still references config.js (optional; go.1ink.us uses bundle-only keys)"
   else
-    echo "✅ index.html correctly references config.js"
+    echo "✅ index.html uses bundle-only Maps key delivery (go.1ink.us style)"
   fi
 fi
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,17 +56,17 @@ import { getMemoryProfiler, MemoryStats } from './utils/memoryProfiler';
 import { loadMapsApi, onMapsAuthFailure, removeFailedBootstrap } from './services/maps/loader';
 
 
-// Google Maps API Key resolution (in priority order):
-//  1. window.MAPS_API_KEY  — set at runtime via public/config.js (no rebuild needed)
-//  2. REACT_APP_MAPS_API_KEY — baked in at build time via .env.local / CI env var
-// Never commit real keys. See public/config.js and README for deployment instructions.
-//
-// NOTE: We use a small state + poller below so a slightly delayed config.js
-// (race on some deploys / CDNs) still gets picked up without requiring a full
-// page reload. See issues #84 and #85.
+// Google Maps API Key resolution (matches go.1ink.us — baked into the JS bundle):
+//  1. REACT_APP_MAPS_API_KEY — set at `npm run build` via .env.local / CI env var
+//  2. __RUNTIME_MAPS_KEY_SENTINEL__ — replaced in the built bundle by deploy.py
+//  3. window.MAPS_API_KEY — optional manual override via config.js (dev/emergency only)
+// Never commit real keys. Production deploy: MAPS_API_KEY=... python deploy.py
+const MAPS_KEY_DEPLOY_SENTINEL = '__RUNTIME_MAPS_KEY_SENTINEL__';
+
 const PLACEHOLDER_MAPS_KEY_PATTERNS: RegExp[] = [
   /^your[_-]?(google[_-]?)?maps[_-]?api[_-]?key[_-]?(here)?$/i,
   /^YOUR_MAPS_API_KEY$/,
+  /^__RUNTIME_MAPS_KEY_SENTINEL__$/,
   /^placeholder/i,
   /^<.*>$/,
   /replace/i,
@@ -78,15 +78,18 @@ function normalizeMapsKey(value: string | undefined): string {
 }
 
 function getConfiguredMapsKey(): string {
-  return normalizeMapsKey(window.MAPS_API_KEY) || normalizeMapsKey(process.env.REACT_APP_MAPS_API_KEY);
+  return (
+    normalizeMapsKey(process.env.REACT_APP_MAPS_API_KEY) ||
+    normalizeMapsKey(MAPS_KEY_DEPLOY_SENTINEL) ||
+    normalizeMapsKey(window.MAPS_API_KEY)
+  );
 }
 const INITIAL_MAPS_KEY = getConfiguredMapsKey();
 if (!INITIAL_MAPS_KEY) {
   console.warn(
     "[WebGPU StreetView] No Maps API key found at initial eval. " +
-    "Set window.MAPS_API_KEY in public/config.js (preferred) or set " +
-    "REACT_APP_MAPS_API_KEY in .env.local and rebuild. " +
-    "A poller will retry for late-arriving runtime keys."
+    "Set REACT_APP_MAPS_API_KEY in .env.local and rebuild, or deploy with " +
+    "MAPS_API_KEY=... python deploy.py to bake the key into the bundle (go.1ink.us style)."
   );
 }
 


### PR DESCRIPTION
go.1ink.us works because the key is compiled into main.js, not loaded from config.js. test.1ink.us was failing with the Google error overlay despite config.js injection because the runtime config path is fragile on that host.

- Resolve key from REACT_APP_MAPS_API_KEY or deploy sentinel in bundle first
- deploy.py replaces __RUNTIME_MAPS_KEY_SENTINEL__ in static/js/*.js at deploy
- Remove config.js script from index.html (match go.1ink.us entry HTML)
- Fail deploy loudly if sentinel is missing from the build