### PR TITLE
Fix COEP/COOP header conflicts that cause Maps flicker

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,7 +1,13 @@
 <IfModule mod_headers.c>
+  # Ensure only one COEP/COOP header value is sent.
+  # Some hosts inject `require-corp` at a higher level, which conflicts with
+  # Street View subresource requests and causes flicker/error overlays.
+  Header always unset Cross-Origin-Embedder-Policy
+  Header always unset Cross-Origin-Opener-Policy
+
   # WebGPU works with credentialless COEP and it does NOT block Google Maps
   # StaticMap / QuotaService / Street View Static API requests the way
   # require-corp does (ERR_BLOCKED_BY_RESPONSE.NotSameOriginAfterDefaultedToSameOriginByCoep).
-  Header set Cross-Origin-Embedder-Policy "credentialless"
-  Header set Cross-Origin-Opener-Policy "same-origin"
+  Header always set Cross-Origin-Embedder-Policy "credentialless"
+  Header always set Cross-Origin-Opener-Policy "same-origin"
 </IfModule>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update `public/.htaccess` to explicitly unset inherited COEP/COOP headers before setting project values
- enforce a single canonical header pair using `Header always set`
- keep COEP as `credentialless` so Google Maps Street View sub-requests are not blocked

## Why
Some deployments can inject `Cross-Origin-Embedder-Policy: require-corp` at a higher layer while `.htaccess` sets `credentialless`, producing duplicate/conflicting COEP headers. That conflict can trigger Google Maps error overlay flicker even when API keys are correct.

## Validation
- `npm run build`
- live smoke check against `https://test.1ink.us/streetview` showed no Google Maps auth/error marker strings during page probe
- response headers currently show duplicate COEP values on live host, consistent with conflict root cause

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48a6a0c2-9494-4992-b486-31dff8555f99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48a6a0c2-9494-4992-b486-31dff8555f99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

