### PR TITLE
fix: car mode blank windows through windshield

### DIFF
--- a/deploy_old.py
+++ b/deploy_old.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import paramiko
 import getpass
 
@@ -14,6 +15,37 @@ USERNAME = "ford442"
 LOCAL_DIRECTORY = "build"
 # The directory on the server where the files should go (e.g., 'public_html/wasm-game').
 REMOTE_DIRECTORY = "go.1ink.us/streetview"
+
+def _validate_build():
+    """Reject obviously broken build/ output before uploading."""
+    index_html = os.path.join(LOCAL_DIRECTORY, "index.html")
+    if not os.path.isfile(index_html):
+        print(f"Error: {index_html} not found. Run 'npm run build' first.")
+        sys.exit(1)
+
+    with open(index_html, encoding="utf-8", errors="replace") as f:
+        content = f.read()
+
+    problems = []
+    if "%PUBLIC_URL%" in content:
+        problems.append("index.html still has %PUBLIC_URL% — you may have uploaded public/ instead of build/")
+    if "static/js/main" not in content:
+        problems.append("index.html does not reference static/js/main.*.js")
+
+    if problems:
+        print("\nERROR: build/ is not safe to deploy:")
+        for p in problems:
+            print(f"  - {p}")
+        print("\nFix: npm run build  (then re-run this script)\n")
+        sys.exit(1)
+
+    print("build/index.html looks valid.")
+
+    print(
+        "\nNOTE: Prefer the maintained deploy path for go.1ink.us:\n"
+        "  MAPS_API_KEY=your_key DEPLOY_TARGET=go python deploy.py\n"
+        "deploy_old.py uploads build/ as-is (no key injection, no Cesium post-build patches).\n"
+    )
 
 def upload_directory(sftp_client, local_path, remote_path):
     """
@@ -76,4 +108,5 @@ if __name__ == "__main__":
     if not os.path.exists(LOCAL_DIRECTORY):
         print(f"Error: Local directory '{LOCAL_DIRECTORY}' not found. Did you run 'npm run build' first?")
     else:
+        _validate_build()
         main()

--- a/src/car/CarInterior.ts
+++ b/src/car/CarInterior.ts
@@ -251,6 +251,8 @@ export class CarInterior {
             this.postProcessing,
             this.canvas
         );
+        // Post-FX OutputPass forces opaque alpha and blocks the WebGPU panorama through glass.
+        this.rendererDelegate.setPostProcessingEnabled(this.postProcessingEnabled);
 
         this.lightingManager = new CarInteriorLightingManager(
             this.headlightsLight,
@@ -595,9 +597,8 @@ private buildInteriorFromBuilder(): void {
     /** Enable/disable post-processing (bloom + SMAA). */
 
     public setPostProcessingEnabled(enabled: boolean): void {
-
+        this.postProcessingEnabled = enabled;
         this.rendererDelegate.setPostProcessingEnabled(enabled);
-
     }
 
     /** Adjust bloom strength (0-1). */

--- a/src/car/interior/CarInteriorRenderer.ts
+++ b/src/car/interior/CarInteriorRenderer.ts
@@ -2,6 +2,9 @@ import * as THREE from 'three';
 import { PostProcessingManager } from './PostProcessingManager';
 
 export class CarInteriorRenderer {
+    /** Post-FX (bloom/SMAA/OutputPass) breaks alpha compositing over the WebGPU panorama. */
+    private postProcessingActive = false;
+
     constructor(
         private renderer: THREE.WebGLRenderer,
         private camera: THREE.PerspectiveCamera,
@@ -11,7 +14,7 @@ export class CarInteriorRenderer {
     ) {}
 
     public render(): void {
-        if (this.postProcessing) {
+        if (this.postProcessing && this.postProcessingActive) {
             this.postProcessing.render();
         } else {
             this.renderer.render(this.scene, this.camera);
@@ -40,6 +43,7 @@ export class CarInteriorRenderer {
     }
 
     public setPostProcessingEnabled(enabled: boolean): void {
+        this.postProcessingActive = enabled;
         if (this.postProcessing) {
             this.postProcessing.setEnabled(enabled);
         }

--- a/src/car/interior/PostProcessingManager.ts
+++ b/src/car/interior/PostProcessingManager.ts
@@ -83,6 +83,10 @@ export class PostProcessingManager {
     this.enabled = enabled && this.gpuProfile.name !== 'low';
   }
 
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
   /** Resize composer targets on window resize. */
   setSize(width: number, height: number): void {
     this.composer.setSize(width, height);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On go.1ink.us (and locally in car mode), the Street View panorama renders correctly in free-look but appears **blank/black through the car windshield**.

## Root cause

`CarInterior` sets `postProcessingEnabled = false` because the interior post-FX stack (bloom/SMAA/`OutputPass`) breaks alpha compositing over the WebGPU panorama canvas underneath.

However, `CarInteriorRenderer.render()` always routed through `PostProcessingManager` whenever it existed (non-low GPUs). That meant either:

1. **Post-FX ran anyway** → `OutputPass` forces opaque alpha, blocking the WebGPU view through glass, or
2. **Post-FX was disabled** → `PostProcessingManager.render()` no-opped, so the interior never drew via the direct renderer path.

## Fix

- Track `postProcessingActive` in `CarInteriorRenderer` and fall back to `renderer.render()` when post-FX is off
- Apply `postProcessingEnabled = false` on init via `rendererDelegate.setPostProcessingEnabled()`
- Sync `postProcessingEnabled` field when toggled via `setPostProcessingEnabled()`
- Add basic `build/` validation + pointer to `DEPLOY_TARGET=go python deploy.py` in `deploy_old.py`

## Deploy notes

After merging, rebuild and redeploy to go.1ink.us:

```bash
npm run build
# preferred:
MAPS_API_KEY=... DEPLOY_TARGET=go python deploy.py
# or legacy SFTP upload:
python deploy_old.py
```

Free-look should be unchanged; car mode windows should show the WebGPU panorama again.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82b5044c-d18b-4094-8bae-2715e7d5dc1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82b5044c-d18b-4094-8bae-2715e7d5dc1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

