### PR TITLE
Require click-to-drag in car free look and steer modes

### DIFF
--- a/src/components/CarInputHandler.tsx
+++ b/src/components/CarInputHandler.tsx
@@ -13,9 +13,9 @@ interface CarInputHandlerProps {
 
 /**
  * CarInputHandler - Routes input by control mode:
- * - freeLook: drag = head look, A/D = head turn, W/S/arrows = drive position
+ * - freeLook: click-drag = head look, A/D = head turn, car stays put (no W/S drive)
  * - uiMouse: dashboard/menus only, right-drag = steer
- * - carSteer: drag X = steer car heading, drag Y = pitch, W/S = drive
+ * - carSteer: click-drag X = steer car heading, drag Y = pitch, W/S = drive
  */
 const CarInputHandler: React.FC<CarInputHandlerProps> = ({
   targetRef,
@@ -40,6 +40,7 @@ const CarInputHandler: React.FC<CarInputHandlerProps> = ({
     headCoupling,
     startTempSteerMode,
     endTempSteerMode,
+    isTempSteerMode,
     carHeading,
     setCarHeading,
   } = useViewMode();
@@ -67,11 +68,32 @@ const CarInputHandler: React.FC<CarInputHandlerProps> = ({
     onSteeringDelta?.(steerDelta * 0.5);
   }, [headCoupling, setCarHeading, setHeading, onSteeringDelta]);
 
+  const clearDragState = useCallback(() => {
+    if (isSteeringWheelDragRef.current) {
+      endTempSteerMode();
+    }
+    isDraggingRef.current = false;
+    isSteeringWheelDragRef.current = false;
+    isRightMouseRef.current = false;
+    dragStartedOnTargetRef.current = false;
+  }, [endTempSteerMode]);
+
+  // Drop any in-progress drag when switching control modes (but not during a
+  // steering-wheel hold, which intentionally switches into temp carSteer).
+  useEffect(() => {
+    if (!isTempSteerMode) {
+      clearDragState();
+    }
+  }, [controlMode, isTempSteerMode, clearDragState]);
+
   useEffect(() => {
     const target = targetRef.current;
     if (!target) return;
 
     const getEffectiveControlMode = (): ControlMode => controlMode;
+
+    const isMouseButtonHeld = (e: MouseEvent): boolean =>
+      (e.buttons & 1) !== 0 || (e.buttons & 2) !== 0;
 
     const handleMouseDown = (e: MouseEvent) => {
       if (controlMode === 'uiMouse' && e.button === 0) return;
@@ -107,6 +129,13 @@ const CarInputHandler: React.FC<CarInputHandlerProps> = ({
       const currentMode = getEffectiveControlMode();
       if (!isDraggingRef.current || !dragStartedOnTargetRef.current) return;
 
+      // Require an actual held mouse button — prevents stale drag state from
+      // mode switches or missed mouseup events from panning without a click.
+      if (!isMouseButtonHeld(e)) {
+        clearDragState();
+        return;
+      }
+
       if (currentMode === 'freeLook') {
         const steeringDrag = isSteeringWheelDragRef.current || isRightMouseRef.current || e.shiftKey;
         if (steeringDrag) {
@@ -126,13 +155,7 @@ const CarInputHandler: React.FC<CarInputHandlerProps> = ({
 
     const handleMouseUp = (e: MouseEvent) => {
       if (e.button === 0 || e.button === 2) {
-        if (e.button === 0 && isSteeringWheelDragRef.current) {
-          endTempSteerMode();
-        }
-        isDraggingRef.current = false;
-        isSteeringWheelDragRef.current = false;
-        isRightMouseRef.current = false;
-        dragStartedOnTargetRef.current = false;
+        clearDragState();
       }
     };
 
@@ -148,21 +171,25 @@ const CarInputHandler: React.FC<CarInputHandlerProps> = ({
       switch (key) {
         case 'w':
         case 'arrowup':
+          if (controlMode === 'freeLook') break;
           if (key.startsWith('arrow')) e.preventDefault();
           advance('forward', carHeading);
-          if (controlMode !== 'freeLook') onThrustRef.current?.('forward');
+          onThrustRef.current?.('forward');
           break;
         case 's':
         case 'arrowdown':
+          if (controlMode === 'freeLook') break;
           if (key.startsWith('arrow')) e.preventDefault();
           advance('backward', carHeading);
-          if (controlMode !== 'freeLook') onThrustRef.current?.('backward');
+          onThrustRef.current?.('backward');
           break;
         case 'arrowleft':
+          if (controlMode === 'freeLook') break;
           e.preventDefault();
           advance('left', carHeading);
           break;
         case 'arrowright':
+          if (controlMode === 'freeLook') break;
           e.preventDefault();
           advance('right', carHeading);
           break;
@@ -199,6 +226,7 @@ const CarInputHandler: React.FC<CarInputHandlerProps> = ({
           break;
         }
         case 'h':
+          clearDragState();
           toggleControlMode();
           break;
         case 'u':
@@ -248,6 +276,8 @@ const CarInputHandler: React.FC<CarInputHandlerProps> = ({
     setCarHeading,
     applySteering,
     onSteeringDelta,
+    isTempSteerMode,
+    clearDragState,
   ]);
 
   return null;

--- a/src/views/CarModeView.tsx
+++ b/src/views/CarModeView.tsx
@@ -403,11 +403,11 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
   const getModeDescription = (mode: ControlMode): string => {
     switch (mode) {
       case 'freeLook':
-        return '🖱️ Drag = look around • A/D = turn head • W/S = drive • Click wheel = steer';
+        return '🖱️ Click-drag = look around • A/D = turn head • Car stays put • Click wheel = steer';
       case 'uiMouse':
         return '🖱️ Use dashboard controls • Right-drag = steer • H = switch mode';
       case 'carSteer':
-        return '🚗 Drag X = steer car • Drag Y = look up/down • W/S = drive • Q/E = snap ±45°';
+        return '🚗 Click-drag X = steer car • drag Y = look up/down • W/S = drive • Q/E = snap ±45°';
     }
   };
   
@@ -422,7 +422,7 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
         backgroundColor: 'transparent',
         // UI mode: let clicks pass through to the dashboard; other modes capture look/steer input
         pointerEvents: controlMode === 'uiMouse' ? 'none' : 'auto',
-        cursor: controlMode === 'uiMouse' ? 'default' : controlMode === 'carSteer' ? 'ew-resize' : 'grab',
+        cursor: controlMode === 'uiMouse' ? 'default' : controlMode === 'carSteer' ? 'ew-resize' : 'default',
       }}
     >
       {/* Input handler */}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes car mode input so free look and steer modes only pan the view after an explicit mouse click, and keeps the car stationary while looking around in free look.

## Changes

- **Click-to-drag guard**: `CarInputHandler` now checks `MouseEvent.buttons` during `mousemove`, so look/steer only applies while a mouse button is actually held. This prevents stale drag state (e.g. from mode switches or missed `mouseup`) from moving the view without a click.
- **Mode switch cleanup**: Drag state is cleared when changing control modes via `H` or the mode buttons, except during temporary steering-wheel steer (click-hold on wheel).
- **Free look = stationary car**: `W`, `S`, and arrow keys no longer call `advance()` in free look mode, so the panorama position stays put while the driver looks around. A/D still turns the head via keyboard.
- **UI copy/cursor**: Updated free look / steer mode hints and changed the free look cursor from `grab` to `default` to match click-drag behavior.

## Testing

- Manual: enter car mode → free look → move mouse without clicking (view should stay still) → click-drag to look around → W/S/arrows should not move panorama.
- Manual: switch to steer mode → same click-drag requirement for steering/look.
- Manual: click-hold steering wheel in free look should still enter temp steer mode.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58490f33-628a-40ca-8f18-ff7778669c39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58490f33-628a-40ca-8f18-ff7778669c39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mouse drag behavior so controls now reset more reliably when switching modes or releasing the mouse.
  * Prevented camera/panning actions from continuing when no mouse button is actually held down.
  * Refined keyboard movement handling so movement keys behave consistently across control modes, especially in free-look.

* **Style**
  * Updated on-screen control hints and cursor behavior to better match the current interaction model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->