### PR TITLE
Polish car interior: physical materials, premium dashboard geometry, live animated gauges

### DIFF
--- a/src/car/CarInterior.ts
+++ b/src/car/CarInterior.ts
@@ -11,6 +11,7 @@ import {
 import { CarInteriorBuilder } from './interior/CarInteriorBuilder';
 import { CarInteriorGauges, GaugeRig } from './interior/CarInteriorGauges';
 import { LocationPanel } from './interior/LocationPanel';
+import { CenterDisplay, DisplayPage } from './interior/CenterDisplay';
 import { PanoLocationInfo } from '../utils/panoLocation';
 import { CarInteriorAnimator } from './interior/CarInteriorAnimator';
 import { CarInteriorRenderer } from './interior/CarInteriorRenderer';
@@ -77,6 +78,10 @@ export class CarInterior {
     private locationPanel: LocationPanel | null = null;
     private lastLocationInfo: PanoLocationInfo | null = null;
     private lastCompassHeading: number = 0;
+
+    // Centre-stack infotainment display (nav / media / trip pages)
+    private centerDisplay: CenterDisplay | null = null;
+    private lastMediaInfo: { name: string; tags: string; playing: boolean } = { name: '', tags: '', playing: false };
 
     private isActive: boolean = true;
 
@@ -310,6 +315,7 @@ export class CarInterior {
         const night = this.lightingManager.getSunNightFactor();
         this.panoEnvironment.setIntensity(1 - night * 0.7);
         this.locationPanel?.setNightGlow(night);
+        this.centerDisplay?.setNightGlow(night);
     }
 
     /**
@@ -408,6 +414,18 @@ private buildInteriorFromBuilder(): void {
             this.locationPanel.setNightGlow(this.lightingManager?.getSunNightFactor() ?? 0);
         }
 
+        this.centerDisplay?.dispose();
+        this.centerDisplay = null;
+        if (this.vehicleConfig.hasDashboard && this.quality !== 'low') {
+            this.centerDisplay = new CenterDisplay(this.vehicleConfig, this.gpuProfile.name);
+            this.interiorGroup.add(this.centerDisplay.group);
+            // Re-apply live state so a vehicle swap keeps the readouts.
+            this.centerDisplay.setLocation(this.lastLocationInfo);
+            this.centerDisplay.setHeading(this.lastCompassHeading);
+            this.centerDisplay.setMedia(this.lastMediaInfo.name, this.lastMediaInfo.tags, this.lastMediaInfo.playing);
+            this.centerDisplay.setNightGlow(this.lightingManager?.getSunNightFactor() ?? 0);
+        }
+
         // On vehicle swaps the animator already exists — point it at the new
         // needles so it never animates meshes from the removed interior.
         this.animator?.setGaugeRig(this.gaugeRig);
@@ -417,12 +435,14 @@ private buildInteriorFromBuilder(): void {
     public setLocationInfo(info: PanoLocationInfo | null): void {
         this.lastLocationInfo = info;
         this.locationPanel?.setLocation(info);
+        this.centerDisplay?.setLocation(info);
     }
 
     /** Update the live compass heading on the location readout panel. */
     public setCompassHeading(heading: number): void {
         this.lastCompassHeading = heading;
         this.locationPanel?.setHeading(heading);
+        this.centerDisplay?.setHeading(heading);
     }
     public setVehicleType(vehicleType: VehicleType): void {
         if (this.vehicleType === vehicleType) return;
@@ -482,6 +502,7 @@ private buildInteriorFromBuilder(): void {
     public update(deltaTime: number): void {
 
         this.animator.update(deltaTime);
+        this.centerDisplay?.update(deltaTime);
 
     }
 
@@ -565,6 +586,7 @@ private buildInteriorFromBuilder(): void {
     public setGaugeValues(speed: number, rpm: number): void {
 
         this.animator.setGaugeValues(speed, rpm);
+        this.centerDisplay?.setTelemetry(speed, rpm);
 
     }
 
@@ -648,6 +670,26 @@ private buildInteriorFromBuilder(): void {
         );
     }
 
+    /** Update the media page with the current radio station state. */
+    public setMediaInfo(name: string, tags: string, playing: boolean): void {
+        this.lastMediaInfo = { name, tags, playing };
+        this.centerDisplay?.setMedia(name, tags, playing);
+    }
+
+    /** Test whether screen coordinates hit the centre display screen. */
+    public isCenterDisplayHit(clientX: number, clientY: number): boolean {
+        if (!this.centerDisplay) return false;
+        return this.interaction.hitTest(
+            clientX, clientY, this.canvas.getBoundingClientRect(),
+            this.camera, this.centerDisplay.screenMesh, false
+        );
+    }
+
+    /** Cycle the centre display to its next page. Returns the new page, or null. */
+    public cycleDisplayPage(): DisplayPage | null {
+        return this.centerDisplay?.cyclePage() ?? null;
+    }
+
     /**
      * Test whether the given screen coordinates intersect the steering wheel geometry.
      * Uses a cached Raycaster to avoid GC churn per click.
@@ -728,6 +770,11 @@ private buildInteriorFromBuilder(): void {
      */
     public dispose(): void {
         cancelAnimationFrame(this.animationId);
+
+        this.centerDisplay?.dispose();
+        this.centerDisplay = null;
+        this.locationPanel?.dispose();
+        this.locationPanel = null;
 
         // Stop clock update loop
         if (this.clockUpdateInterval !== undefined) {

--- a/src/car/CarInterior.ts
+++ b/src/car/CarInterior.ts
@@ -9,7 +9,7 @@ import {
   detectGPUProfile
 } from '../utils/performance';
 import { CarInteriorBuilder } from './interior/CarInteriorBuilder';
-import { CarInteriorGauges } from './interior/CarInteriorGauges';
+import { CarInteriorGauges, GaugeRig } from './interior/CarInteriorGauges';
 import { LocationPanel } from './interior/LocationPanel';
 import { PanoLocationInfo } from '../utils/panoLocation';
 import { CarInteriorAnimator } from './interior/CarInteriorAnimator';
@@ -49,6 +49,7 @@ export class CarInterior {
     private wiperRight!: THREE.Group;
     private speedometerNeedle!: THREE.Mesh;
     private tachometerNeedle!: THREE.Mesh;
+    private gaugeRig: GaugeRig | null = null;
     private headlightsLight!: THREE.SpotLight;
     private domeLightSource!: THREE.PointLight;
     private domeLightFixtureMesh!: THREE.Mesh;
@@ -249,14 +250,13 @@ export class CarInterior {
             this.steeringWheelGroup,
             this.wiperLeft,
             this.wiperRight,
-            this.speedometerNeedle,
-            this.tachometerNeedle,
             this.lodManager,
             this.rainSystem,
             this.lodUpdateFn,
             this.quality,
             this.reducedMotion
         );
+        this.animator.setGaugeRig(this.gaugeRig);
 
         this.rendererDelegate = new CarInteriorRenderer(
             this.renderer,
@@ -376,6 +376,9 @@ private buildInteriorFromBuilder(): void {
         this.domeLightFixtureMesh = buildResult.domeLightFixtureMesh;
         this.domeSwitchMesh = buildResult.domeSwitchMesh;
 
+        if (!this.vehicleConfig.hasGauges) {
+            this.gaugeRig = null;
+        }
         if (this.vehicleConfig.hasGauges) {
             const gaugeResult = CarInteriorGauges.build(
                 this.interiorGroup,
@@ -386,6 +389,7 @@ private buildInteriorFromBuilder(): void {
             );
             this.speedometerNeedle = gaugeResult.speedometerNeedle;
             this.tachometerNeedle = gaugeResult.tachometerNeedle;
+            this.gaugeRig = gaugeResult.gaugeRig;
             this.digitalClockMesh = gaugeResult.digitalClockMesh ?? null;
             this.clockCanvas = gaugeResult.clockCanvas ?? null;
             this.clockCtx = gaugeResult.clockCtx ?? null;
@@ -403,6 +407,10 @@ private buildInteriorFromBuilder(): void {
             // on vehicle swaps it re-applies the current night glow.
             this.locationPanel.setNightGlow(this.lightingManager?.getSunNightFactor() ?? 0);
         }
+
+        // On vehicle swaps the animator already exists — point it at the new
+        // needles so it never animates meshes from the removed interior.
+        this.animator?.setGaugeRig(this.gaugeRig);
     }
 
     /** Update the location readout panel with per-pano metadata. */
@@ -624,6 +632,8 @@ private buildInteriorFromBuilder(): void {
     public setInteriorLighting(headlightsOn: boolean, nightIntensity: number, domeLightOn: boolean): void {
 
         this.lightingManager.setInteriorLighting(headlightsOn, nightIntensity, domeLightOn);
+        // Gauge backlight brightens with the same night factor.
+        this.animator.setNightFactor(nightIntensity);
 
     }
 

--- a/src/car/CarInterior.ts
+++ b/src/car/CarInterior.ts
@@ -12,6 +12,8 @@ import { CarInteriorBuilder } from './interior/CarInteriorBuilder';
 import { CarInteriorGauges, GaugeRig } from './interior/CarInteriorGauges';
 import { LocationPanel } from './interior/LocationPanel';
 import { CenterDisplay, DisplayPage } from './interior/CenterDisplay';
+import { SunShafts } from './interior/SunShafts';
+import { resetGlowRegistry } from './interior/MaterialFactory';
 import { PanoLocationInfo } from '../utils/panoLocation';
 import { CarInteriorAnimator } from './interior/CarInteriorAnimator';
 import { CarInteriorRenderer } from './interior/CarInteriorRenderer';
@@ -81,6 +83,11 @@ export class CarInterior {
 
     // Centre-stack infotainment display (nav / media / trip pages)
     private centerDisplay: CenterDisplay | null = null;
+
+    // Fake volumetric light shafts through the side windows at low sun
+    private sunShafts: SunShafts | null = null;
+    private lastSunAzimuth: number = 0;
+    private lastSunAltitude: number = -1;
     private lastMediaInfo: { name: string; tags: string; playing: boolean } = { name: '', tags: '', playing: false };
 
     private isActive: boolean = true;
@@ -294,6 +301,7 @@ export class CarInterior {
             this.rearGlassMesh,
             this.sunLight
         );
+        this.lightingManager.setReducedMotion(this.reducedMotion);
     }
 
     /**
@@ -311,6 +319,8 @@ export class CarInterior {
      * @param altitude - SunCalc altitude in radians (0 = horizon)
      */
     public setSunPosition(azimuth: number, altitude: number): void {
+        this.lastSunAzimuth = azimuth;
+        this.lastSunAltitude = altitude;
         this.lightingManager.setSunState(azimuth, altitude);
         const night = this.lightingManager.getSunNightFactor();
         this.panoEnvironment.setIntensity(1 - night * 0.7);
@@ -350,6 +360,8 @@ export class CarInterior {
      */
 
 private buildInteriorFromBuilder(): void {
+        // Emissive trim/backlight materials re-register as the builders run.
+        resetGlowRegistry();
         const builder = new CarInteriorBuilder(
             this.interiorGroup,
             this.roofGroup,
@@ -412,6 +424,13 @@ private buildInteriorFromBuilder(): void {
             // lightingManager is undefined during the constructor's first build;
             // on vehicle swaps it re-applies the current night glow.
             this.locationPanel.setNightGlow(this.lightingManager?.getSunNightFactor() ?? 0);
+        }
+
+        this.sunShafts?.dispose();
+        this.sunShafts = null;
+        if (this.quality !== 'low') {
+            this.sunShafts = new SunShafts(this.reducedMotion);
+            this.interiorGroup.add(this.sunShafts.group);
         }
 
         this.centerDisplay?.dispose();
@@ -503,6 +522,17 @@ private buildInteriorFromBuilder(): void {
 
         this.animator.update(deltaTime);
         this.centerDisplay?.update(deltaTime);
+        if (this.sunShafts) {
+            // interiorGroup.rotation.y is -carHeading (set by the animator).
+            const carHeadingRad = -this.interiorGroup.rotation.y;
+            this.sunShafts.update(
+                deltaTime,
+                this.lastSunAzimuth,
+                this.lastSunAltitude,
+                carHeadingRad,
+                this.lightingManager?.getWeatherIntensity() ?? 0
+            );
+        }
 
     }
 
@@ -707,6 +737,15 @@ private buildInteriorFromBuilder(): void {
         if (this.rainSystem) this.rainSystem.setActive(active);
     }
 
+    /**
+     * 0-1 rain intensity: dims/diffuses the daylight rig, kills the sun
+     * shafts, and toggles the windshield droplet system.
+     */
+    public setWeatherIntensity(rain: number): void {
+        this.lightingManager.setWeatherIntensity(rain);
+        this.rainSystem?.setActive(rain > 0.02);
+    }
+
     /** Enable/disable post-processing (bloom + SMAA). */
 
     public setPostProcessingEnabled(enabled: boolean): void {
@@ -773,6 +812,8 @@ private buildInteriorFromBuilder(): void {
 
         this.centerDisplay?.dispose();
         this.centerDisplay = null;
+        this.sunShafts?.dispose();
+        this.sunShafts = null;
         this.locationPanel?.dispose();
         this.locationPanel = null;
 

--- a/src/car/CarInterior.ts
+++ b/src/car/CarInterior.ts
@@ -107,6 +107,7 @@ export class CarInterior {
     private glassMaterial!: THREE.MeshStandardMaterial;
     private mirrorMaterial!: THREE.MeshStandardMaterial;
     private accentMaterial!: THREE.MeshStandardMaterial;
+    private chromeMaterial!: THREE.MeshPhysicalMaterial;
 
     // Performance optimization
     private lodUpdateFn?: () => void;
@@ -224,6 +225,7 @@ export class CarInterior {
         this.glassMaterial = mats.glass;
         this.mirrorMaterial = mats.mirror;
         this.accentMaterial = mats.accent;
+        this.chromeMaterial = mats.chrome;
         const lights = buildInteriorLighting(this.scene, this.interiorGroup, this.renderer, this.vehicleConfig);
         this.hemisphereLight = lights.hemisphereLight;
         this.ambientLight = lights.ambientLight;
@@ -357,6 +359,7 @@ private buildInteriorFromBuilder(): void {
                 glass: this.glassMaterial,
                 mirror: this.mirrorMaterial,
                 accent: this.accentMaterial,
+                chrome: this.chromeMaterial,
             }
         );
 
@@ -441,6 +444,7 @@ private buildInteriorFromBuilder(): void {
         this.glassMaterial = mats.glass;
         this.mirrorMaterial = mats.mirror;
         this.accentMaterial = mats.accent;
+        this.chromeMaterial = mats.chrome;
         this.buildInteriorFromBuilder();
         
         // Update roof state based on vehicle

--- a/src/car/DashboardUI.tsx
+++ b/src/car/DashboardUI.tsx
@@ -93,6 +93,12 @@ export interface DashboardUIProps {
   stationName?: string;
   /** Comma-separated genre tags for the current station */
   stationTags?: string;
+  /** Live vehicle speed in km/h; when provided, replaces the demo simulation. */
+  speedKmh?: number;
+  /** Live engine RPM; when provided, replaces the demo simulation. */
+  rpm?: number;
+  /** Live gear indicator (P/R/N/D/1-3); when provided, replaces the demo simulation. */
+  gear?: string;
 }
 
 // ============================================================================
@@ -232,14 +238,18 @@ export const DashboardUI: React.FC<DashboardUIProps> = ({
   ambientLightColor = 'rgba(255, 255, 255, 0.0)',
   stationName = '',
   stationTags = '',
+  speedKmh,
+  rpm,
+  gear,
 }) => {
-  // Gauge simulation state
+  // Demo gauge simulation — used only when no live telemetry props arrive.
+  const hasTelemetry = speedKmh !== undefined;
   const [simulatedSpeed, setSimulatedSpeed] = useState(45);
   const [simulatedRpm, setSimulatedRpm] = useState(2500);
-  const [gear, setGear] = useState('D');
+  const [simulatedGear, setSimulatedGear] = useState('D');
 
-  // Simulate realistic gauge values
   useEffect(() => {
+    if (hasTelemetry) return;
     const interval = setInterval(() => {
       const targetSpeed = Math.floor(Math.random() * 40) + 25;
       setSimulatedSpeed((prev) => {
@@ -254,12 +264,17 @@ export const DashboardUI: React.FC<DashboardUIProps> = ({
       });
 
       if (Math.random() > 0.9) {
-        setGear((prev) => (prev === 'D' ? (Math.random() > 0.5 ? '3' : 'D') : 'D'));
+        setSimulatedGear((prev) => (prev === 'D' ? (Math.random() > 0.5 ? '3' : 'D') : 'D'));
       }
     }, 2500);
 
     return () => clearInterval(interval);
-  }, []);
+  }, [hasTelemetry]);
+
+  // SpeedGauge displays MPH; live telemetry arrives in km/h.
+  const displaySpeedMph = hasTelemetry ? speedKmh! * 0.621371 : simulatedSpeed;
+  const displayRpm = hasTelemetry ? rpm ?? 0 : simulatedRpm;
+  const displayGear = hasTelemetry ? gear ?? 'D' : simulatedGear;
 
   // Event handlers – prevent propagation to underlying canvas
   const stopProp = useCallback((e: React.SyntheticEvent) => {
@@ -305,14 +320,14 @@ export const DashboardUI: React.FC<DashboardUIProps> = ({
         <ZoneLeft>
           <div className={styles.gaugeRow}>
             <SpeedGauge
-              value={Math.round(simulatedSpeed)}
+              value={Math.round(displaySpeedMph)}
               size={120}
               unit="MPH"
               nightGlow={nightIntensity}
             />
-            <GearIndicator gear={gear} size={36} />
+            <GearIndicator gear={displayGear} size={36} />
             <RpmGauge
-              value={Math.round(simulatedRpm)}
+              value={Math.round(displayRpm)}
               size={120}
               nightGlow={nightIntensity}
             />

--- a/src/car/VehicleDynamics.ts
+++ b/src/car/VehicleDynamics.ts
@@ -1,0 +1,107 @@
+/**
+ * VehicleDynamics — lightweight speed/RPM/gear simulation for the dashboard.
+ *
+ * Street View movement is discrete (panorama hops), so real velocity has to be
+ * inferred: each hop reports its GPS distance and the model converts sustained
+ * hopping (manual driving or cruise mode) into a smooth speed that coasts back
+ * down when movement stops. RPM follows speed through a simple gearbox with
+ * shift drops and a throttle flare while accelerating.
+ */
+
+export interface VehicleTelemetry {
+    /** Vehicle speed in km/h */
+    speedKmh: number;
+    /** Engine RPM */
+    rpm: number;
+    /** Gear indicator: P, R, 1-3, D */
+    gear: string;
+    /** True while the model is actively accelerating toward a higher speed */
+    accelerating: boolean;
+}
+
+const IDLE_RPM = 850;
+const MAX_SPEED_KMH = 160;
+const ACCEL_KMH_PER_S = 22;
+const BRAKE_KMH_PER_S = 30;
+const COAST_KMH_PER_S = 9;
+/** Target speed starts bleeding off this long after the last movement input (s). */
+const COAST_DELAY_S = 2.4;
+/** Upshift speeds (km/h); the band above the last entry is top gear. */
+const SHIFT_POINTS = [0, 20, 40, 65, 95];
+
+export class VehicleDynamics {
+    private speed = 0;
+    private targetSpeed = 0;
+    private rpm = IDLE_RPM;
+    /** Simulation seconds since the last movement input. */
+    private sinceMove = Infinity;
+    private reversing = false;
+
+    /**
+     * Report a panorama hop of `distanceMeters`. Repeated hops (cruise mode,
+     * held W) sustain the target speed; a lone hop gives a short surge.
+     */
+    public notePanoHop(distanceMeters: number): void {
+        if (!(distanceMeters > 0) || distanceMeters > 300) return;
+        // A typical hop is ~10 m every ~1.5 s in cruise → reads as ~25-40 km/h.
+        const estimate = Math.min(MAX_SPEED_KMH * 0.6, 14 + distanceMeters * 2.2);
+        this.targetSpeed = Math.max(this.targetSpeed, estimate);
+        this.reversing = false;
+        this.sinceMove = 0;
+    }
+
+    /** Report a W/S thrust input. */
+    public noteThrust(direction: 'forward' | 'backward'): void {
+        if (direction === 'forward') {
+            this.targetSpeed = Math.max(this.targetSpeed, 30);
+            this.reversing = false;
+        } else {
+            this.targetSpeed = Math.max(this.targetSpeed, 12);
+            this.reversing = this.speed < 20;
+        }
+        this.sinceMove = 0;
+    }
+
+    /** Immediately kill all motion (e.g. entering free-look). */
+    public stop(): void {
+        this.targetSpeed = 0;
+        this.reversing = false;
+    }
+
+    /** Advance the simulation by dt seconds and return current telemetry. */
+    public update(dt: number): VehicleTelemetry {
+        const clamped = Math.min(Math.max(dt, 0), 0.1);
+
+        this.sinceMove += clamped;
+        if (this.sinceMove > COAST_DELAY_S) {
+            this.targetSpeed = Math.max(0, this.targetSpeed - COAST_KMH_PER_S * clamped);
+        }
+
+        const diff = this.targetSpeed - this.speed;
+        const accelerating = diff > 1.5;
+        const rate = diff > 0 ? ACCEL_KMH_PER_S : -BRAKE_KMH_PER_S;
+        if (Math.abs(diff) <= Math.abs(rate) * clamped) {
+            this.speed = this.targetSpeed;
+        } else {
+            this.speed += rate * clamped;
+        }
+
+        // Gearbox: find the band, run RPM up within it, drop on shift.
+        let gearNum = 1;
+        while (gearNum < SHIFT_POINTS.length && this.speed > SHIFT_POINTS[gearNum]) gearNum++;
+        const lo = SHIFT_POINTS[gearNum - 1];
+        const hi = gearNum < SHIFT_POINTS.length ? SHIFT_POINTS[gearNum] : MAX_SPEED_KMH;
+        const bandFrac = Math.min(1, (this.speed - lo) / (hi - lo));
+        const targetRpm = this.speed < 0.5
+            ? IDLE_RPM
+            : 1200 + bandFrac * 3200 + (accelerating ? 700 : 0);
+        this.rpm += (targetRpm - this.rpm) * Math.min(1, clamped * 4.5);
+
+        let gear: string;
+        if (this.speed < 0.5 && this.targetSpeed < 0.5) gear = 'P';
+        else if (this.reversing) gear = 'R';
+        else gear = gearNum <= 3 ? String(gearNum) : 'D';
+
+        return { speedKmh: this.speed, rpm: this.rpm, gear, accelerating };
+    }
+}

--- a/src/car/index.ts
+++ b/src/car/index.ts
@@ -395,6 +395,31 @@ export function getCarDomeLightState(): boolean {
 }
 
 /**
+ * Update the media page on the centre display (radio station name/tags/state).
+ */
+export function setCarMediaInfo(name: string, tags: string, playing: boolean): void {
+    if (!carModeState) return;
+    carModeState.interior.setMediaInfo(name, tags, playing);
+}
+
+/**
+ * Test whether screen coordinates hit the centre display screen.
+ */
+export function isCarCenterDisplayHit(clientX: number, clientY: number): boolean {
+    if (!carModeState) return false;
+    return carModeState.interior.isCenterDisplayHit(clientX, clientY);
+}
+
+/**
+ * Cycle the centre display to its next page (nav → media → trip).
+ * Returns the new page name, or null when no display exists.
+ */
+export function cycleCarDisplayPage(): string | null {
+    if (!carModeState) return null;
+    return carModeState.interior.cycleDisplayPage();
+}
+
+/**
  * Test whether screen coordinates hit the dome switch mesh.
  */
 export function isCarDomeSwitchHit(clientX: number, clientY: number): boolean {

--- a/src/car/index.ts
+++ b/src/car/index.ts
@@ -539,6 +539,15 @@ export function setCarRainActive(active: boolean): void {
 }
 
 /**
+ * Set 0-1 rain intensity: dims and diffuses the cabin daylight, suppresses
+ * the low-sun window shafts, and drives the windshield droplet system.
+ */
+export function setCarWeather(rain: number): void {
+    if (!carModeState) return;
+    carModeState.interior.setWeatherIntensity(rain);
+}
+
+/**
  * Enable/disable post-processing (bloom + SMAA).
  */
 export function setCarPostProcessingEnabled(enabled: boolean): void {

--- a/src/car/interior/CarInteriorAnimator.ts
+++ b/src/car/interior/CarInteriorAnimator.ts
@@ -1,7 +1,12 @@
 import * as THREE from 'three';
 import { LODManager } from './LODManager';
 import { RainSystem } from './RainSystem';
-import { CarInteriorGauges } from './CarInteriorGauges';
+import {
+    GaugeRig,
+    needleAngle,
+    SPEED_DIAL_MAX_KMH,
+    TACHO_DIAL_MAX_RPM,
+} from './CarInteriorGauges';
 
 export class CarInteriorAnimator {
     constructor(
@@ -11,8 +16,6 @@ export class CarInteriorAnimator {
         private steeringWheelGroup: THREE.Group | null,
         private wiperLeft: THREE.Group | null,
         private wiperRight: THREE.Group | null,
-        private speedometerNeedle: THREE.Mesh | null | undefined,
-        private tachometerNeedle: THREE.Mesh | null | undefined,
         private lodManager: LODManager,
         private rainSystem: RainSystem | undefined,
         private lodUpdateFn: (() => void) | undefined,
@@ -23,10 +26,22 @@ export class CarInteriorAnimator {
     private steeringAngle: number = 0;
     private isWiperActive: boolean = false;
     private wiperAnimationTime: number = 0;
-    private speedometer: number = 0;
-    private tachometer: number = 0;
     private isActive: boolean = true;
     private roofTargetY: number = 0;
+
+    // Gauge state — needles run on a spring toward the target values so
+    // they overshoot slightly on hard acceleration (needle bounce).
+    private gaugeRig: GaugeRig | null = null;
+    private targetSpeed: number = 0;
+    private targetRpm: number = 0;
+    private speedFrac: number = 0;
+    private speedVel: number = 0;
+    private rpmFrac: number = 0;
+    private rpmVel: number = 0;
+    private fuelLevel: number = 0.85;
+    private tempFrac: number = 0.05;
+    private gaugeClock: number = 0;
+    private nightFactor: number = 0;
 
     public update(deltaTime: number): void {
         if (this.reducedMotion) {
@@ -38,7 +53,7 @@ export class CarInteriorAnimator {
                 this.wiperLeft && (this.wiperLeft.rotation.z = -Math.PI / 6);
                 this.wiperRight && (this.wiperRight.rotation.z = Math.PI / 6);
             }
-            if (this.quality !== 'low') this.updateGaugles();
+            if (this.quality !== 'low') this.updateGauges(Math.min(deltaTime, 0.1));
             if (this.lodUpdateFn) this.lodUpdateFn();
             this.lodManager.updateLOD(this.camera);
             return;
@@ -68,19 +83,65 @@ export class CarInteriorAnimator {
             if (this.wiperRight) this.wiperRight.rotation.z = wiperAngle + Math.PI / 6;
         }
 
-        if (this.quality !== 'low') this.updateGaugles();
+        if (this.quality !== 'low') this.updateGauges(clampedDelta);
         if (this.lodUpdateFn) this.lodUpdateFn();
         this.lodManager.updateLOD(this.camera);
         if (this.rainSystem) this.rainSystem.update(deltaTime);
     }
 
-    private updateGaugles(): void {
-        CarInteriorGauges.updateGaugeNeedles(
-            this.speedometerNeedle,
-            this.tachometerNeedle,
-            this.speedometer,
-            this.tachometer
-        );
+    private updateGauges(dt: number): void {
+        const rig = this.gaugeRig;
+        if (!rig) return;
+
+        this.gaugeClock += dt;
+        const t = this.gaugeClock;
+        const speedTargetFrac = this.targetSpeed / SPEED_DIAL_MAX_KMH;
+        const rpmTargetFrac = this.targetRpm / TACHO_DIAL_MAX_RPM;
+
+        if (this.reducedMotion) {
+            // Direct, wobble-free tracking under prefers-reduced-motion.
+            this.speedFrac = speedTargetFrac;
+            this.rpmFrac = rpmTargetFrac;
+            this.speedVel = this.rpmVel = 0;
+            rig.speedNeedle.rotation.z = needleAngle(this.speedFrac);
+            rig.tachoNeedle.rotation.z = needleAngle(this.rpmFrac);
+        } else {
+            // Underdamped springs: the speedo is heavy and slow, the tacho
+            // snappy — both overshoot a touch on hard changes.
+            this.speedVel += (-32 * (this.speedFrac - speedTargetFrac) - 7.0 * this.speedVel) * dt;
+            this.speedFrac += this.speedVel * dt;
+            this.rpmVel += (-90 * (this.rpmFrac - rpmTargetFrac) - 10.5 * this.rpmVel) * dt;
+            this.rpmFrac += this.rpmVel * dt;
+
+            // Road vibration grows with speed; engine buzz grows with RPM.
+            const roadWobble =
+                (Math.sin(t * 29.7) + Math.sin(t * 17.3) * 0.6) *
+                0.0035 * Math.min(1, this.speedFrac * 2.5);
+            const engineWobble = Math.sin(t * 47.1) * 0.004 * (0.2 + this.rpmFrac);
+            rig.speedNeedle.rotation.z = needleAngle(this.speedFrac + roadWobble);
+            rig.tachoNeedle.rotation.z = needleAngle(this.rpmFrac + engineWobble);
+        }
+
+        // Fuel burns with distance; coolant warms toward an operating point
+        // set by load and slowly cools back down.
+        const speedKmh = this.speedFrac * SPEED_DIAL_MAX_KMH;
+        this.fuelLevel = Math.max(0.06, this.fuelLevel - speedKmh * dt * 1.4e-5);
+        const tempTarget = speedKmh > 1 || this.rpmFrac > 0.15
+            ? Math.min(0.8, 0.5 + this.rpmFrac * 0.35)
+            : 0.05;
+        const tempRate = tempTarget > this.tempFrac ? 0.05 : 0.015;
+        this.tempFrac += (tempTarget - this.tempFrac) * Math.min(1, dt * tempRate * 10);
+
+        if (rig.fuelNeedle) rig.fuelNeedle.rotation.z = needleAngle(this.fuelLevel);
+        if (rig.tempNeedle) rig.tempNeedle.rotation.z = needleAngle(this.tempFrac);
+
+        // Backlight: brighter at night, flares with revs, and breathes
+        // gently like real cluster illumination.
+        const breathe = this.reducedMotion ? 0.5 : 0.5 + 0.5 * Math.sin(t * 1.6);
+        const dialGlow = 0.22 + this.nightFactor * 0.55 + breathe * 0.05 + this.rpmFrac * 0.1;
+        for (const mat of rig.dialMaterials) mat.emissiveIntensity = dialGlow;
+        const needleGlow = 0.85 + this.nightFactor * 0.9 + breathe * 0.12 + this.rpmFrac * 0.4;
+        for (const mat of rig.needleMaterials) mat.emissiveIntensity = needleGlow;
     }
 
     public setActive(active: boolean): void {
@@ -117,8 +178,18 @@ export class CarInteriorAnimator {
         }
     }
 
+    /** Swap in the live gauge handles (called after every interior build). */
+    public setGaugeRig(rig: GaugeRig | null): void {
+        this.gaugeRig = rig;
+    }
+
+    /** 0-1 night intensity; drives gauge backlight brightness. */
+    public setNightFactor(night: number): void {
+        this.nightFactor = Math.max(0, Math.min(1, night));
+    }
+
     public setGaugeValues(speed: number, rpm: number): void {
-        this.speedometer = Math.max(0, Math.min(100, speed));
-        this.tachometer = Math.max(0, Math.min(8000, rpm));
+        this.targetSpeed = Math.max(0, Math.min(SPEED_DIAL_MAX_KMH, speed));
+        this.targetRpm = Math.max(0, Math.min(TACHO_DIAL_MAX_RPM, rpm));
     }
 }

--- a/src/car/interior/CarInteriorBuilder.ts
+++ b/src/car/interior/CarInteriorBuilder.ts
@@ -14,6 +14,7 @@ export interface CarInteriorMaterials {
     glass: THREE.MeshStandardMaterial;
     mirror: THREE.MeshStandardMaterial;
     accent: THREE.MeshStandardMaterial;
+    chrome: THREE.MeshPhysicalMaterial;
 }
 
 export interface CarInteriorBuildResult {
@@ -153,12 +154,7 @@ export class CarInteriorBuilder {
 
     private buildDoorPanelDetails(): void {
         const gf = this.geometryFactory;
-
-        const chromeMaterial = new THREE.MeshStandardMaterial({
-            color: 0xdddddd,
-            roughness: 0.15,
-            metalness: 0.9,
-        });
+        const chromeMaterial = this.materials.chrome;
 
         const softTouchMat = new THREE.MeshStandardMaterial({
             color: 0x2a2a2a,

--- a/src/car/interior/CarInteriorDashboardBuilder.ts
+++ b/src/car/interior/CarInteriorDashboardBuilder.ts
@@ -2,9 +2,13 @@ import * as THREE from 'three';
 import { VehicleConfig } from '../VehicleManager';
 import { GeometryFactory } from './GeometryFactory';
 import { LODManager } from './LODManager';
+import { createAccentMaterial } from './MaterialFactory';
 import type { CarInteriorMaterials } from './CarInteriorBuilder';
 
 export class CarInteriorDashboardBuilder {
+    /** Radial/tubular segment counts scale with quality tier. */
+    private readonly segments: number;
+
     constructor(
         private interiorGroup: THREE.Group,
         private materials: CarInteriorMaterials,
@@ -12,7 +16,9 @@ export class CarInteriorDashboardBuilder {
         private quality: 'high' | 'medium' | 'low',
         private geometryFactory: GeometryFactory,
         private lodManager: LODManager
-    ) {}
+    ) {
+        this.segments = quality === 'high' ? 48 : quality === 'medium' ? 24 : 12;
+    }
 
     public build(): { instrumentClusterMat: THREE.MeshStandardMaterial; centerDisplayMat: THREE.MeshStandardMaterial } {
         const dashGeo = new THREE.BoxGeometry(2.0, 0.4, 0.5);
@@ -20,105 +26,158 @@ export class CarInteriorDashboardBuilder {
         dash.position.set(0, 0.8, -1.0);
         this.interiorGroup.add(dash);
 
-        const dashTopGeo = new THREE.CylinderGeometry(0.15, 0.15, 2.0, 8, 1, false, 0, Math.PI);
+        const dashTopGeo = new THREE.CylinderGeometry(0.15, 0.15, 2.0, this.segments, 1, false, 0, Math.PI);
         const dashTop = new THREE.Mesh(dashTopGeo, this.materials.dashboard);
         dashTop.rotation.set(0, 0, Math.PI / 2);
         dashTop.position.set(0, 1.0, -0.85);
         this.interiorGroup.add(dashTop);
 
-        const clusterGeo = new THREE.BoxGeometry(0.6, 0.25, 0.05);
+        // Instrument cluster: emissive panel recessed into a chamfered bezel hood.
         const clusterMat = new THREE.MeshStandardMaterial({ color: 0x000000, emissive: 0x001100, emissiveIntensity: 0.5 });
-        const cluster = new THREE.Mesh(clusterGeo, clusterMat);
+        const cluster = new THREE.Mesh(new THREE.BoxGeometry(0.6, 0.25, 0.05), clusterMat);
         cluster.position.set(-0.3, 0.95, -0.74);
         this.interiorGroup.add(cluster);
 
-        const displayGeo = new THREE.BoxGeometry(0.3, 0.2, 0.02);
         const displayMat = new THREE.MeshStandardMaterial({ color: 0x000000, emissive: 0x002200, emissiveIntensity: 0.3 });
-        const display = new THREE.Mesh(displayGeo, displayMat);
+        const display = new THREE.Mesh(new THREE.BoxGeometry(0.3, 0.2, 0.02), displayMat);
         display.position.set(0.15, 0.95, -0.74);
         this.interiorGroup.add(display);
 
         if (this.quality !== 'low') {
-            const accentHex = parseInt(this.vehicleConfig.accentColor.replace('#', '0x'));
-            const trimGeo = new THREE.BoxGeometry(1.96, 0.008, 0.012);
-            const trimMat = new THREE.MeshStandardMaterial({
-                color: accentHex,
-                roughness: 0.3,
-                metalness: 0.7,
-                emissive: new THREE.Color(accentHex),
-                emissiveIntensity: 0.15,
-            });
-            const trim = new THREE.Mesh(trimGeo, trimMat);
+            // Bezels sit just proud of each panel face (cluster face z=-0.715,
+            // display face z=-0.73) so the chamfered lip catches light.
+            const clusterBezel = new THREE.Mesh(this.makeBezelFrameGeometry(0.64, 0.29, 0.03), this.materials.dashboard);
+            clusterBezel.position.set(-0.3, 0.95, -0.728);
+            this.interiorGroup.add(clusterBezel);
+
+            const displayBezel = new THREE.Mesh(this.makeBezelFrameGeometry(0.34, 0.24, 0.025), this.materials.dashboard);
+            displayBezel.position.set(0.15, 0.95, -0.741);
+            this.interiorGroup.add(displayBezel);
+
+            // Accent trim: emissive intensity varies per piece so the long
+            // strips read as soft ambient light while rings pop as highlights.
+            const stripMat = createAccentMaterial(this.vehicleConfig, 0.25);
+            const trim = new THREE.Mesh(new THREE.BoxGeometry(1.96, 0.008, 0.012), stripMat);
             trim.position.set(0, 1.005, -0.86);
             this.interiorGroup.add(trim);
 
-            const lowerTrimGeo = new THREE.BoxGeometry(1.96, 0.006, 0.01);
-            const lowerTrim = new THREE.Mesh(lowerTrimGeo, trimMat);
+            const lowerStripMat = createAccentMaterial(this.vehicleConfig, 0.12);
+            const lowerTrim = new THREE.Mesh(new THREE.BoxGeometry(1.96, 0.006, 0.01), lowerStripMat);
             lowerTrim.position.set(0, 0.625, -0.99);
             this.interiorGroup.add(lowerTrim);
 
-            const bezelRingGeo = new THREE.TorusGeometry(0.155, 0.008, 8, 32);
-            const bezelRingMat = new THREE.MeshStandardMaterial({
-                color: accentHex,
-                roughness: 0.2,
-                metalness: 0.8,
-                emissive: new THREE.Color(accentHex),
-                emissiveIntensity: 0.4,
-            });
-            const bezelRing = new THREE.Mesh(bezelRingGeo, bezelRingMat);
-            bezelRing.position.set(-0.3, 0.95, -0.73);
+            const ringMat = createAccentMaterial(this.vehicleConfig, 0.45);
+            const bezelRing = new THREE.Mesh(
+                new THREE.TorusGeometry(0.155, 0.008, 12, this.segments),
+                ringMat
+            );
+            bezelRing.position.set(-0.3, 0.95, -0.708);
             this.interiorGroup.add(bezelRing);
-        }
 
-        if (this.quality !== 'low') {
+            const displayRing = new THREE.Mesh(
+                new THREE.TorusGeometry(0.11, 0.005, 12, this.segments),
+                createAccentMaterial(this.vehicleConfig, 0.3)
+            );
+            displayRing.scale.set(1.4, 1, 1);
+            displayRing.position.set(0.15, 0.95, -0.722);
+            this.interiorGroup.add(displayRing);
+
             this.buildDetails();
         }
 
         return { instrumentClusterMat: clusterMat, centerDisplayMat: displayMat };
     }
 
+    /** Flat frame with rounded corners and a chamfered edge, opening in the middle. */
+    private makeBezelFrameGeometry(w: number, h: number, border: number): THREE.ExtrudeGeometry {
+        const outer = this.geometryFactory.getRoundedRectShape(w, h, border);
+        const inner = this.geometryFactory.getRoundedRectShape(w - border * 2, h - border * 2, border * 0.5);
+        outer.holes.push(new THREE.Path(inner.getPoints(12)));
+        return new THREE.ExtrudeGeometry(outer, {
+            depth: 0.012,
+            bevelEnabled: true,
+            bevelThickness: 0.004,
+            bevelSize: 0.004,
+            bevelSegments: 2,
+        });
+    }
+
+    /** Push-button cap with rounded corners and a chamfered face. */
+    private makeButtonGeometry(w: number, h: number): THREE.ExtrudeGeometry {
+        const shape = this.geometryFactory.getRoundedRectShape(w, h, Math.min(w, h) * 0.25);
+        return new THREE.ExtrudeGeometry(shape, {
+            depth: 0.004,
+            bevelEnabled: true,
+            bevelThickness: 0.0015,
+            bevelSize: 0.0015,
+            bevelSegments: 2,
+        });
+    }
+
     private buildDetails(): void {
         const gf = this.geometryFactory;
+        const chrome = this.materials.chrome;
 
-        const chromeMaterial = new THREE.MeshStandardMaterial({
-            color: 0xdddddd,
-            roughness: 0.15,
-            metalness: 0.9,
+        // Air vents: dark recessed housing, chrome surround, horizontal slats.
+        const ventHousingMat = new THREE.MeshPhysicalMaterial({ color: 0x0c0c0c, roughness: 0.85, metalness: 0.05 });
+        const ventPositions: Array<{ x: number; w: number; h: number }> = [
+            { x: -0.7, w: 0.12, h: 0.08 },
+            { x: 0.7, w: 0.12, h: 0.08 },
+            { x: 0.55, w: 0.15, h: 0.06 },
+        ];
+
+        const slatGeo = gf.getBox(0.11, 0.006, 0.006);
+        const slatMat = new THREE.MeshPhysicalMaterial({
+            color: 0x1a1a1a,
+            roughness: 0.5,
+            metalness: 0.2,
+            clearcoat: 0.4,
+            clearcoatRoughness: 0.3,
         });
+        this.lodManager.registerBatch('ventSlats', slatGeo, slatMat, 12);
+        const slatBatch = this.lodManager.getBatch('ventSlats')!;
+        this.interiorGroup.add(slatBatch);
 
-        const ventGeo = gf.getBox(0.12, 0.08, 0.03);
-        const ventMat = new THREE.MeshStandardMaterial({ color: 0x111111, roughness: 0.8 });
+        const dummy = new THREE.Object3D();
+        for (const vent of ventPositions) {
+            const housing = new THREE.Mesh(gf.getBox(vent.w, vent.h, 0.03), ventHousingMat);
+            housing.position.set(vent.x, 0.95, -0.75);
+            this.interiorGroup.add(housing);
 
-        const leftVent = new THREE.Mesh(ventGeo, ventMat);
-        leftVent.position.set(-0.7, 0.95, -0.74);
-        this.interiorGroup.add(leftVent);
+            const surround = new THREE.Mesh(this.makeBezelFrameGeometry(vent.w + 0.02, vent.h + 0.02, 0.008), chrome);
+            surround.position.set(vent.x, 0.95, -0.745);
+            this.interiorGroup.add(surround);
 
-        const ventSurroundGeo = gf.getBox(0.14, 0.1, 0.02);
-        const leftVentSurround = new THREE.Mesh(ventSurroundGeo, chromeMaterial);
-        leftVentSurround.position.set(-0.7, 0.95, -0.735);
-        this.interiorGroup.add(leftVentSurround);
+            const slatCount = 4;
+            for (let i = 0; i < slatCount; i++) {
+                const y = 0.95 - vent.h / 2 + (vent.h / (slatCount + 1)) * (i + 1);
+                dummy.position.set(vent.x, y, -0.735);
+                dummy.rotation.set(-0.25, 0, 0);
+                dummy.scale.set(vent.w / 0.12, 1, 1);
+                dummy.updateMatrix();
+                this.lodManager.addInstance('ventSlats', dummy.matrix);
+            }
+        }
+        dummy.rotation.set(0, 0, 0);
+        dummy.scale.set(1, 1, 1);
 
-        const rightVent = new THREE.Mesh(ventGeo, ventMat);
-        rightVent.position.set(0.7, 0.95, -0.74);
-        this.interiorGroup.add(rightVent);
-
-        const rightVentSurround = new THREE.Mesh(ventSurroundGeo, chromeMaterial);
-        rightVentSurround.position.set(0.7, 0.95, -0.735);
-        this.interiorGroup.add(rightVentSurround);
-
-        const centerVent = new THREE.Mesh(gf.getBox(0.15, 0.06, 0.03), ventMat);
-        centerVent.position.set(0.55, 0.95, -0.74);
-        this.interiorGroup.add(centerVent);
-
-        const knobGeo = gf.getCylinder(0.025, 0.025, 0.015, 16);
-        const knobMat = new THREE.MeshStandardMaterial({
-            color: 0x333333,
-            roughness: 0.4,
+        // Climate knobs: knurled cylinders with chrome collars and position indicators.
+        const knobGeo = gf.getCylinder(0.025, 0.025, 0.015, this.segments);
+        const knobMat = new THREE.MeshPhysicalMaterial({
+            color: 0x2e2e2e,
+            roughness: 0.45,
             metalness: 0.3,
+            clearcoat: 0.5,
+            clearcoatRoughness: 0.2,
         });
         this.lodManager.registerBatch('knobs', knobGeo, knobMat, 3);
         const knobBatch = this.lodManager.getBatch('knobs')!;
         this.interiorGroup.add(knobBatch);
+
+        const collarGeo = new THREE.TorusGeometry(0.026, 0.003, 8, this.segments);
+        this.lodManager.registerBatch('knobCollars', collarGeo, chrome, 3);
+        const collarBatch = this.lodManager.getBatch('knobCollars')!;
+        this.interiorGroup.add(collarBatch);
 
         const indicatorGeo = gf.getBox(0.015, 0.002, 0.008);
         const indicatorMat = new THREE.MeshBasicMaterial({ color: 0xffffff });
@@ -126,11 +185,11 @@ export class CarInteriorDashboardBuilder {
         const indicatorBatch = this.lodManager.getBatch('indicators')!;
         this.interiorGroup.add(indicatorBatch);
 
-        const dummy = new THREE.Object3D();
         for (let i = 0; i < 3; i++) {
             dummy.position.set(0.45 + i * 0.06, 0.85, -0.72);
             dummy.updateMatrix();
             this.lodManager.addInstance('knobs', dummy.matrix);
+            this.lodManager.addInstance('knobCollars', dummy.matrix);
 
             dummy.position.set(0.45 + i * 0.06, 0.85, -0.715);
             dummy.updateMatrix();
@@ -138,12 +197,14 @@ export class CarInteriorDashboardBuilder {
         }
         this.lodManager.finalize();
 
-        const hazardGeo = new THREE.CylinderGeometry(0.02, 0.02, 0.008, 16);
-        const hazardMat = new THREE.MeshStandardMaterial({
+        const hazardGeo = new THREE.CylinderGeometry(0.02, 0.02, 0.008, this.segments);
+        const hazardMat = new THREE.MeshPhysicalMaterial({
             color: 0xff0000,
             emissive: 0x330000,
             emissiveIntensity: 0.3,
             roughness: 0.3,
+            clearcoat: 0.6,
+            clearcoatRoughness: 0.15,
         });
         const hazardBtn = new THREE.Mesh(hazardGeo, hazardMat);
         hazardBtn.position.set(0.35, 0.85, -0.72);
@@ -156,31 +217,41 @@ export class CarInteriorDashboardBuilder {
         hazardSymbol.position.set(0.35, 0.85, -0.715);
         this.interiorGroup.add(hazardSymbol);
 
-        const btnGeo = new THREE.BoxGeometry(0.03, 0.015, 0.005);
-        const btnMat = new THREE.MeshStandardMaterial({ color: 0x444444, roughness: 0.6 });
+        // Center-stack button bank: extruded caps with depth and chamfers.
+        const btnGeo = this.makeButtonGeometry(0.03, 0.015);
+        const btnMat = new THREE.MeshPhysicalMaterial({
+            color: 0x3a3a3a,
+            roughness: 0.55,
+            metalness: 0.1,
+            clearcoat: 0.35,
+            clearcoatRoughness: 0.4,
+        });
 
         for (let row = 0; row < 2; row++) {
             for (let col = 0; col < 4; col++) {
                 const btn = new THREE.Mesh(btnGeo, btnMat);
-                btn.position.set(0.05 + col * 0.035, 0.82 - row * 0.02, -0.72);
+                btn.position.set(0.05 + col * 0.035, 0.82 - row * 0.02, -0.722);
                 this.interiorGroup.add(btn);
+                this.lodManager.registerDetail(btn);
             }
         }
 
-        const startBtnGeo = new THREE.CylinderGeometry(0.018, 0.018, 0.01, 16);
-        const startBtnMat = new THREE.MeshStandardMaterial({
+        const startBtnGeo = new THREE.CylinderGeometry(0.018, 0.018, 0.01, this.segments);
+        const startBtnMat = new THREE.MeshPhysicalMaterial({
             color: 0xcc0000,
             emissive: 0x220000,
             emissiveIntensity: 0.2,
             roughness: 0.3,
             metalness: 0.4,
+            clearcoat: 0.8,
+            clearcoatRoughness: 0.1,
         });
         const startBtn = new THREE.Mesh(startBtnGeo, startBtnMat);
         startBtn.position.set(-0.15, 0.88, -0.72);
         this.interiorGroup.add(startBtn);
 
-        const startRingGeo = new THREE.TorusGeometry(0.02, 0.003, 8, 24);
-        const startRing = new THREE.Mesh(startRingGeo, chromeMaterial);
+        const startRingGeo = new THREE.TorusGeometry(0.02, 0.003, 12, this.segments);
+        const startRing = new THREE.Mesh(startRingGeo, chrome);
         startRing.position.set(-0.15, 0.88, -0.715);
         this.interiorGroup.add(startRing);
     }

--- a/src/car/interior/CarInteriorDashboardBuilder.ts
+++ b/src/car/interior/CarInteriorDashboardBuilder.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { VehicleConfig } from '../VehicleManager';
 import { GeometryFactory } from './GeometryFactory';
 import { LODManager } from './LODManager';
-import { createAccentMaterial } from './MaterialFactory';
+import { createAccentMaterial, registerGlowMaterial } from './MaterialFactory';
 import type { CarInteriorMaterials } from './CarInteriorBuilder';
 
 export class CarInteriorDashboardBuilder {
@@ -201,6 +201,7 @@ export class CarInteriorDashboardBuilder {
             clearcoat: 0.6,
             clearcoatRoughness: 0.15,
         });
+        registerGlowMaterial(hazardMat, 0.3);
         const hazardBtn = new THREE.Mesh(hazardGeo, hazardMat);
         hazardBtn.position.set(0.35, 0.85, -0.72);
         this.interiorGroup.add(hazardBtn);
@@ -220,7 +221,10 @@ export class CarInteriorDashboardBuilder {
             metalness: 0.1,
             clearcoat: 0.35,
             clearcoatRoughness: 0.4,
+            emissive: 0xffb060,
+            emissiveIntensity: 0.12,
         });
+        registerGlowMaterial(btnMat, 0.12);
 
         for (let row = 0; row < 2; row++) {
             for (let col = 0; col < 4; col++) {
@@ -241,6 +245,7 @@ export class CarInteriorDashboardBuilder {
             clearcoat: 0.8,
             clearcoatRoughness: 0.1,
         });
+        registerGlowMaterial(startBtnMat, 0.2);
         const startBtn = new THREE.Mesh(startBtnGeo, startBtnMat);
         startBtn.position.set(0.0, 0.82, -0.72);
         this.interiorGroup.add(startBtn);

--- a/src/car/interior/CarInteriorDashboardBuilder.ts
+++ b/src/car/interior/CarInteriorDashboardBuilder.ts
@@ -38,9 +38,12 @@ export class CarInteriorDashboardBuilder {
         cluster.position.set(-0.3, 0.95, -0.74);
         this.interiorGroup.add(cluster);
 
+        // Recessed housing behind the centre display. At medium/high quality
+        // the live CenterDisplay screen sits in front of it; at low quality
+        // this emissive panel IS the display.
         const displayMat = new THREE.MeshStandardMaterial({ color: 0x000000, emissive: 0x002200, emissiveIntensity: 0.3 });
         const display = new THREE.Mesh(new THREE.BoxGeometry(0.3, 0.2, 0.02), displayMat);
-        display.position.set(0.15, 0.95, -0.74);
+        display.position.set(0.15, 0.925, -0.74);
         this.interiorGroup.add(display);
 
         if (this.quality !== 'low') {
@@ -51,7 +54,7 @@ export class CarInteriorDashboardBuilder {
             this.interiorGroup.add(clusterBezel);
 
             const displayBezel = new THREE.Mesh(this.makeBezelFrameGeometry(0.34, 0.24, 0.025), this.materials.dashboard);
-            displayBezel.position.set(0.15, 0.95, -0.741);
+            displayBezel.position.set(0.15, 0.925, -0.741);
             this.interiorGroup.add(displayBezel);
 
             // Accent trim: emissive intensity varies per piece so the long
@@ -73,14 +76,6 @@ export class CarInteriorDashboardBuilder {
                 bezelRing.position.set(x, 0.95, -0.708);
                 this.interiorGroup.add(bezelRing);
             }
-
-            const displayRing = new THREE.Mesh(
-                new THREE.TorusGeometry(0.11, 0.005, 12, this.segments),
-                createAccentMaterial(this.vehicleConfig, 0.3)
-            );
-            displayRing.scale.set(1.4, 1, 1);
-            displayRing.position.set(0.15, 0.95, -0.722);
-            this.interiorGroup.add(displayRing);
 
             this.buildDetails();
         }

--- a/src/car/interior/CarInteriorDashboardBuilder.ts
+++ b/src/car/interior/CarInteriorDashboardBuilder.ts
@@ -67,12 +67,12 @@ export class CarInteriorDashboardBuilder {
             this.interiorGroup.add(lowerTrim);
 
             const ringMat = createAccentMaterial(this.vehicleConfig, 0.45);
-            const bezelRing = new THREE.Mesh(
-                new THREE.TorusGeometry(0.155, 0.008, 12, this.segments),
-                ringMat
-            );
-            bezelRing.position.set(-0.3, 0.95, -0.708);
-            this.interiorGroup.add(bezelRing);
+            const ringGeo = new THREE.TorusGeometry(0.162, 0.008, 12, this.segments);
+            for (const x of [-0.5, -0.15]) {
+                const bezelRing = new THREE.Mesh(ringGeo, ringMat);
+                bezelRing.position.set(x, 0.95, -0.708);
+                this.interiorGroup.add(bezelRing);
+            }
 
             const displayRing = new THREE.Mesh(
                 new THREE.TorusGeometry(0.11, 0.005, 12, this.segments),
@@ -247,12 +247,12 @@ export class CarInteriorDashboardBuilder {
             clearcoatRoughness: 0.1,
         });
         const startBtn = new THREE.Mesh(startBtnGeo, startBtnMat);
-        startBtn.position.set(-0.15, 0.88, -0.72);
+        startBtn.position.set(0.0, 0.82, -0.72);
         this.interiorGroup.add(startBtn);
 
         const startRingGeo = new THREE.TorusGeometry(0.02, 0.003, 12, this.segments);
         const startRing = new THREE.Mesh(startRingGeo, chrome);
-        startRing.position.set(-0.15, 0.88, -0.715);
+        startRing.position.set(0.0, 0.82, -0.715);
         this.interiorGroup.add(startRing);
     }
 }

--- a/src/car/interior/CarInteriorGauges.ts
+++ b/src/car/interior/CarInteriorGauges.ts
@@ -1,13 +1,54 @@
 import * as THREE from 'three';
 
+export const SPEED_DIAL_MAX_KMH = 180;
+export const TACHO_DIAL_MAX_RPM = 8000;
+export const TACHO_REDLINE_RPM = 6500;
+
+/**
+ * Map a 0..1 dial fraction to needle rotation.z.
+ * Dials sweep 270° clockwise from lower-left (7:30) to lower-right (4:30);
+ * a needle mesh pointing +Y at rotation 0 therefore starts at +135°.
+ */
+export function needleAngle(frac: number): number {
+    const clamped = Math.max(0, Math.min(1, frac));
+    return THREE.MathUtils.degToRad(135 - clamped * 270);
+}
+
+/** Live handles the animator uses to drive needles and backlighting. */
+export interface GaugeRig {
+    speedNeedle: THREE.Mesh;
+    tachoNeedle: THREE.Mesh;
+    fuelNeedle: THREE.Mesh | null;
+    tempNeedle: THREE.Mesh | null;
+    /** Dial-face materials whose emissiveIntensity is pulsed for backlight. */
+    dialMaterials: THREE.MeshStandardMaterial[];
+    /** Needle materials whose emissive glow tracks night/engine state. */
+    needleMaterials: THREE.MeshStandardMaterial[];
+}
+
 export interface CarInteriorGaugeResult {
     speedometerNeedle: THREE.Mesh;
     tachometerNeedle: THREE.Mesh;
+    gaugeRig: GaugeRig;
     digitalClockMesh?: THREE.Mesh;
     clockCanvas?: HTMLCanvasElement;
     clockCtx?: CanvasRenderingContext2D;
     clockUpdateInterval?: number;
 }
+
+interface DialSpec {
+    emissiveColor: string;
+    /** Labels placed at major ticks, evenly across the sweep. */
+    majorLabels: string[];
+    minorTicksPerMajor: number;
+    unit: string;
+    /** Fraction of the sweep where the red zone begins. */
+    redlineFrac?: number;
+}
+
+/** Dial sweep in canvas coordinates: 270° clockwise starting at lower-left. */
+const DIAL_START = Math.PI * 0.75;
+const DIAL_SWEEP = Math.PI * 1.5;
 
 export class CarInteriorGauges {
     static build(
@@ -17,7 +58,7 @@ export class CarInteriorGauges {
         gpuProfile: { name: string },
         quality: 'high' | 'medium' | 'low'
     ): CarInteriorGaugeResult {
-        const result = CarInteriorGauges.buildGauges(interiorGroup, metalMaterial);
+        const result = CarInteriorGauges.buildGauges(interiorGroup, vehicleConfig, gpuProfile, quality);
         if (quality !== 'low') {
             const clock = CarInteriorGauges.buildDigitalClock(interiorGroup, vehicleConfig, gpuProfile);
             return {
@@ -28,116 +69,262 @@ export class CarInteriorGauges {
         return result;
     }
 
+    /**
+     * Paint a dial face. Rendered at 2× the display request and left to
+     * mipmapping + anisotropy so ticks and numerals stay crisp at an angle.
+     */
+    private static buildDialCanvas(size: number, spec: DialSpec): HTMLCanvasElement {
+        const c = document.createElement('canvas');
+        c.width = size; c.height = size;
+        const ctx = c.getContext('2d')!;
+        const cx = size / 2;
+        const r = size / 2;
+
+        const bg = ctx.createRadialGradient(cx, cx, 0, cx, cx, r);
+        bg.addColorStop(0, '#242428');
+        bg.addColorStop(0.75, '#141416');
+        bg.addColorStop(1, '#08080a');
+        ctx.fillStyle = bg;
+        ctx.beginPath();
+        ctx.arc(cx, cx, r, 0, Math.PI * 2);
+        ctx.fill();
+
+        // Glancing sheen from upper-left, like light on a recessed dial.
+        const sheen = ctx.createLinearGradient(0, 0, size, size);
+        sheen.addColorStop(0, 'rgba(255,255,255,0.10)');
+        sheen.addColorStop(0.35, 'rgba(255,255,255,0.0)');
+        ctx.fillStyle = sheen;
+        ctx.beginPath();
+        ctx.arc(cx, cx, r - 2, 0, Math.PI * 2);
+        ctx.fill();
+
+        // Accent rim ring
+        ctx.strokeStyle = spec.emissiveColor;
+        ctx.lineWidth = Math.max(2, size * 0.012);
+        ctx.globalAlpha = 0.5;
+        ctx.beginPath();
+        ctx.arc(cx, cx, r - size * 0.02, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.globalAlpha = 1.0;
+
+        // Red zone arc
+        if (spec.redlineFrac !== undefined) {
+            ctx.strokeStyle = '#e01818';
+            ctx.lineWidth = size * 0.028;
+            ctx.beginPath();
+            ctx.arc(cx, cx, r - size * 0.055, DIAL_START + spec.redlineFrac * DIAL_SWEEP, DIAL_START + DIAL_SWEEP);
+            ctx.stroke();
+        }
+
+        const majorCount = spec.majorLabels.length - 1;
+        const minorTicks = majorCount * spec.minorTicksPerMajor;
+        for (let i = 0; i <= minorTicks; i++) {
+            const frac = i / minorTicks;
+            const a = DIAL_START + frac * DIAL_SWEEP;
+            const isMajor = i % spec.minorTicksPerMajor === 0;
+            const inRedline = spec.redlineFrac !== undefined && frac >= spec.redlineFrac;
+            const inner = isMajor ? r - size * 0.085 : r - size * 0.058;
+            const outer = r - size * 0.03;
+            ctx.strokeStyle = inRedline ? '#ff4040' : isMajor ? spec.emissiveColor : 'rgba(255,255,255,0.4)';
+            ctx.lineWidth = isMajor ? Math.max(2, size * 0.012) : Math.max(1, size * 0.005);
+            ctx.lineCap = 'round';
+            ctx.beginPath();
+            ctx.moveTo(cx + Math.cos(a) * inner, cx + Math.sin(a) * inner);
+            ctx.lineTo(cx + Math.cos(a) * outer, cx + Math.sin(a) * outer);
+            ctx.stroke();
+
+            if (isMajor) {
+                const labelRadius = r - size * 0.16;
+                const label = spec.majorLabels[i / spec.minorTicksPerMajor];
+                ctx.fillStyle = inRedline ? '#ff6060' : 'rgba(255,255,255,0.85)';
+                ctx.font = `bold ${Math.round(size * 0.09)}px "Arial Narrow", Arial, sans-serif`;
+                ctx.textAlign = 'center';
+                ctx.textBaseline = 'middle';
+                ctx.fillText(label, cx + Math.cos(a) * labelRadius, cx + Math.sin(a) * labelRadius);
+            }
+        }
+
+        ctx.fillStyle = 'rgba(255,255,255,0.55)';
+        ctx.font = `${Math.round(size * 0.075)}px "Arial Narrow", Arial, sans-serif`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(spec.unit, cx, cx + size * 0.24);
+
+        // Hub
+        ctx.fillStyle = '#151517';
+        ctx.beginPath();
+        ctx.arc(cx, cx, size * 0.075, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.strokeStyle = spec.emissiveColor;
+        ctx.lineWidth = Math.max(1.5, size * 0.007);
+        ctx.globalAlpha = 0.65;
+        ctx.beginPath();
+        ctx.arc(cx, cx, size * 0.075, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.globalAlpha = 1.0;
+
+        return c;
+    }
+
+    private static buildDialMesh(
+        canvas: HTMLCanvasElement,
+        radius: number,
+        emissive: number,
+        anisotropy: number
+    ): { mesh: THREE.Mesh; material: THREE.MeshStandardMaterial } {
+        const tex = new THREE.CanvasTexture(canvas);
+        tex.anisotropy = anisotropy;
+        tex.colorSpace = THREE.SRGBColorSpace;
+        const material = new THREE.MeshStandardMaterial({
+            map: tex,
+            roughness: 0.7,
+            emissive: new THREE.Color(emissive),
+            emissiveIntensity: 0.25,
+            emissiveMap: tex,
+        });
+        const mesh = new THREE.Mesh(new THREE.CircleGeometry(radius, 48), material);
+        return { mesh, material };
+    }
+
+    /**
+     * Tapered flat needle pivoting at the hub, with a short counterweight
+     * tail. rotation.z spins it around the gauge center.
+     */
+    private static buildNeedle(
+        length: number,
+        color: number
+    ): { mesh: THREE.Mesh; material: THREE.MeshStandardMaterial } {
+        const halfBase = length * 0.055;
+        const shape = new THREE.Shape();
+        shape.moveTo(-halfBase, -length * 0.22);
+        shape.lineTo(halfBase, -length * 0.22);
+        shape.lineTo(halfBase * 0.22, length);
+        shape.lineTo(-halfBase * 0.22, length);
+        shape.closePath();
+        const geo = new THREE.ShapeGeometry(shape);
+        const material = new THREE.MeshStandardMaterial({
+            color,
+            emissive: color,
+            emissiveIntensity: 1.0,
+            roughness: 0.4,
+            metalness: 0.1,
+        });
+        const mesh = new THREE.Mesh(geo, material);
+        return { mesh, material };
+    }
+
     private static buildGauges(
         interiorGroup: THREE.Group,
-        metalMaterial: THREE.MeshStandardMaterial
-    ): { speedometerNeedle: THREE.Mesh; tachometerNeedle: THREE.Mesh } {
-        const buildDialCanvas = (size: number, emissiveColor: string, labelMax: number, unit: string): HTMLCanvasElement => {
-            const c = document.createElement('canvas');
-            c.width = size; c.height = size;
-            const ctx = c.getContext('2d')!;
+        vehicleConfig: { accentColor: string },
+        gpuProfile: { name: string },
+        quality: 'high' | 'medium' | 'low'
+    ): { speedometerNeedle: THREE.Mesh; tachometerNeedle: THREE.Mesh; gaugeRig: GaugeRig } {
+        const dialSize = gpuProfile.name === 'high' ? 512 : 256;
+        const anisotropy = gpuProfile.name === 'high' ? 8 : 4;
+        const dialMaterials: THREE.MeshStandardMaterial[] = [];
+        const needleMaterials: THREE.MeshStandardMaterial[] = [];
 
-            const bg = ctx.createRadialGradient(size/2, size/2, 0, size/2, size/2, size/2);
-            bg.addColorStop(0, '#222222');
-            bg.addColorStop(1, '#0d0d0d');
-            ctx.fillStyle = bg;
-            ctx.beginPath();
-            ctx.arc(size/2, size/2, size/2, 0, Math.PI * 2);
-            ctx.fill();
+        const speedLabels: string[] = [];
+        for (let v = 0; v <= SPEED_DIAL_MAX_KMH; v += 30) speedLabels.push(String(v));
+        const speedDial = CarInteriorGauges.buildDialMesh(
+            CarInteriorGauges.buildDialCanvas(dialSize, {
+                emissiveColor: '#00dd88',
+                majorLabels: speedLabels,
+                minorTicksPerMajor: 5,
+                unit: 'km/h',
+            }),
+            0.15, 0x002211, anisotropy
+        );
+        speedDial.mesh.position.set(-0.5, 0.95, -0.712);
+        interiorGroup.add(speedDial.mesh);
+        dialMaterials.push(speedDial.material);
 
-            ctx.strokeStyle = emissiveColor;
-            ctx.lineWidth = 3;
-            ctx.globalAlpha = 0.45;
-            ctx.beginPath();
-            ctx.arc(size/2, size/2, size/2 - 4, 0, Math.PI * 2);
-            ctx.stroke();
-            ctx.globalAlpha = 1.0;
+        const speedNeedle = CarInteriorGauges.buildNeedle(0.115, 0xff5030);
+        speedNeedle.mesh.position.set(-0.5, 0.95, -0.706);
+        speedNeedle.mesh.rotation.z = needleAngle(0);
+        interiorGroup.add(speedNeedle.mesh);
+        needleMaterials.push(speedNeedle.material);
 
-            const startAngle = -Math.PI * 0.75;
-            const sweepAngle = Math.PI * 1.5;
-            const majorTicks = 6;
-            const minorTicks = 30;
-            for (let i = 0; i <= minorTicks; i++) {
-                const a = startAngle + (i / minorTicks) * sweepAngle;
-                const isMajor = i % (minorTicks / majorTicks) === 0;
-                const inner = isMajor ? size/2 - 18 : size/2 - 11;
-                const outer = size/2 - 6;
-                ctx.strokeStyle = isMajor ? emissiveColor : 'rgba(255,255,255,0.35)';
-                ctx.lineWidth = isMajor ? 2 : 1;
-                ctx.beginPath();
-                ctx.moveTo(size/2 + Math.cos(a) * inner, size/2 + Math.sin(a) * inner);
-                ctx.lineTo(size/2 + Math.cos(a) * outer, size/2 + Math.sin(a) * outer);
-                ctx.stroke();
+        const tachoLabels: string[] = [];
+        for (let v = 0; v <= 8; v++) tachoLabels.push(String(v));
+        const tachoDial = CarInteriorGauges.buildDialMesh(
+            CarInteriorGauges.buildDialCanvas(dialSize, {
+                emissiveColor: '#dd4422',
+                majorLabels: tachoLabels,
+                minorTicksPerMajor: 4,
+                unit: 'x1000',
+                redlineFrac: TACHO_REDLINE_RPM / TACHO_DIAL_MAX_RPM,
+            }),
+            0.15, 0x220800, anisotropy
+        );
+        tachoDial.mesh.position.set(-0.15, 0.95, -0.712);
+        interiorGroup.add(tachoDial.mesh);
+        dialMaterials.push(tachoDial.material);
 
-                if (isMajor) {
-                    const labelRadius = size/2 - 28;
-                    const val = Math.round((i / minorTicks) * labelMax);
-                    ctx.fillStyle = 'rgba(255,255,255,0.75)';
-                    ctx.font = `bold ${Math.round(size * 0.10)}px "Arial Narrow", Arial, sans-serif`;
-                    ctx.textAlign = 'center';
-                    ctx.textBaseline = 'middle';
-                    ctx.fillText(String(val), size/2 + Math.cos(a) * labelRadius, size/2 + Math.sin(a) * labelRadius);
-                }
-            }
+        const tachoNeedle = CarInteriorGauges.buildNeedle(0.115, 0xff5030);
+        tachoNeedle.mesh.position.set(-0.15, 0.95, -0.706);
+        tachoNeedle.mesh.rotation.z = needleAngle(0);
+        interiorGroup.add(tachoNeedle.mesh);
+        needleMaterials.push(tachoNeedle.material);
 
-            ctx.fillStyle = 'rgba(255,255,255,0.5)';
-            ctx.font = `${Math.round(size * 0.09)}px "Arial Narrow", Arial, sans-serif`;
-            ctx.textAlign = 'center';
-            ctx.textBaseline = 'middle';
-            ctx.fillText(unit, size/2, size/2 + size * 0.28);
+        // Fuel + coolant-temperature mini gauges below the main pair.
+        let fuelNeedleMesh: THREE.Mesh | null = null;
+        let tempNeedleMesh: THREE.Mesh | null = null;
+        if (quality !== 'low') {
+            const miniSize = dialSize / 2;
+            const fuelDial = CarInteriorGauges.buildDialMesh(
+                CarInteriorGauges.buildDialCanvas(miniSize, {
+                    emissiveColor: '#ffaa00',
+                    majorLabels: ['E', '½', 'F'],
+                    minorTicksPerMajor: 2,
+                    unit: 'FUEL',
+                }),
+                0.05, 0x221400, anisotropy
+            );
+            fuelDial.mesh.position.set(-0.43, 0.78, -0.712);
+            interiorGroup.add(fuelDial.mesh);
+            dialMaterials.push(fuelDial.material);
 
-            ctx.fillStyle = '#1a1a1a';
-            ctx.beginPath();
-            ctx.arc(size/2, size/2, size * 0.08, 0, Math.PI * 2);
-            ctx.fill();
-            ctx.strokeStyle = emissiveColor;
-            ctx.lineWidth = 1.5;
-            ctx.globalAlpha = 0.6;
-            ctx.beginPath();
-            ctx.arc(size/2, size/2, size * 0.08, 0, Math.PI * 2);
-            ctx.stroke();
-            ctx.globalAlpha = 1.0;
+            const fuelNeedle = CarInteriorGauges.buildNeedle(0.038, 0xffaa30);
+            fuelNeedle.mesh.position.set(-0.43, 0.78, -0.706);
+            fuelNeedle.mesh.rotation.z = needleAngle(0.85);
+            interiorGroup.add(fuelNeedle.mesh);
+            needleMaterials.push(fuelNeedle.material);
+            fuelNeedleMesh = fuelNeedle.mesh;
 
-            return c;
-        };
+            const tempDial = CarInteriorGauges.buildDialMesh(
+                CarInteriorGauges.buildDialCanvas(miniSize, {
+                    emissiveColor: '#44aaff',
+                    majorLabels: ['C', '', 'H'],
+                    minorTicksPerMajor: 2,
+                    unit: 'TEMP',
+                    redlineFrac: 0.86,
+                }),
+                0.05, 0x081422, anisotropy
+            );
+            tempDial.mesh.position.set(-0.22, 0.78, -0.712);
+            interiorGroup.add(tempDial.mesh);
+            dialMaterials.push(tempDial.material);
 
-        const speedDialCanvas = buildDialCanvas(256, '#00dd88', 300, 'km/h');
-        const speedTex = new THREE.CanvasTexture(speedDialCanvas);
-        const speedoMat = new THREE.MeshStandardMaterial({
-            map: speedTex,
-            roughness: 0.7,
-            emissive: new THREE.Color(0x004422),
-            emissiveIntensity: 0.25,
-            emissiveMap: speedTex,
+            const tempNeedle = CarInteriorGauges.buildNeedle(0.038, 0x60b8ff);
+            tempNeedle.mesh.position.set(-0.22, 0.78, -0.706);
+            tempNeedle.mesh.rotation.z = needleAngle(0.05);
+            interiorGroup.add(tempNeedle.mesh);
+            needleMaterials.push(tempNeedle.material);
+            tempNeedleMesh = tempNeedle.mesh;
+        }
+
+        // Chrome hub caps over the needle pivots.
+        const hubMat = new THREE.MeshPhysicalMaterial({
+            color: 0xd8d8dc, metalness: 1, roughness: 0.12,
+            clearcoat: 1, clearcoatRoughness: 0.08,
         });
-        const speedoGeo = new THREE.CircleGeometry(0.15, 32);
-        const speedometer = new THREE.Mesh(speedoGeo, speedoMat);
-        speedometer.position.set(-0.5, 0.95, -0.72);
-        interiorGroup.add(speedometer);
-
-        const needleGeo = new THREE.BoxGeometry(0.008, 0.12, 0.008);
-        const speedometerNeedle = new THREE.Mesh(needleGeo, metalMaterial);
-        speedometerNeedle.position.set(-0.5, 0.98, -0.71);
-        interiorGroup.add(speedometerNeedle);
-
-        const tachoDialCanvas = buildDialCanvas(256, '#dd2200', 8, 'x1000');
-        const tachoTex = new THREE.CanvasTexture(tachoDialCanvas);
-        const tachoMat = new THREE.MeshStandardMaterial({
-            map: tachoTex,
-            roughness: 0.7,
-            emissive: new THREE.Color(0x220000),
-            emissiveIntensity: 0.25,
-            emissiveMap: tachoTex,
-        });
-        const tachoGeo = new THREE.CircleGeometry(0.15, 32);
-        const tachometer = new THREE.Mesh(tachoGeo, tachoMat);
-        tachometer.position.set(-0.15, 0.95, -0.72);
-        interiorGroup.add(tachometer);
-
-        const tachoNeedleGeo = new THREE.BoxGeometry(0.008, 0.12, 0.008);
-        const tachometerNeedle = new THREE.Mesh(tachoNeedleGeo, metalMaterial);
-        tachometerNeedle.position.set(-0.15, 0.98, -0.71);
-        interiorGroup.add(tachometerNeedle);
+        const hubGeo = new THREE.CircleGeometry(0.012, 24);
+        for (const pos of [[-0.5, 0.95, -0.703], [-0.15, 0.95, -0.703]] as const) {
+            const hub = new THREE.Mesh(hubGeo, hubMat);
+            hub.position.set(pos[0], pos[1], pos[2]);
+            interiorGroup.add(hub);
+        }
 
         // Physical-glass covers over the gauge faces so they pick up the
         // panorama environment reflections like real instrument glass.
@@ -162,7 +349,18 @@ export class CarInteriorGauges {
         tachoCover.position.set(-0.15, 0.95, -0.695);
         interiorGroup.add(tachoCover);
 
-        return { speedometerNeedle, tachometerNeedle };
+        return {
+            speedometerNeedle: speedNeedle.mesh,
+            tachometerNeedle: tachoNeedle.mesh,
+            gaugeRig: {
+                speedNeedle: speedNeedle.mesh,
+                tachoNeedle: tachoNeedle.mesh,
+                fuelNeedle: fuelNeedleMesh,
+                tempNeedle: tempNeedleMesh,
+                dialMaterials,
+                needleMaterials,
+            },
+        };
     }
 
     private static buildDigitalClock(
@@ -268,21 +466,5 @@ export class CarInteriorGauges {
 
         const clockMat = mesh.material as THREE.MeshStandardMaterial;
         if (clockMat.map) clockMat.map.needsUpdate = true;
-    }
-
-    static updateGaugeNeedles(
-        speedometerNeedle: THREE.Mesh | null | undefined,
-        tachometerNeedle: THREE.Mesh | null | undefined,
-        speed: number,
-        rpm: number
-    ): void {
-        if (speedometerNeedle) {
-            const speedAngle = THREE.MathUtils.degToRad((speed / 100) * 300 - 150);
-            speedometerNeedle.rotation.z = speedAngle;
-        }
-        if (tachometerNeedle) {
-            const tachoAngle = THREE.MathUtils.degToRad((rpm / 8000) * 300 - 150);
-            tachometerNeedle.rotation.z = tachoAngle;
-        }
     }
 }

--- a/src/car/interior/CarInteriorLightingManager.ts
+++ b/src/car/interior/CarInteriorLightingManager.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { setCabinGlowState } from './MaterialFactory';
 
 export class CarInteriorLightingManager {
     constructor(
@@ -26,6 +27,12 @@ export class CarInteriorLightingManager {
     private isDomeLightOn: boolean = false;
     /** 0 = sun up, 1 = full night; derived from real sun altitude. */
     private sunNightFactor: number = 0;
+    /** 0-1 rain intensity: overcast skies dim and diffuse the daylight. */
+    private weatherIntensity: number = 0;
+    /** Sun intensity before weather attenuation (set with the sun state). */
+    private sunBaseIntensity: number = 0;
+    /** Disables the ambient breathing modulation. */
+    private reducedMotion: boolean = false;
 
     // Sun colour ramp: warm at the horizon (golden hour) → neutral at midday.
     private static readonly SUN_WARM = new THREE.Color(0xffab5e);
@@ -61,7 +68,7 @@ export class CarInteriorLightingManager {
 
             // Ramp up over the first ~14° of altitude; off below the horizon.
             const strength = Math.max(0, Math.min(1, sinAlt / 0.25));
-            this.sunLight.intensity = strength * 1.1;
+            this.sunBaseIntensity = strength * 1.1;
             this.sunLight.color
                 .copy(CarInteriorLightingManager.SUN_WARM)
                 .lerp(CarInteriorLightingManager.SUN_NEUTRAL, strength);
@@ -83,6 +90,19 @@ export class CarInteriorLightingManager {
     /** Night factor (0-1) derived from the last reported sun altitude. */
     public getSunNightFactor(): number {
         return this.sunNightFactor;
+    }
+
+    /** 0-1 rain intensity; dims the sun and diffuses window light. */
+    public setWeatherIntensity(rain: number): void {
+        this.weatherIntensity = Math.max(0, Math.min(1, rain));
+    }
+
+    public getWeatherIntensity(): number {
+        return this.weatherIntensity;
+    }
+
+    public setReducedMotion(reduced: boolean): void {
+        this.reducedMotion = reduced;
     }
 
     public toggleHeadlights(): void {
@@ -119,26 +139,45 @@ export class CarInteriorLightingManager {
         // the real sun's altitude at the pano's location.
         const effectiveNight = Math.max(nightIntensity, this.sunNightFactor);
         const dayFactor = 1 - effectiveNight;
+        // Rain reads as overcast: direct sun collapses, diffuse light dims a
+        // little but survives (clouds scatter rather than block).
+        const rain = this.weatherIntensity;
+        const direct = 1 - rain * 0.75;
+        const diffuse = 1 - rain * 0.3;
+        // Living-cabin breathing: a ±2% swell on the ambient terms, slow
+        // enough to be felt rather than seen.
+        const breathe = this.reducedMotion
+            ? 0
+            : Math.sin(performance.now() * 0.0006) * 0.02;
+
+        if (this.sunLight) {
+            const sunTarget = this.sunBaseIntensity * direct;
+            this.sunLight.intensity += (sunTarget - this.sunLight.intensity) * 0.05;
+        }
         if (this.hemisphereLight) {
-            const hemiTarget = 0.38 * dayFactor + 0.05;
+            const hemiTarget = (0.38 * dayFactor + 0.05) * diffuse * (1 + breathe);
             this.hemisphereLight.intensity += (hemiTarget - this.hemisphereLight.intensity) * 0.05;
         }
         if (this.ambientLight) {
-            const ambTarget = 0.11 * dayFactor + 0.02;
+            const ambTarget = (0.11 * dayFactor + 0.02) * diffuse * (1 + breathe);
             this.ambientLight.intensity += (ambTarget - this.ambientLight.intensity) * 0.05;
         }
         if (this.overheadLight) {
-            const overTarget = 0.55 * dayFactor;
+            const overTarget = 0.55 * dayFactor * direct;
             this.overheadLight.intensity += (overTarget - this.overheadLight.intensity) * 0.05;
         }
         if (this.leftWindowLight) {
-            const leftTarget = 0.28 * dayFactor + 0.03;
+            const leftTarget = (0.28 * dayFactor + 0.03) * diffuse;
             this.leftWindowLight.intensity += (leftTarget - this.leftWindowLight.intensity) * 0.05;
         }
         if (this.rightWindowLight) {
-            const rightTarget = 0.18 * dayFactor + 0.02;
+            const rightTarget = (0.18 * dayFactor + 0.02) * diffuse;
             this.rightWindowLight.intensity += (rightTarget - this.rightWindowLight.intensity) * 0.05;
         }
+
+        // Accent strips + button backlights: one call scales every registered
+        // emissive material for the current cabin state.
+        setCabinGlowState(effectiveNight, headlightsOn, breathe);
 
         const matBrightness = 0.6 + dayFactor * 0.4;
         if (this.dashboardMaterial) {
@@ -168,7 +207,7 @@ export class CarInteriorLightingManager {
         }
 
         // Faint warm cabin glow at night even with the dome switch off.
-        const domeTarget = domeLightOn ? 1.2 : effectiveNight * 0.18;
+        const domeTarget = (domeLightOn ? 1.2 : effectiveNight * 0.18) * (1 + breathe);
         if (this.domeLightSource) {
             this.domeLightSource.intensity += (domeTarget - this.domeLightSource.intensity) * 0.08;
         }

--- a/src/car/interior/CenterDisplay.ts
+++ b/src/car/interior/CenterDisplay.ts
@@ -1,0 +1,451 @@
+import * as THREE from 'three';
+import { PanoLocationInfo, headingToCompass } from '../../utils/panoLocation';
+import { createAccentMaterial } from './MaterialFactory';
+import { VehicleConfig } from '../VehicleManager';
+
+export type DisplayPage = 'nav' | 'media' | 'trip';
+const PAGES: DisplayPage[] = ['nav', 'media', 'trip'];
+
+/**
+ * CenterDisplay — the infotainment screen on the centre stack.
+ *
+ * A gently curved screen mesh with a live CanvasTexture cycling through three
+ * pages (navigation, media, trip computer), covered by a physical-glass
+ * overlay whose clearcoat picks up the panorama IBL environment, so the
+ * street reflects off the glossy surface with a natural Fresnel falloff.
+ * An accent-colored frame provides the inner glow around the panel.
+ *
+ * Redraws are throttled to ~8 Hz and skipped entirely when the rendered
+ * content hash hasn't changed (static page, no animation running).
+ */
+export class CenterDisplay {
+    readonly group: THREE.Group;
+    /** Raycast target for click-to-cycle interaction. */
+    readonly screenMesh: THREE.Mesh;
+
+    private canvas: HTMLCanvasElement;
+    private ctx: CanvasRenderingContext2D;
+    private texture: THREE.CanvasTexture;
+    private screenMat: THREE.MeshStandardMaterial;
+    private accent: string;
+
+    private page: DisplayPage = 'nav';
+    private info: PanoLocationInfo | null = null;
+    private headingDeg = 0;
+    private mediaName = '';
+    private mediaTags = '';
+    private mediaPlaying = false;
+    private speedKmh = 0;
+    private rpm = 0;
+    private odometerKm = 0;
+    private driveTimeS = 0;
+
+    private clock = 0;
+    private sinceDraw = Infinity;
+    private renderedKey = '';
+
+    private static readonly W = 512;
+    private static readonly H = 320;
+    private static readonly REDRAW_INTERVAL = 0.125;
+
+    constructor(vehicleConfig: VehicleConfig, gpuProfileName: string) {
+        this.accent = vehicleConfig.accentColor || '#00ffcc';
+        this.group = new THREE.Group();
+
+        this.canvas = document.createElement('canvas');
+        this.canvas.width = CenterDisplay.W;
+        this.canvas.height = CenterDisplay.H;
+        this.ctx = this.canvas.getContext('2d', { alpha: true })!;
+
+        this.texture = new THREE.CanvasTexture(this.canvas);
+        this.texture.anisotropy = gpuProfileName === 'high' ? 8 : 4;
+        this.texture.colorSpace = THREE.SRGBColorSpace;
+
+        const accentHex = parseInt(this.accent.replace('#', '0x')) || 0x00ffcc;
+        this.screenMat = new THREE.MeshStandardMaterial({
+            map: this.texture,
+            emissive: new THREE.Color(0xffffff),
+            emissiveIntensity: 0.55,
+            emissiveMap: this.texture,
+            roughness: 0.35,
+            metalness: 0.0,
+        });
+
+        // Screen: subtle horizontal convex curve (centre ~5 mm proud) so
+        // reflections sweep across it as the head moves.
+        const screenGeo = CenterDisplay.curvedPlane(0.27, 0.17, 0.005);
+        this.screenMesh = new THREE.Mesh(screenGeo, this.screenMat);
+        this.screenMesh.name = 'centerDisplayScreen';
+        this.group.add(this.screenMesh);
+
+        // Glass cover: clearcoat + envMap → panorama reflections with
+        // Fresnel edge falloff on top of the emissive content.
+        const glassMat = new THREE.MeshPhysicalMaterial({
+            color: 0xcfe0ea,
+            metalness: 0,
+            roughness: 0.05,
+            transparent: true,
+            opacity: 0.09,
+            depthWrite: false,
+            envMapIntensity: 1.6,
+            clearcoat: 1.0,
+            clearcoatRoughness: 0.05,
+        });
+        const glass = new THREE.Mesh(CenterDisplay.curvedPlane(0.272, 0.172, 0.005), glassMat);
+        glass.position.z = 0.003;
+        this.group.add(glass);
+
+        // Accent frame hugging the screen: the "inner glow" between the
+        // screen edge and the dashboard bezel.
+        const frameShape = CenterDisplay.roundedRect(0.288, 0.188, 0.012);
+        frameShape.holes.push(new THREE.Path(CenterDisplay.roundedRect(0.276, 0.176, 0.008).getPoints(10)));
+        const frame = new THREE.Mesh(
+            new THREE.ShapeGeometry(frameShape),
+            createAccentMaterial(vehicleConfig, 0.55)
+        );
+        frame.position.z = 0.002;
+        this.group.add(frame);
+
+        // Slightly below the housing centre: the dash-top roll overhangs
+        // y≈1.0 at this depth and would clip the top row of the panel.
+        this.group.position.set(0.15, 0.925, -0.726);
+        this.render(true);
+    }
+
+    /** Plane with a gentle horizontal bulge toward +Z. */
+    private static curvedPlane(w: number, h: number, depth: number): THREE.PlaneGeometry {
+        const geo = new THREE.PlaneGeometry(w, h, 24, 1);
+        const pos = geo.attributes.position;
+        const half = w / 2;
+        for (let i = 0; i < pos.count; i++) {
+            const nx = pos.getX(i) / half;
+            pos.setZ(i, (1 - nx * nx) * depth);
+        }
+        geo.computeVertexNormals();
+        return geo;
+    }
+
+    private static roundedRect(w: number, h: number, r: number): THREE.Shape {
+        const s = new THREE.Shape();
+        s.moveTo(-w / 2 + r, -h / 2);
+        s.lineTo(w / 2 - r, -h / 2);
+        s.quadraticCurveTo(w / 2, -h / 2, w / 2, -h / 2 + r);
+        s.lineTo(w / 2, h / 2 - r);
+        s.quadraticCurveTo(w / 2, h / 2, w / 2 - r, h / 2);
+        s.lineTo(-w / 2 + r, h / 2);
+        s.quadraticCurveTo(-w / 2, h / 2, -w / 2, h / 2 - r);
+        s.lineTo(-w / 2, -h / 2 + r);
+        s.quadraticCurveTo(-w / 2, -h / 2, -w / 2 + r, -h / 2);
+        return s;
+    }
+
+    // ------------------------------------------------------------------ data
+
+    setLocation(info: PanoLocationInfo | null): void {
+        this.info = info;
+    }
+
+    setHeading(heading: number): void {
+        this.headingDeg = ((heading % 360) + 360) % 360;
+    }
+
+    setMedia(name: string, tags: string, playing: boolean): void {
+        this.mediaName = name;
+        this.mediaTags = tags;
+        this.mediaPlaying = playing;
+    }
+
+    setTelemetry(speedKmh: number, rpm: number): void {
+        this.speedKmh = speedKmh;
+        this.rpm = rpm;
+    }
+
+    /** Boost the screen glow after dark (0 = day baseline, 1 = full night). */
+    setNightGlow(night: number): void {
+        this.screenMat.emissiveIntensity = 0.55 + Math.max(0, Math.min(1, night)) * 0.5;
+    }
+
+    /** Advance to the next page; returns the new page. */
+    cyclePage(): DisplayPage {
+        this.page = PAGES[(PAGES.indexOf(this.page) + 1) % PAGES.length];
+        this.render(true);
+        return this.page;
+    }
+
+    getPage(): DisplayPage {
+        return this.page;
+    }
+
+    getMaterial(): THREE.MeshStandardMaterial {
+        return this.screenMat;
+    }
+
+    /** Per-frame tick: integrates trip data and throttles canvas redraws. */
+    update(dt: number): void {
+        const clamped = Math.min(Math.max(dt, 0), 0.1);
+        this.clock += clamped;
+        if (this.speedKmh > 0.5) {
+            this.odometerKm += (this.speedKmh / 3600) * clamped;
+            this.driveTimeS += clamped;
+        }
+        this.sinceDraw += clamped;
+        if (this.sinceDraw >= CenterDisplay.REDRAW_INTERVAL) {
+            this.sinceDraw = 0;
+            this.render();
+        }
+    }
+
+    // -------------------------------------------------------------- painting
+
+    private contentKey(): string {
+        switch (this.page) {
+            case 'nav':
+                return [
+                    'nav',
+                    this.info?.address ?? this.info?.description ?? '',
+                    Math.round(this.headingDeg / 2),
+                ].join('|');
+            case 'media':
+                // Animated while playing → unique key every throttled frame.
+                return ['media', this.mediaName, this.mediaTags,
+                    this.mediaPlaying ? this.clock.toFixed(2) : 'off'].join('|');
+            case 'trip':
+                return ['trip', Math.round(this.speedKmh), Math.round(this.rpm / 50),
+                    this.odometerKm.toFixed(2), Math.round(this.driveTimeS)].join('|');
+        }
+    }
+
+    private render(force = false): void {
+        const key = this.contentKey();
+        if (!force && key === this.renderedKey) return;
+        this.renderedKey = key;
+
+        const ctx = this.ctx;
+        const W = CenterDisplay.W;
+        const H = CenterDisplay.H;
+        const accent = this.accent;
+
+        // Panel background with a vertical falloff like an LCD at an angle
+        ctx.clearRect(0, 0, W, H);
+        const bg = ctx.createLinearGradient(0, 0, 0, H);
+        bg.addColorStop(0, '#0b0e14');
+        bg.addColorStop(1, '#05070b');
+        ctx.fillStyle = bg;
+        ctx.fillRect(0, 0, W, H);
+
+        // Faint pixel grid
+        ctx.fillStyle = 'rgba(255,255,255,0.018)';
+        for (let y = 12; y < H - 8; y += 8) {
+            for (let x = 12; x < W - 8; x += 8) ctx.fillRect(x, y, 1, 1);
+        }
+
+        switch (this.page) {
+            case 'nav': this.renderNav(); break;
+            case 'media': this.renderMedia(); break;
+            case 'trip': this.renderTrip(); break;
+        }
+
+        // Page indicator dots
+        const dotY = H - 16;
+        for (let i = 0; i < PAGES.length; i++) {
+            const active = PAGES[i] === this.page;
+            ctx.beginPath();
+            ctx.arc(W / 2 + (i - 1) * 18, dotY, active ? 4 : 2.5, 0, Math.PI * 2);
+            ctx.fillStyle = active ? accent : 'rgba(255,255,255,0.25)';
+            ctx.shadowColor = accent;
+            ctx.shadowBlur = active ? 8 : 0;
+            ctx.fill();
+            ctx.shadowBlur = 0;
+        }
+
+        // Inner glow: accent bleed from the frame edges
+        const glow = ctx.createLinearGradient(0, 0, 0, 14);
+        glow.addColorStop(0, this.accentRgba(0.22));
+        glow.addColorStop(1, this.accentRgba(0));
+        ctx.fillStyle = glow;
+        ctx.fillRect(0, 0, W, 14);
+        const glowB = ctx.createLinearGradient(0, H, 0, H - 14);
+        glowB.addColorStop(0, this.accentRgba(0.22));
+        glowB.addColorStop(1, this.accentRgba(0));
+        ctx.fillStyle = glowB;
+        ctx.fillRect(0, H - 14, W, 14);
+
+        // Painted Fresnel-style edge highlight along the top
+        const sheen = ctx.createLinearGradient(0, 0, 0, H * 0.35);
+        sheen.addColorStop(0, 'rgba(255,255,255,0.07)');
+        sheen.addColorStop(1, 'rgba(255,255,255,0)');
+        ctx.fillStyle = sheen;
+        ctx.fillRect(0, 0, W, H * 0.35);
+
+        this.texture.needsUpdate = true;
+    }
+
+    private accentRgba(alpha: number): string {
+        const hex = parseInt(this.accent.replace('#', '0x')) || 0x00ffcc;
+        return `rgba(${(hex >> 16) & 255},${(hex >> 8) & 255},${hex & 255},${alpha})`;
+    }
+
+    private header(title: string): void {
+        const ctx = this.ctx;
+        ctx.fillStyle = 'rgba(255,255,255,0.4)';
+        ctx.font = '600 18px "SF Mono", "Consolas", monospace';
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'alphabetic';
+        ctx.fillText(title, 28, 42);
+        ctx.strokeStyle = this.accentRgba(0.5);
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(28, 54);
+        ctx.lineTo(CenterDisplay.W - 28, 54);
+        ctx.stroke();
+    }
+
+    private glowText(text: string, x: number, y: number, size: number, align: CanvasTextAlign = 'left', color?: string): void {
+        const ctx = this.ctx;
+        ctx.textAlign = align;
+        ctx.textBaseline = 'alphabetic';
+        ctx.font = `700 ${size}px "SF Mono", "Consolas", monospace`;
+        ctx.shadowColor = color ?? this.accent;
+        ctx.shadowBlur = 12;
+        ctx.fillStyle = color ?? this.accent;
+        ctx.fillText(text, x, y);
+        ctx.shadowBlur = 0;
+    }
+
+    private fit(text: string, font: string, maxW: number): string {
+        const ctx = this.ctx;
+        ctx.font = font;
+        if (ctx.measureText(text).width <= maxW) return text;
+        let t = text;
+        while (t.length > 1 && ctx.measureText(t + '…').width > maxW) t = t.slice(0, -1);
+        return t + '…';
+    }
+
+    private renderNav(): void {
+        const ctx = this.ctx;
+        const W = CenterDisplay.W;
+        this.header('NAVIGATION');
+
+        const road = this.info?.address || this.info?.description || '— NO SIGNAL —';
+        this.glowText(this.fit(road, '700 34px monospace', W - 56), 28, 104, 34);
+
+        const coords = this.info?.lat != null && this.info?.lng != null
+            ? `${this.info.lat.toFixed(5)}, ${this.info.lng.toFixed(5)}`
+            : '—';
+        ctx.fillStyle = 'rgba(255,255,255,0.55)';
+        ctx.font = '600 20px "SF Mono", "Consolas", monospace';
+        ctx.textAlign = 'left';
+        ctx.fillText(coords, 28, 140);
+
+        // Compass ribbon: ticks every 15°, cardinal labels, sliding with heading.
+        const ribbonY = 220;
+        const pxPerDeg = 3.2;
+        ctx.save();
+        ctx.beginPath();
+        ctx.rect(28, ribbonY - 44, W - 56, 72);
+        ctx.clip();
+        for (let deg = -90; deg <= 90; deg += 15) {
+            const worldDeg = Math.round((this.headingDeg + deg) / 15) * 15;
+            const offset = worldDeg - this.headingDeg;
+            const x = W / 2 + offset * pxPerDeg;
+            const norm = ((worldDeg % 360) + 360) % 360;
+            const isCardinal = norm % 90 === 0;
+            ctx.strokeStyle = isCardinal ? this.accentRgba(0.9) : 'rgba(255,255,255,0.3)';
+            ctx.lineWidth = isCardinal ? 2.5 : 1;
+            ctx.beginPath();
+            ctx.moveTo(x, ribbonY);
+            ctx.lineTo(x, ribbonY + (isCardinal ? 18 : 10));
+            ctx.stroke();
+            if (isCardinal) {
+                this.glowText('NESW'[Math.round(norm / 90) % 4], x, ribbonY - 8, 24, 'center');
+            }
+        }
+        ctx.restore();
+        // Centre marker
+        ctx.strokeStyle = '#ffffff';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(W / 2, ribbonY + 24);
+        ctx.lineTo(W / 2 - 6, ribbonY + 36);
+        ctx.lineTo(W / 2 + 6, ribbonY + 36);
+        ctx.closePath();
+        ctx.stroke();
+        this.glowText(`${headingToCompass(this.headingDeg)} ${Math.round(this.headingDeg)}°`, W / 2, ribbonY + 62, 22, 'center');
+    }
+
+    private renderMedia(): void {
+        const ctx = this.ctx;
+        const W = CenterDisplay.W;
+        const H = CenterDisplay.H;
+        this.header('MEDIA');
+
+        const name = this.mediaName || 'RADIO OFF';
+        this.glowText(this.fit(name, '700 30px monospace', W - 56), 28, 102, 30);
+        ctx.fillStyle = 'rgba(255,255,255,0.5)';
+        ctx.font = '600 18px "SF Mono", "Consolas", monospace';
+        ctx.textAlign = 'left';
+        ctx.fillText(this.fit(this.mediaTags || '—', '600 18px monospace', W - 200), 28, 134);
+
+        const status = this.mediaPlaying ? '▶ PLAYING' : '❚❚ STANDBY';
+        this.glowText(status, W - 28, 134, 18, 'right', this.mediaPlaying ? undefined : 'rgba(255,255,255,0.45)');
+
+        // Equaliser bars: pseudo-random but deterministic per bar + time.
+        const bars = 24;
+        const barW = (W - 76) / bars;
+        const baseY = H - 52;
+        for (let i = 0; i < bars; i++) {
+            const level = this.mediaPlaying
+                ? 0.18 + 0.82 * Math.abs(Math.sin(this.clock * (2.1 + (i % 7) * 0.63) + i * 1.7))
+                : 0.06;
+            const h = level * 96;
+            const g = ctx.createLinearGradient(0, baseY - h, 0, baseY);
+            g.addColorStop(0, this.accentRgba(0.95));
+            g.addColorStop(1, this.accentRgba(0.25));
+            ctx.fillStyle = g;
+            ctx.fillRect(28 + i * barW + 2, baseY - h, barW - 4, h);
+        }
+    }
+
+    private renderTrip(): void {
+        const ctx = this.ctx;
+        const W = CenterDisplay.W;
+        this.header('TRIP COMPUTER');
+
+        this.glowText(String(Math.round(this.speedKmh)), 158, 158, 84, 'right');
+        ctx.fillStyle = 'rgba(255,255,255,0.5)';
+        ctx.font = '600 20px "SF Mono", "Consolas", monospace';
+        ctx.textAlign = 'left';
+        ctx.fillText('km/h', 172, 158);
+
+        this.glowText(String(Math.round(this.rpm)), W - 96, 158, 44, 'right');
+        ctx.fillStyle = 'rgba(255,255,255,0.5)';
+        ctx.font = '600 20px "SF Mono", "Consolas", monospace';
+        ctx.textAlign = 'left';
+        ctx.fillText('rpm', W - 84, 158);
+
+        const label = (text: string, x: number, y: number) => {
+            ctx.fillStyle = 'rgba(255,255,255,0.35)';
+            ctx.font = '600 16px "SF Mono", "Consolas", monospace';
+            ctx.textAlign = 'left';
+            ctx.fillText(text, x, y);
+        };
+        label('ODOMETER', 28, 212);
+        this.glowText(`${this.odometerKm.toFixed(2)} km`, 28, 244, 26);
+
+        const mins = Math.floor(this.driveTimeS / 60);
+        const secs = Math.floor(this.driveTimeS % 60);
+        label('DRIVE TIME', W / 2 + 28, 212);
+        this.glowText(`${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`, W / 2 + 28, 244, 26);
+    }
+
+    dispose(): void {
+        this.group.traverse(obj => {
+            if (obj instanceof THREE.Mesh) {
+                obj.geometry.dispose();
+                (Array.isArray(obj.material) ? obj.material : [obj.material])
+                    .forEach(m => m.dispose());
+            }
+        });
+        this.texture.dispose();
+    }
+}

--- a/src/car/interior/LODManager.ts
+++ b/src/car/interior/LODManager.ts
@@ -30,7 +30,13 @@ export class LODManager {
     mat: THREE.Material,
     count: number
   ): void {
-    if (this.instances.has(name)) return;
+    const existing = this.instances.get(name);
+    if (existing) {
+      // Re-registering (e.g. interior rebuild on vehicle swap): reset the
+      // batch so addInstance calls repopulate it instead of overflowing.
+      existing.count = 0;
+      return;
+    }
     const im = new THREE.InstancedMesh(geo, mat, count);
     im.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
     im.count = 0; // start empty

--- a/src/car/interior/MaterialFactory.ts
+++ b/src/car/interior/MaterialFactory.ts
@@ -3,13 +3,14 @@ import { VehicleConfig } from '../VehicleManager';
 import { GPUPerformanceProfile } from '../../utils/performance';
 
 export interface MaterialSet {
-  dashboard: THREE.MeshStandardMaterial;
-  leather: THREE.MeshStandardMaterial;
-  metal: THREE.MeshStandardMaterial;
+  dashboard: THREE.MeshPhysicalMaterial;
+  leather: THREE.MeshPhysicalMaterial;
+  metal: THREE.MeshPhysicalMaterial;
   frame: THREE.MeshStandardMaterial;
   glass: THREE.MeshStandardMaterial;
   mirror: THREE.MeshStandardMaterial;
-  accent: THREE.MeshStandardMaterial;
+  accent: THREE.MeshPhysicalMaterial;
+  chrome: THREE.MeshPhysicalMaterial;
 }
 
 /** Generate a procedural canvas texture */
@@ -26,11 +27,123 @@ function canvasTexture(
   return tex;
 }
 
+/**
+ * Convert a tiling height field into a tangent-space normal map
+ * (Sobel filter, wrapped edges so the texture stays seamless).
+ */
+function normalMapFromHeight(
+  size: number,
+  height: Float32Array,
+  strength: number
+): THREE.CanvasTexture {
+  return canvasTexture(size, (ctx) => {
+    const img = ctx.createImageData(size, size);
+    const d = img.data;
+    const h = (x: number, y: number) =>
+      height[((y + size) % size) * size + ((x + size) % size)];
+    for (let y = 0; y < size; y++) {
+      for (let x = 0; x < size; x++) {
+        const dx =
+          (h(x + 1, y - 1) + 2 * h(x + 1, y) + h(x + 1, y + 1)) -
+          (h(x - 1, y - 1) + 2 * h(x - 1, y) + h(x - 1, y + 1));
+        const dy =
+          (h(x - 1, y + 1) + 2 * h(x, y + 1) + h(x + 1, y + 1)) -
+          (h(x - 1, y - 1) + 2 * h(x, y - 1) + h(x + 1, y - 1));
+        const nx = -dx * strength;
+        const ny = -dy * strength;
+        const len = Math.sqrt(nx * nx + ny * ny + 1);
+        const i = (y * size + x) * 4;
+        d[i] = ((nx / len) * 0.5 + 0.5) * 255;
+        d[i + 1] = ((ny / len) * 0.5 + 0.5) * 255;
+        d[i + 2] = ((1 / len) * 0.5 + 0.5) * 255;
+        d[i + 3] = 255;
+      }
+    }
+    ctx.putImageData(img, 0, 0);
+  });
+}
+
+/** Leather grain height field, with two dashed stitch rows that tile into seam lines. */
+function leatherHeightField(size: number): Float32Array {
+  const field = new Float32Array(size * size);
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const fine = (Math.random() - 0.5) * 0.5;
+      const coarse =
+        Math.sin(x * 0.18 + y * 0.1) * Math.cos(x * 0.1 - y * 0.15) * 0.35;
+      field[y * size + x] = fine + coarse;
+    }
+  }
+  // Stitch bumps: dashes of raised thread just inside the top and bottom edges,
+  // sunk into a shallow seam groove.
+  const stitchRows = [Math.floor(size * 0.06), Math.floor(size * 0.94)];
+  const dash = Math.floor(size / 16);
+  for (const row of stitchRows) {
+    for (let x = 0; x < size; x++) {
+      for (let dyOff = -2; dyOff <= 2; dyOff++) {
+        field[(row + dyOff) * size + x] -= 0.5; // seam groove
+      }
+      if (x % dash < dash * 0.55) {
+        field[row * size + x] += 1.6; // raised thread
+        field[(row - 1) * size + x] += 0.9;
+        field[(row + 1) * size + x] += 0.9;
+      }
+    }
+  }
+  return field;
+}
+
+/** Brushed-metal roughness map: fine horizontal streaks over a polished base. */
+function brushedMetalRoughnessTexture(size: number): THREE.CanvasTexture {
+  return canvasTexture(size, (ctx) => {
+    const img = ctx.createImageData(size, size);
+    const d = img.data;
+    for (let y = 0; y < size; y++) {
+      const streak = 50 + Math.random() * 40;
+      for (let x = 0; x < size; x++) {
+        const v = streak + (Math.random() - 0.5) * 18;
+        const i = (y * size + x) * 4;
+        d[i] = d[i + 1] = d[i + 2] = Math.max(30, Math.min(120, v));
+        d[i + 3] = 255;
+      }
+    }
+    ctx.putImageData(img, 0, 0);
+  });
+}
+
+/**
+ * Lacquered accent trim material. Clearcoat gives the pieces a sharp
+ * reflection of the panorama environment on top of the tinted base, and the
+ * emissive term makes the trim read as ambient accent lighting. Callers pass
+ * different `emissiveIntensity` values so trim pieces vary in glow (bezels
+ * brighter than long strips); the neon theme boosts all of them.
+ */
+export function createAccentMaterial(
+  config: VehicleConfig,
+  emissiveIntensity: number
+): THREE.MeshPhysicalMaterial {
+  const accentHex = parseInt(config.accentColor.replace('#', '0x'));
+  const themeBoost = config.theme === 'neon' ? 1.6 : 1;
+  return new THREE.MeshPhysicalMaterial({
+    color: accentHex,
+    roughness: 0.3,
+    metalness: 0.65,
+    emissive: accentHex,
+    emissiveIntensity: emissiveIntensity * themeBoost,
+    envMapIntensity: 0.8,
+    clearcoat: 0.9,
+    clearcoatRoughness: 0.12,
+    side: THREE.DoubleSide,
+  });
+}
+
 /** Create all interior materials from vehicle config + GPU profile */
 export function createMaterials(
   config: VehicleConfig,
   gpuProfile: GPUPerformanceProfile
 ): MaterialSet {
+  const detailMaps = gpuProfile.name !== 'low';
+
   // Leather texture (multi-scale grain)
   const leatherTex = canvasTexture(256, (ctx) => {
     const img = ctx.createImageData(256, 256);
@@ -50,10 +163,23 @@ export function createMaterials(
       data[i + 2] = Math.max(8, Math.min(55, v * 0.54));
       data[i + 3] = 255;
     }
+    // Stitch thread color where the height field raises the seam dashes
+    const dash = 16;
     ctx.putImageData(img, 0, 0);
+    ctx.fillStyle = 'rgba(196,168,120,0.9)';
+    for (const row of [Math.floor(256 * 0.06), Math.floor(256 * 0.94)]) {
+      for (let x = 0; x < 256; x += dash) {
+        ctx.fillRect(x, row - 1, dash * 0.55, 3);
+      }
+    }
   });
   leatherTex.repeat.set(3, 3);
   leatherTex.anisotropy = gpuProfile.name === 'high' ? 8 : 4;
+
+  const leatherNormalTex = detailMaps
+    ? normalMapFromHeight(256, leatherHeightField(256), 1.4)
+    : null;
+  leatherNormalTex?.repeat.set(3, 3);
 
   // Dashboard soft-touch texture
   const dashTex = canvasTexture(128, (ctx) => {
@@ -67,6 +193,14 @@ export function createMaterials(
   });
   dashTex.repeat.set(4, 4);
 
+  let dashNormalTex: THREE.CanvasTexture | null = null;
+  if (detailMaps) {
+    const grain = new Float32Array(128 * 128);
+    for (let i = 0; i < grain.length; i++) grain[i] = Math.random();
+    dashNormalTex = normalMapFromHeight(128, grain, 0.35);
+    dashNormalTex.repeat.set(4, 4);
+  }
+
   const dashboardColors: Record<string, number> = {
     dark: 0x1a1a1a,
     light: 0x2a2a2a,
@@ -74,34 +208,51 @@ export function createMaterials(
     clinical: 0xf0f0f0,
   };
   const dashColor = dashboardColors[config.theme] ?? 0x1a1a1a;
+  const clinical = config.theme === 'clinical';
 
-  const dashboard = new THREE.MeshStandardMaterial({
+  // Soft-touch dash: near-dielectric with a faint sheen so grazing light
+  // picks up the matte-plastic look; clinical theme reads as hard gloss.
+  const dashboard = new THREE.MeshPhysicalMaterial({
     color: dashColor,
-    map: config.theme === 'clinical' ? null : dashTex,
-    roughness: config.theme === 'clinical' ? 0.35 : 0.88,
-    metalness: config.theme === 'clinical' ? 0.15 : 0.04,
+    map: clinical ? null : dashTex,
+    normalMap: clinical ? null : dashNormalTex,
+    normalScale: new THREE.Vector2(0.4, 0.4),
+    roughness: clinical ? 0.35 : 0.88,
+    metalness: clinical ? 0.15 : 0.04,
+    clearcoat: clinical ? 0.6 : 0.0,
+    clearcoatRoughness: 0.25,
+    sheen: clinical ? 0 : 0.25,
+    sheenRoughness: 0.9,
+    sheenColor: new THREE.Color(0x222222),
     envMapIntensity: 0.4,
     side: THREE.DoubleSide,
   });
 
-  const leather = new THREE.MeshStandardMaterial({
+  const leather = new THREE.MeshPhysicalMaterial({
     map: leatherTex,
+    normalMap: leatherNormalTex,
+    normalScale: new THREE.Vector2(0.8, 0.8),
     roughness: 0.78,
     metalness: 0,
+    sheen: 0.35,
+    sheenRoughness: 0.7,
+    sheenColor: new THREE.Color(0x3a2a1a),
     envMapIntensity: 0.2,
     side: THREE.DoubleSide,
   });
 
-  const metal = new THREE.MeshStandardMaterial({
-    color: config.theme === 'clinical' ? 0xd4d4d4 : 0x969696,
-    roughness: 0.22,
+  // Brushed metal: streaked roughness map breaks up reflections along the grain.
+  const metal = new THREE.MeshPhysicalMaterial({
+    color: clinical ? 0xd4d4d4 : 0x969696,
+    roughness: detailMaps ? 1.0 : 0.22,
+    roughnessMap: detailMaps ? brushedMetalRoughnessTexture(128) : null,
     metalness: 0.88,
     envMapIntensity: 1,
     side: THREE.DoubleSide,
   });
 
   const frame = new THREE.MeshStandardMaterial({
-    color: config.theme === 'clinical' ? 0xeeeeee : 0x131313,
+    color: clinical ? 0xeeeeee : 0x131313,
     roughness: 0.92,
     metalness: 0,
     envMapIntensity: 0.15,
@@ -126,19 +277,17 @@ export function createMaterials(
     side: THREE.FrontSide,
   });
 
-  // Lacquered trim: clearcoat gives the accent pieces a sharp reflection of
-  // the panorama environment on top of the tinted base.
-  const accent = new THREE.MeshPhysicalMaterial({
-    color: parseInt(config.accentColor.replace('#', '0x')),
-    roughness: 0.35,
-    metalness: 0.65,
-    emissive: parseInt(config.accentColor.replace('#', '0x')),
-    emissiveIntensity: 0.2,
-    envMapIntensity: 0.8,
-    clearcoat: 0.9,
-    clearcoatRoughness: 0.12,
-    side: THREE.DoubleSide,
+  const accent = createAccentMaterial(config, 0.2);
+
+  // Polished chrome for vent surrounds, rings, handles.
+  const chrome = new THREE.MeshPhysicalMaterial({
+    color: 0xe8e8e8,
+    roughness: 0.08,
+    metalness: 1,
+    clearcoat: 1,
+    clearcoatRoughness: 0.06,
+    envMapIntensity: 1.4,
   });
 
-  return { dashboard, leather, metal, frame, glass, mirror, accent };
+  return { dashboard, leather, metal, frame, glass, mirror, accent, chrome };
 }

--- a/src/car/interior/MaterialFactory.ts
+++ b/src/car/interior/MaterialFactory.ts
@@ -111,12 +111,58 @@ function brushedMetalRoughnessTexture(size: number): THREE.CanvasTexture {
   });
 }
 
+// ---------------------------------------------------------------------------
+// Cabin glow registry: every emissive trim/backlight material registers its
+// authored base intensity here, and the lighting manager scales them all with
+// one call per frame — accent strips brighten at night, button backlights
+// come up with the headlights, and the whole set breathes together. No extra
+// lights are involved; it's pure emissive modulation.
+// ---------------------------------------------------------------------------
+
+interface GlowEntry {
+  material: THREE.MeshStandardMaterial;
+  base: number;
+}
+
+let glowRegistry: GlowEntry[] = [];
+
+/** Drop all registered glow materials (call before rebuilding an interior). */
+export function resetGlowRegistry(): void {
+  glowRegistry = [];
+}
+
+/** Register an emissive material whose glow should follow cabin state. */
+export function registerGlowMaterial(
+  material: THREE.MeshStandardMaterial,
+  baseIntensity: number
+): void {
+  glowRegistry.push({ material, base: baseIntensity });
+}
+
+/**
+ * Scale every registered glow material for the current cabin state.
+ * @param night        0-1 effective night factor
+ * @param headlightsOn instrument/backlight bump when the lights are on
+ * @param breathe      small ±modulation for the ambient breathing effect
+ */
+export function setCabinGlowState(
+  night: number,
+  headlightsOn: boolean,
+  breathe: number
+): void {
+  const scale = 1 + night * 1.1 + (headlightsOn ? 0.25 : 0) + breathe;
+  for (const entry of glowRegistry) {
+    entry.material.emissiveIntensity = entry.base * scale;
+  }
+}
+
 /**
  * Lacquered accent trim material. Clearcoat gives the pieces a sharp
  * reflection of the panorama environment on top of the tinted base, and the
  * emissive term makes the trim read as ambient accent lighting. Callers pass
  * different `emissiveIntensity` values so trim pieces vary in glow (bezels
- * brighter than long strips); the neon theme boosts all of them.
+ * brighter than long strips); the neon theme boosts all of them. Each accent
+ * material joins the glow registry so cabin state modulates it.
  */
 export function createAccentMaterial(
   config: VehicleConfig,
@@ -124,7 +170,7 @@ export function createAccentMaterial(
 ): THREE.MeshPhysicalMaterial {
   const accentHex = parseInt(config.accentColor.replace('#', '0x'));
   const themeBoost = config.theme === 'neon' ? 1.6 : 1;
-  return new THREE.MeshPhysicalMaterial({
+  const material = new THREE.MeshPhysicalMaterial({
     color: accentHex,
     roughness: 0.3,
     metalness: 0.65,
@@ -135,6 +181,8 @@ export function createAccentMaterial(
     clearcoatRoughness: 0.12,
     side: THREE.DoubleSide,
   });
+  registerGlowMaterial(material, emissiveIntensity * themeBoost);
+  return material;
 }
 
 /** Create all interior materials from vehicle config + GPU profile */

--- a/src/car/interior/SunShafts.ts
+++ b/src/car/interior/SunShafts.ts
@@ -1,0 +1,150 @@
+import * as THREE from 'three';
+
+/**
+ * SunShafts — fake volumetric light shafts through the side windows.
+ *
+ * Two additive-blended gradient cards hang from each side window, leaning
+ * into the cabin at the real sun's descent angle. They only appear when the
+ * sun is low (golden hour, roughly 2°-25° altitude) and only on the side of
+ * the car the sun is actually shining through, so they read as god rays
+ * without any volumetric rendering cost: no lights, four transparent quads,
+ * one shared geometry and texture.
+ */
+export class SunShafts {
+    readonly group: THREE.Group;
+
+    private leftPivot: THREE.Group;
+    private rightPivot: THREE.Group;
+    private leftMat: THREE.MeshBasicMaterial;
+    private rightMat: THREE.MeshBasicMaterial;
+    private texture: THREE.CanvasTexture;
+    private geometry: THREE.PlaneGeometry;
+    private clock = 0;
+
+    /** Peak card opacity (per-side strength scales down from here). */
+    private static readonly MAX_OPACITY = 0.14;
+
+    constructor(private reducedMotion: boolean) {
+        this.group = new THREE.Group();
+
+        this.texture = SunShafts.buildShaftTexture();
+        this.geometry = new THREE.PlaneGeometry(1.2, 1.15);
+
+        const makeMaterial = () => new THREE.MeshBasicMaterial({
+            map: this.texture,
+            color: 0xffe3b8,
+            transparent: true,
+            opacity: 0,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false,
+            side: THREE.DoubleSide,
+        });
+        this.leftMat = makeMaterial();
+        this.rightMat = makeMaterial();
+
+        this.leftPivot = SunShafts.buildSide(this.geometry, this.leftMat, -1);
+        this.rightPivot = SunShafts.buildSide(this.geometry, this.rightMat, 1);
+        this.group.add(this.leftPivot, this.rightPivot);
+    }
+
+    /** Streaky vertical gradient: bright at the window edge, fading inward. */
+    private static buildShaftTexture(): THREE.CanvasTexture {
+        const canvas = document.createElement('canvas');
+        canvas.width = 128;
+        canvas.height = 256;
+        const ctx = canvas.getContext('2d')!;
+
+        const fade = ctx.createLinearGradient(0, 0, 0, 256);
+        fade.addColorStop(0, 'rgba(255,255,255,0.9)');
+        fade.addColorStop(0.55, 'rgba(255,255,255,0.35)');
+        fade.addColorStop(1, 'rgba(255,255,255,0)');
+        ctx.fillStyle = fade;
+        ctx.fillRect(0, 0, 128, 256);
+
+        // Vertical streaks: soft bands like light through a dusty window.
+        ctx.globalCompositeOperation = 'destination-out';
+        for (let x = 0; x < 128; x += 4) {
+            const cut = 0.15 + 0.75 * Math.abs(Math.sin(x * 0.55) * Math.cos(x * 0.21));
+            ctx.fillStyle = `rgba(0,0,0,${cut})`;
+            ctx.fillRect(x, 0, 4, 256);
+        }
+        ctx.globalCompositeOperation = 'source-over';
+
+        const tex = new THREE.CanvasTexture(canvas);
+        tex.wrapS = tex.wrapT = THREE.ClampToEdgeWrapping;
+        return tex;
+    }
+
+    /** Two offset cards hanging from one window's top edge. */
+    private static buildSide(
+        geometry: THREE.PlaneGeometry,
+        material: THREE.MeshBasicMaterial,
+        side: 1 | -1
+    ): THREE.Group {
+        const pivot = new THREE.Group();
+        pivot.position.set(side * 0.92, 1.25, -0.1);
+        for (const offset of [-0.03, 0.03]) {
+            const card = new THREE.Mesh(geometry, material);
+            // Plane normal along ±X so the card faces across the cabin;
+            // geometry width runs along the car's length after this turn.
+            card.rotation.y = Math.PI / 2;
+            card.position.set(offset, -0.55, 0);
+            pivot.add(card);
+        }
+        return pivot;
+    }
+
+    /**
+     * Aim and fade the shafts from the real sun.
+     * @param dt            frame delta (seconds)
+     * @param sunAzimuth    SunCalc azimuth in radians (0 = south, positive west)
+     * @param sunAltitude   SunCalc altitude in radians (0 = horizon)
+     * @param carHeadingRad car body compass heading in radians
+     * @param rain          0-1 rain intensity (overcast kills direct shafts)
+     */
+    public update(
+        dt: number,
+        sunAzimuth: number,
+        sunAltitude: number,
+        carHeadingRad: number,
+        rain: number
+    ): void {
+        this.clock += Math.min(Math.max(dt, 0), 0.1);
+
+        // Shafts exist in a low-sun band: ramp in above ~1°, gone by ~25°.
+        const sinAlt = Math.sin(sunAltitude);
+        const lowSun = sunAltitude <= 0.02
+            ? 0
+            : Math.min(1, sinAlt / 0.06) * Math.max(0, Math.min(1, 1 - (sinAlt - 0.1) / 0.32));
+
+        // Sun direction in the car's frame: which window does it shine through?
+        const sunHeading = sunAzimuth + Math.PI;
+        const relative = sunHeading - carHeadingRad;
+        const localX = Math.sin(relative) * Math.cos(sunAltitude);
+        const rightStrength = Math.max(0, localX);
+        const leftStrength = Math.max(0, -localX);
+
+        const weather = 1 - Math.max(0, Math.min(1, rain)) * 0.85;
+        const flicker = this.reducedMotion ? 1 : 1 + Math.sin(this.clock * 0.7) * 0.06;
+        const base = SunShafts.MAX_OPACITY * lowSun * weather * flicker;
+
+        this.leftMat.opacity = base * leftStrength;
+        this.rightMat.opacity = base * rightStrength;
+        this.leftPivot.visible = this.leftMat.opacity > 0.004;
+        this.rightPivot.visible = this.rightMat.opacity > 0.004;
+
+        // Lean the cards to the sun's descent angle (rays steepen as it rises),
+        // pivoting at the window's top edge, plus a slow drift for life.
+        const drift = this.reducedMotion ? 0 : Math.sin(this.clock * 0.23) * 0.015;
+        const lean = Math.PI / 2 - Math.max(0.05, sunAltitude);
+        this.leftPivot.rotation.z = lean + drift;
+        this.rightPivot.rotation.z = -lean + drift;
+    }
+
+    public dispose(): void {
+        this.geometry.dispose();
+        this.texture.dispose();
+        this.leftMat.dispose();
+        this.rightMat.dispose();
+    }
+}

--- a/src/views/CarModeView.tsx
+++ b/src/views/CarModeView.tsx
@@ -21,6 +21,9 @@ import {
   setWindowTint,
   setMirrorStreetViewCanvas,
   setCarZoomFOV,
+  setCarMediaInfo,
+  isCarCenterDisplayHit,
+  cycleCarDisplayPage,
   CarModeState
 } from '../car';
 import { DashboardUI } from '../car/DashboardUI';
@@ -187,6 +190,11 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
     );
   }, [wipersEnabled, headlightsOn, domeLightOn, nightIntensity]);
   
+  // Keep the centre display's media page in sync with the radio
+  useEffect(() => {
+    setCarMediaInfo(stationName, stationTags, isRadioPlaying);
+  }, [stationName, stationTags, isRadioPlaying]);
+
   // Keep rearview mirror fed from the scraped Street View canvas
   useEffect(() => {
     setMirrorStreetViewCanvas(canvas);
@@ -318,6 +326,22 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
   const isSteeringWheelAtPoint = useCallback((x: number, y: number): boolean => {
     return isCarSteeringWheelHit(x, y);
   }, []);
+
+  // Click (press-release without drag) on the centre display cycles its page.
+  const displayPressRef = useRef<{ x: number; y: number } | null>(null);
+  const handleDisplayMouseDown = useCallback((e: React.MouseEvent) => {
+    displayPressRef.current = e.button === 0 ? { x: e.clientX, y: e.clientY } : null;
+  }, []);
+  const handleDisplayClick = useCallback((e: React.MouseEvent) => {
+    const press = displayPressRef.current;
+    displayPressRef.current = null;
+    if (!press) return;
+    const moved = Math.hypot(e.clientX - press.x, e.clientY - press.y);
+    if (moved > 6) return; // was a look/steer drag, not a tap
+    if (isCarCenterDisplayHit(e.clientX, e.clientY)) {
+      cycleCarDisplayPage();
+    }
+  }, []);
   
   // Handle thrust from W/S keys for body pitch effect
   const handleThrust = useCallback((direction: 'forward' | 'backward') => {
@@ -441,6 +465,8 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
   return (
     <div
       ref={containerRef}
+      onMouseDown={handleDisplayMouseDown}
+      onClick={handleDisplayClick}
       style={{
         position: 'relative',
         width: '100vw',

--- a/src/views/CarModeView.tsx
+++ b/src/views/CarModeView.tsx
@@ -24,6 +24,7 @@ import {
   CarModeState
 } from '../car';
 import { DashboardUI } from '../car/DashboardUI';
+import { VehicleDynamics, VehicleTelemetry } from '../car/VehicleDynamics';
 
 interface CarModeViewProps {
   mapsApiKey: string;
@@ -114,6 +115,14 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
   const steeringInputRef = useRef(0);
   const carSpeedRef = useRef(0);
   const carRPMRef = useRef(0);
+  // Speed/RPM/gear model fed by pano hops (GPS velocity) and thrust keys.
+  const dynamicsRef = useRef<VehicleDynamics | null>(null);
+  if (!dynamicsRef.current) dynamicsRef.current = new VehicleDynamics();
+  const [telemetry, setTelemetry] = useState<VehicleTelemetry>({
+    speedKmh: 0, rpm: 850, gear: 'P', accelerating: false,
+  });
+  const lastTelemetryPushRef = useRef(0);
+  const prevPositionRef = useRef<google.maps.LatLng | null>(null);
   const bodyPitchRef = useRef(0);
   const bodyRollRef = useRef(0);
   const pitchImpulseRef = useRef(0);
@@ -148,6 +157,21 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
     };
   }, [registerCarModeState]);
   
+  // Infer GPS velocity from panorama hops: each position change reports its
+  // travel distance, so cruise mode / repeated advances read as real speed.
+  useEffect(() => {
+    const prev = prevPositionRef.current;
+    prevPositionRef.current = position;
+    if (!prev || !position) return;
+    const toRad = Math.PI / 180;
+    const dLat = (position.lat() - prev.lat()) * toRad;
+    const dLng = (position.lng() - prev.lng()) * toRad;
+    const a = Math.sin(dLat / 2) ** 2 +
+      Math.cos(prev.lat() * toRad) * Math.cos(position.lat() * toRad) * Math.sin(dLng / 2) ** 2;
+    const distanceMeters = 6371000 * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    dynamicsRef.current?.notePanoHop(distanceMeters);
+  }, [position]);
+
   // Sync environment settings to car interior
   useEffect(() => {
     if (!carModeStateRef.current) return;
@@ -228,9 +252,16 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
       // Update steering wheel
       setCarSteering(steeringInputRef.current);
       
-      // Update gauges
-      carRPMRef.current = Math.abs(steeringInputRef.current) * 100 + carSpeedRef.current * 50;
-      updateCarGauges(carSpeedRef.current, carRPMRef.current);
+      // Vehicle dynamics → 3D cluster needles + React dashboard gauges
+      const telem = dynamicsRef.current!.update(deltaTime);
+      carSpeedRef.current = telem.speedKmh;
+      carRPMRef.current = telem.rpm;
+      updateCarGauges(telem.speedKmh, telem.rpm);
+      // Throttle React state pushes; the HUD gauges spring-animate between them.
+      if (now - lastTelemetryPushRef.current > 150) {
+        lastTelemetryPushRef.current = now;
+        setTelemetry(telem);
+      }
       
       // Decay steering
       if (steeringInputRef.current !== 0) {
@@ -238,11 +269,6 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
         if (Math.abs(steeringInputRef.current) < 0.1) {
           steeringInputRef.current = 0;
         }
-      }
-      
-      // Decay speed
-      if (carSpeedRef.current > 0) {
-        carSpeedRef.current = Math.max(0, carSpeedRef.current - 5 * deltaTime);
       }
       
       // Body tilt physics: only in carSteer mode and clamped
@@ -297,7 +323,7 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
   const handleThrust = useCallback((direction: 'forward' | 'backward') => {
     if (controlMode === 'freeLook') return; // Car is locked when looking around
     pitchImpulseRef.current = direction === 'forward' ? -2 : 1;
-    carSpeedRef.current = direction === 'forward' ? 25 : 12;
+    dynamicsRef.current?.noteThrust(direction);
   }, [controlMode]);
 
   // Handle steering deltas from CarInputHandler for wheel visual + body tilt
@@ -364,6 +390,7 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
   // Reset body physics when entering freeLook so no residual tilt remains
   useEffect(() => {
     if (controlMode === 'freeLook') {
+      dynamicsRef.current?.stop();
       carSpeedRef.current = 0;
       pitchImpulseRef.current = 0;
       steeringInputRef.current = 0;
@@ -473,6 +500,9 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
         ambientLightColor={ambientLightColor}
         stationName={stationName}
         stationTags={stationTags}
+        speedKmh={telemetry.speedKmh}
+        rpm={telemetry.rpm}
+        gear={telemetry.gear}
       />
       
       {/* Control Mode Indicator (small overlay) */}

--- a/src/views/CarModeView.tsx
+++ b/src/views/CarModeView.tsx
@@ -24,6 +24,7 @@ import {
   setCarMediaInfo,
   isCarCenterDisplayHit,
   cycleCarDisplayPage,
+  setCarWeather,
   CarModeState
 } from '../car';
 import { DashboardUI } from '../car/DashboardUI';
@@ -190,6 +191,11 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
     );
   }, [wipersEnabled, headlightsOn, domeLightOn, nightIntensity]);
   
+  // Rain dims/diffuses the cabin daylight and enables windshield droplets
+  useEffect(() => {
+    setCarWeather(rainIntensity / 100);
+  }, [rainIntensity]);
+
   // Keep the centre display's media page in sync with the radio
   useEffect(() => {
     setCarMediaInfo(stationName, stationTags, isRadioPlaying);


### PR DESCRIPTION
## Summary

Four rounds of car-interior polish on this branch:

### Round 1 — Materials & dashboard geometry
- Dash/leather/metal upgraded to `MeshPhysicalMaterial` with procedural canvas detail: Sobel-generated normal maps (leather grain with stitched seams, soft-touch dash grain), brushed-metal roughness map, sheen, and a shared chrome material plumbed through the builders.
- `createAccentMaterial(config, intensity)`: lacquered clearcoat trim colored/emissive from `vehicleConfig.accentColor` with per-piece intensity variation and a neon-theme boost.
- Quality-scaled segment counts, chamfered extruded bezel frames, vents with chrome surrounds and instanced angled slats, extruded chamfered button caps, chrome knob collars.
- `LODManager.registerBatch` resets existing batches so vehicle swaps repopulate instead of overflowing.

### Round 2 — Gauges tied to gameplay state
- New `VehicleDynamics` model infers simulated GPS velocity from panorama hop distances (cruise mode reads as sustained speed) and derives RPM through a gearbox with shift drops and a P/R/1–3/D indicator; `CarModeView` drives the 3D cluster every frame and the React HUD at ~7 Hz, with `DashboardUI`'s random simulation kept only as fallback.
- `CarInteriorGauges` rebuilt: crisp quality-scaled dial canvases, tacho redline, hub-pivot emissive needles, chrome caps, new fuel + coolant-temp mini gauges; `CarInteriorAnimator` runs underdamped spring needles (bounce on accel), road/engine wobble, fuel/temp simulation, and night-following backlight.
- Fixed mirrored needle mapping, needles rotating off-hub, dial faces buried in the cluster box, start button hidden behind the tach, and stale animator refs after vehicle swaps.

### Round 3 — Center display: connected-cockpit infotainment screen
- New `CenterDisplay`: curved screen with a live throttled CanvasTexture cycling NAVIGATION (location + animated compass ribbon), MEDIA (real radio state + equalizer), and TRIP COMPUTER (live speed/RPM, integrating odometer/drive time); click-to-cycle through the existing raycast helper.
- Physical-glass overlay picks up the `PanoEnvironment` PMREM IBL so the street view reflects off the surface with Fresnel falloff; accent frame supplies the bezel inner glow; emissive-mapped screen feeds the bloom pass when post-FX is on.

### Round 4 — Dynamic cabin lighting
- **Sun shafts / god rays**: new `SunShafts` hangs additive gradient cards from each side window, leaned to the real sun's descent angle (SunCalc altitude, already flowing via `useAutoNight` → `useCabinEnvironment` → `setCarSunPosition`). They appear only in the low-sun band (~1–25° altitude) and **only on the side the sun actually shines through** (sun azimuth resolved against the live car heading), with slow drift/flicker for life. Performance-friendly by construction: zero added lights — four transparent quads sharing one geometry and texture; skipped on low quality and static under `prefers-reduced-motion`.
- **State-driven accent & button backlighting**: a cabin glow registry in `MaterialFactory` — every accent trim material plus the newly amber-backlit center-stack buttons, hazard, and start button register a base intensity, and `CarInteriorLightingManager` scales them all with one call per frame. Trim and backlights brighten with night and with the headlights, and the registry resets on interior rebuilds so vehicle swaps never touch disposed materials.
- **Weather → interior light**: new `setCarWeather(0–1)` wired from the dashboard rain slider. Rain reads as overcast — direct sun collapses (×0.25 at full rain), diffuse fills dim gently, the sun shafts fade out, and the windshield droplet `RainSystem` engages automatically.
- **Ambient breathing**: ±2% slow sine on the hemisphere/ambient/dome targets, shared with the glow registry so the whole cabin swells as one; disabled under reduced motion.
- Sun intensity now eases per frame toward its weather-attenuated target instead of stepping on each 30 s SunCalc tick.

## Verification
- `tsc --noEmit` clean; test suite identical to `main` (2 pre-existing cesium-import failures, no regressions).
- Headless-Chromium harnesses each round. Lighting round asserts: west sun at 8° lights only the left shafts (0.124 vs 0.000), an east sun swaps sides, 50° sun kills them, full rain collapses them to 0.019; glow registry scales accent trim 0.20 (day) → 0.47 (night + headlights). Screenshot confirms golden-hour shafts through the left window with amber button backlights.
- Earlier rounds: gauge needle angles asserted against the painted dial scale; `VehicleDynamics` cruise/coast/reverse scenario in Node; all three display pages rendered with live data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTfS1d8M2dbZqpV5gu7XdX