### PR TITLE
Fix deploy error when build/index.html contains %PUBLIC_URL%

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -23,6 +23,7 @@ Requirements:
 import io
 import os
 import re
+import subprocess
 import sys
 import zipfile
 from pathlib import Path
@@ -47,20 +48,54 @@ def _is_placeholder(key: str) -> bool:
     return any(p.search(key) for p in _PLACEHOLDER_PATTERNS)
 
 
-def _validate_build_index(build_path: Path) -> None:
-    """Reject builds whose index.html looks like an unprocessed CRA template."""
+def _build_index_problems(build_path: Path) -> list[str]:
+    """Return deploy-blocking problems with build/index.html, if any."""
     index_html = build_path / "index.html"
     if not index_html.is_file():
-        print(f"\nERROR: {index_html} is missing. Run 'npm run build' first.")
-        sys.exit(1)
+        return ["build/index.html is missing"]
 
     content = index_html.read_text(encoding="utf-8", errors="replace")
     problems: list[str] = []
     if "%PUBLIC_URL%" in content:
-        problems.append("contains unprocessed %PUBLIC_URL% (public/index.html was deployed instead of build/index.html)")
+        problems.append(
+            "contains unprocessed %PUBLIC_URL% (public/index.html was deployed instead of build/index.html)"
+        )
     if "static/js/main" not in content:
         problems.append("does not reference static/js/main.*.js (React bundle will never load)")
+    return problems
 
+
+def _ensure_production_build(build_path: Path) -> None:
+    """Run npm run build when build/ is missing or still looks like public/ template."""
+    repo_root = Path(__file__).resolve().parent
+    needs_build = not build_path.is_dir()
+    problems: list[str] = []
+
+    if not needs_build:
+        problems = _build_index_problems(build_path)
+        needs_build = bool(problems)
+
+    if not needs_build:
+        return
+
+    reason = problems[0] if problems else "build/ directory is missing"
+    print(f"\n  build/ is not deployable ({reason}).")
+    print("  Running 'npm run build' to produce a production bundle...\n")
+    result = subprocess.run(
+        ["npm", "run", "build"],
+        cwd=repo_root,
+        env=os.environ.copy(),
+    )
+    if result.returncode != 0:
+        print("\nERROR: 'npm run build' failed. Fix build errors, then run deploy again.")
+        sys.exit(1)
+
+    print("\n  npm run build completed successfully.\n")
+
+
+def _validate_build_index(build_path: Path) -> None:
+    """Reject builds whose index.html looks like an unprocessed CRA template."""
+    problems = _build_index_problems(build_path)
     if problems:
         print("\n" + "!" * 70)
         print("  ERROR: build/index.html is not safe to deploy:")
@@ -176,12 +211,18 @@ def _inject_maps_key_into_bundle(data: bytes, key: str) -> bytes:
 def _repair_index_html(index_html: bytes, build_path: Path) -> bytes:
     """Ensure index.html references the CRA main.js bundle (not just public/ template)."""
     text = index_html.decode("utf-8", errors="replace")
+    changed = False
+    if "%PUBLIC_URL%" in text:
+        text = text.replace("%PUBLIC_URL%", ".")
+        changed = True
+        print("  ! index.html repaired — replaced leftover %PUBLIC_URL% with '.'")
+
     if "static/js/main" in text:
-        return index_html
+        return text.encode("utf-8") if changed else index_html
 
     manifest_path = build_path / "asset-manifest.json"
     if not manifest_path.is_file():
-        return index_html
+        return text.encode("utf-8") if changed else index_html
 
     import json
 
@@ -189,7 +230,7 @@ def _repair_index_html(index_html: bytes, build_path: Path) -> bytes:
     main_js = manifest.get("files", {}).get("main.js", "")
     main_css = manifest.get("files", {}).get("main.css", "")
     if not main_js:
-        return index_html
+        return text.encode("utf-8") if changed else index_html
 
     insert = ""
     if main_css and main_css not in text:
@@ -198,7 +239,7 @@ def _repair_index_html(index_html: bytes, build_path: Path) -> bytes:
         insert += f'<script defer="defer" src="{main_js}"></script>'
 
     if not insert:
-        return index_html
+        return text.encode("utf-8") if changed else index_html
 
     if "</head>" in text:
         repaired = text.replace("</head>", f"{insert}</head>", 1)
@@ -308,12 +349,9 @@ def main():
     print(f"\n=== Deploying '{PROJECT_NAME}' via Contabo -> {_site_host} (target={DEPLOY_TARGET}) ===\n")
 
     build_path = Path(BUILD_DIR)
-    if not build_path.exists() or not build_path.is_dir():
-        print(f"ERROR: Build directory '{BUILD_DIR}/' does not exist.")
-        print("Please run your build command first (e.g. `npm run build`).")
-        sys.exit(1)
 
     # --- Pre-deploy build + Maps key validation ---
+    _ensure_production_build(build_path)
     print("Checking build/index.html...")
     _validate_build_index(build_path)
     print("Checking Maps API key...")

--- a/public/config.js.example
+++ b/public/config.js.example
@@ -3,7 +3,7 @@
 // Copy this to `config.js` (gitignored in practice via deployment) and fill in your key,
 // OR (recommended for production) let `deploy.py` generate it by setting MAPS_API_KEY.
 //
-// This file is loaded via <script src="%PUBLIC_URL%/config.js"> in index.html
+// This file is loaded via <script src="./config.js"> in index.html
 // BEFORE the React bundle, so the key is available to the earliest module code.
 //
 // For the official demo hosts, create a single key with multiple referrer patterns:

--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
     <script>
       (function loadRuntimeMapsConfig() {
         var script = document.createElement('script');
-        script.src = '%PUBLIC_URL%/config.js';
+        script.src = './config.js';
         script.onload = function () {
           window.dispatchEvent(new CustomEvent('maps-api-key-ready'));
         };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`python deploy.py` fails with:

```
ERROR: build/index.html is not safe to deploy:
  - contains unprocessed %PUBLIC_URL% (public/index.html was deployed instead of build/index.html)
```

This happens when `build/` is missing or stale — e.g. `public/index.html` was copied instead of running `npm run build`.

## Solution

1. **`public/index.html`**: Use `./config.js` instead of `%PUBLIC_URL%/config.js` in the inline runtime config loader. With `homepage: "."` this is equivalent and avoids leaving CRA placeholders in the source template.

2. **`deploy.py`**: Auto-run `npm run build` when:
   - `build/` is missing, or
   - `build/index.html` still contains `%PUBLIC_URL%`, or
   - `build/index.html` does not reference `static/js/main.*.js`

3. **`deploy.py` zip repair**: Replace any leftover `%PUBLIC_URL%` with `.` as a belt-and-suspenders fallback during packaging.

## Testing

- Simulated stale `build/index.html` with `%PUBLIC_URL%` → `_ensure_production_build()` auto-rebuilds and validation passes
- Deleted `build/` entirely → auto-rebuild creates valid output
- `python3 -m py_compile deploy.py` passes

## Deploy

After merge, deploy as usual:

```bash
MAPS_API_KEY=AIzaSy... python deploy.py
```

`deploy.py` will now build automatically if needed, so a separate `npm run build` step is optional but still recommended for CI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e2ef973-73c0-4598-bf03-59c6843e20d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e2ef973-73c0-4598-bf03-59c6843e20d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

