### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run tests
+        run: npm test -- --watchAll=false
+
+      - name: Build
+        # CRA fails on pre-existing ESLint warnings when CI=true, so override
+        # the runner's default CI=true just for this step (build/build:wasm,
+        # patch-cesium-bundle.sh, and verify-build.sh all run as part of
+        # `npm run build` and any failure here blocks the merge).
+        run: npm run build
+        env:
+          CI: false

--- a/.github/workflows/nightly-probe.yml
+++ b/.github/workflows/nightly-probe.yml
@@ -1,0 +1,49 @@
+name: Nightly hold-pause probe
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  hold-pause-probe:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'ford442/webgpu_streetview' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+
+      - name: Start dev server
+        run: npm start &
+        env:
+          REACT_APP_MAPS_API_KEY: ${{ secrets.REACT_APP_MAPS_API_KEY }}
+          BROWSER: none
+
+      - name: Wait for dev server
+        run: |
+          for i in $(seq 1 60); do
+            curl -sf http://localhost:3000 > /dev/null && exit 0
+            sleep 2
+          done
+          echo "Dev server did not become ready in time" >&2
+          exit 1
+
+      - name: Run hold-pause probe
+        run: npm run probe:hold-pause
+        env:
+          REACT_APP_MAPS_API_KEY: ${{ secrets.REACT_APP_MAPS_API_KEY }}
+
+      - name: Upload probe screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hold-pause-probe-screenshots
+          path: repro-screenshots/hold-pause-probe/
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 A high-performance Google Maps Street View viewer with an immersive 3D car interior experience, built with React 19, WebGPU, and Three.js.
 
+[![CI](https://github.com/ford442/webgpu_streetview/actions/workflows/ci.yml/badge.svg)](https://github.com/ford442/webgpu_streetview/actions/workflows/ci.yml)
 [![React](https://img.shields.io/badge/React-19.1.1-61DAFB?logo=react)](https://react.dev/)
 [![WebGPU](https://img.shields.io/badge/WebGPU-Latest-FF6B00)](https://gpuweb.github.io/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-4.9-3178C6?logo=typescript)](https://www.typescriptlang.org/)

--- a/docs/DEPLOY_CHECKLIST.md
+++ b/docs/DEPLOY_CHECKLIST.md
@@ -91,7 +91,14 @@ These open issues capture the symptoms and remaining engineering work:
 
 See the comments on each for the latest codebase status and partial fixes (reactive key poller, init guard reset, deploy.py injection support, etc.).
 
-## 8. One-time / periodic
+## 8. CI (GitHub Actions)
+
+- `.github/workflows/ci.yml` runs on every push/PR to `main`: `npm ci`, `npm test -- --watchAll=false`, then `npm run build` (which chains `build:wasm`, `patch-cesium-bundle.sh`, and `verify-build.sh`). No secrets are required for this job — it never touches a real Maps key.
+- `.github/workflows/nightly-probe.yml` runs `npm run probe:hold-pause` against a real dev server on a daily schedule (and via manual dispatch). This job needs a repository secret:
+  - **`REACT_APP_MAPS_API_KEY`** — a Maps key with `http://localhost:3000/*` (or whatever CI runner host) in its referrer allowlist. Without it the probe reports "Street View imagery did not render" rather than false-passing (see `scripts/hold-pause-probe.mjs`).
+- Configure secrets under Settings → Secrets and variables → Actions on the repo.
+
+## 9. One-time / periodic
 
 - [ ] Rotate the production key every 90 days (create new restricted key, deploy with it, delete old).
 - [ ] Review the GCP project's enabled APIs and billing monthly.


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml`: runs `npm ci`, `npm test -- --watchAll=false`, and `npm run build` on every push/PR to `main`. The build step chains `build:wasm`, `patch-cesium-bundle.sh`, and `verify-build.sh`, so failures in any of those (e.g. a Cesium `import.meta` regression) fail the check. Overrides the runner's default `CI=true` to `false` for the build step only, since CRA otherwise treats pre-existing ESLint warnings as build errors.
- Adds `.github/workflows/nightly-probe.yml`: optional daily (+ manual dispatch) job that boots the dev server and runs `npm run probe:hold-pause` (the hold-pause regression guard), gated on a `REACT_APP_MAPS_API_KEY` repo secret since it needs real Street View imagery to render. Uploads probe screenshots as an artifact.
- Documents the new `REACT_APP_MAPS_API_KEY` secret requirement in `docs/DEPLOY_CHECKLIST.md`.
- Adds a CI status badge to `README.md`.

## Test plan
- [x] Validated both workflow YAML files parse correctly (`yaml.safe_load`)
- [ ] Confirm the `test-and-build` job goes green on this PR
- [ ] Confirm `npm run build` succeeds in the Actions runner with `CI: false`
- [ ] (Follow-up, separate issue) Fix the 2 currently-failing test suites noted in the original CI-setup issue so `test-and-build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PDGibWE81cG6iRqAQ1an2q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated continuous integration checks for tests and production builds.
  * Added a nightly and on-demand browser probe with screenshot artifact capture.
* **Documentation**
  * Added a CI status badge to the README.
  * Expanded the deployment checklist with CI workflow details and required configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->