### PR TITLE
TypeScript target ES2020 + strict unused/index-access checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       # aren't usable here.
       - run: npm install
 
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Run tests
         run: npm test -- --watchAll=false
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "build:wasm": "bash scripts/build-wasm.sh",
     "build:wasm:watch": "bash scripts/build-wasm.sh --wat-only && echo 'Run npm run build:wasm to rebuild after changes.'",
     "test": "react-scripts test",
+    "typecheck": "tsc --noEmit",
     "eject": "react-scripts eject",
     "validate:maps-key": "node -e \"\nconst k=process.env.REACT_APP_MAPS_API_KEY||''; const bad=!k||/placeholder|your_|replace/i.test(k);\nconsole.log(bad ? '❌ Key missing or placeholder' : '✅ Key looks configured ('+k.length+' chars)');\nprocess.exit(bad?1:0);\n\"",
     "probe:hold-pause": "node scripts/hold-pause-probe.mjs"

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import App from './App';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import StreetView, { type MapsLoadStatus } from './components/StreetView';
 import WelcomeModal from './components/WelcomeModal';
 import type { RendererBackendType } from './renderer/RendererBackend';
@@ -101,7 +101,7 @@ if (!INITIAL_MAPS_KEY) {
  */
 function InnerApp() {
   // Connect to contexts
-  const { setCanvas, setPanorama, panorama, heading, pitch, canvas, advance, isTransitioning, isPanoramaReady } = useStreetView();
+  const { setCanvas, setPanorama, panorama, heading, pitch, canvas, isTransitioning, isPanoramaReady } = useStreetView();
   const { advanceSafe, teleportSafe, panoCache } = useAdvanceSafe();
   const { viewMode, toggleViewMode } = useViewMode();
   const {
@@ -764,7 +764,7 @@ function InnerApp() {
                 const pos = panorama.getPosition();
                 return pos ? { lat: pos.lat(), lng: pos.lng() } : { lat: 0, lng: 0 };
               })()}
-              onTeleport={(lat, lng, h, p) => {
+              onTeleport={(_lat, _lng, _h, _p) => {
                 // Teleport via StreetView context
               }}
               onAddBookmark={handleAddBookmark}

--- a/src/audio/AudioAnalyzer.ts
+++ b/src/audio/AudioAnalyzer.ts
@@ -164,28 +164,29 @@ export class AudioAnalyzer {
       highMid = 0,
       high = 0;
 
+    // All loop bounds below are <= totalBins === this.dataArray.length.
     for (let i = 0; i < bassBins; i++) {
-      bass += this.dataArray[i];
+      bass += this.dataArray[i]!;
     }
     bass /= Math.max(1, bassBins) * 255;
 
     for (let i = bassBins; i < lowMidBins; i++) {
-      lowMid += this.dataArray[i];
+      lowMid += this.dataArray[i]!;
     }
     lowMid /= Math.max(1, lowMidBins - bassBins) * 255;
 
     for (let i = lowMidBins; i < midBins; i++) {
-      mid += this.dataArray[i];
+      mid += this.dataArray[i]!;
     }
     mid /= Math.max(1, midBins - lowMidBins) * 255;
 
     for (let i = midBins; i < highMidBins; i++) {
-      highMid += this.dataArray[i];
+      highMid += this.dataArray[i]!;
     }
     highMid /= Math.max(1, highMidBins - midBins) * 255;
 
     for (let i = highMidBins; i < totalBins; i++) {
-      high += this.dataArray[i];
+      high += this.dataArray[i]!;
     }
     high /= Math.max(1, totalBins - highMidBins) * 255;
 

--- a/src/car/CarInterior.ts
+++ b/src/car/CarInterior.ts
@@ -50,8 +50,6 @@ export class CarInterior {
     /** User seat-distance offset (metres) added to the config eye position along +Z (dolly back). */
     private seatOffset: number = 0;
     private steeringWheelGroup!: THREE.Group;
-    private leftMirrorPlane!: THREE.Mesh;
-    private rightMirrorPlane!: THREE.Mesh;
     private wiperLeft!: THREE.Group;
     private wiperRight!: THREE.Group;
     private speedometerNeedle!: THREE.Mesh;
@@ -76,8 +74,6 @@ export class CarInterior {
 
     // Digital Clock
     private digitalClockMesh: THREE.Mesh | null = null;
-    private clockCanvas: HTMLCanvasElement | null = null;
-    private clockCtx: CanvasRenderingContext2D | null = null;
     private clockUpdateInterval?: number;
 
     // Location readout dash panel (road/area, coords, heading, capture date)
@@ -94,16 +90,9 @@ export class CarInterior {
     private lastSunAzimuth: number = 0;
     private lastSunAltitude: number = -1;
 
-    private isActive: boolean = true;
-
     private isRoofOpen: boolean = false;
     private roofTargetY: number = 0;
     private animationId: number = 0;
-    private steeringAngle: number = 0;
-    private wiperAnimationTime: number = 0;
-    private isWiperActive: boolean = false;
-    private speedometer: number = 0; // 0-100 km/h
-    private tachometer: number = 0; // 0-8000 RPM
     private interaction: InteractionHelper;
     private reducedMotion: boolean;
     private geometryFactory: GeometryFactory;
@@ -426,8 +415,6 @@ export class CarInterior {
         this.steeringWheelGroup = buildResult.steeringWheelGroup;
         this.wiperLeft = buildResult.wiperLeft;
         this.wiperRight = buildResult.wiperRight;
-        this.leftMirrorPlane = buildResult.leftMirrorPlane;
-        this.rightMirrorPlane = buildResult.rightMirrorPlane;
         this.windshieldGlassMesh = buildResult.windshieldGlassMesh;
         this.rearGlassMesh = buildResult.rearGlassMesh;
         this.instrumentClusterMat = buildResult.instrumentClusterMat;
@@ -450,8 +437,6 @@ export class CarInterior {
             this.tachometerNeedle = gaugeResult.tachometerNeedle;
             this.gaugeRig = gaugeResult.gaugeRig ?? null;
             this.digitalClockMesh = gaugeResult.digitalClockMesh ?? null;
-            this.clockCanvas = gaugeResult.clockCanvas ?? null;
-            this.clockCtx = gaugeResult.clockCtx ?? null;
             this.clockUpdateInterval = gaugeResult.clockUpdateInterval;
         }
 

--- a/src/car/Controls.tsx
+++ b/src/car/Controls.tsx
@@ -56,7 +56,7 @@ export {
   TEMP_ICON,
 } from './ui/icons';
 
-export default {
+const controlsUI = {
   IconButton,
   Slider,
   ToggleGroup,
@@ -66,3 +66,5 @@ export default {
   Divider,
   injectSliderStyles,
 };
+
+export default controlsUI;

--- a/src/car/DashboardLayout.tsx
+++ b/src/car/DashboardLayout.tsx
@@ -7,7 +7,7 @@
  * this file contains only component structure and event handling.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import styles from './DashboardLayout.module.css';
 
 // ============================================================================

--- a/src/car/DashboardUI.tsx
+++ b/src/car/DashboardUI.tsx
@@ -21,8 +21,6 @@ import {
   SliderControl,
   ButtonRow,
   Label,
-  Value,
-  Unit,
 } from './DashboardLayout';
 
 // Gauge components
@@ -38,11 +36,7 @@ import {
   HEADLIGHT_ICON,
   HIGHBEAM_ICON,
   DOME_ICON,
-  SNOW_ICON,
-  RAIN_ICON,
-  WIND_ICON,
   VEHICLE_ICON,
-  TINT_ICON,
 } from './Controls';
 
 // ============================================================================

--- a/src/car/Gauges.tsx
+++ b/src/car/Gauges.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react';
+import React, { useEffect, useRef, useState, useMemo } from 'react';
 import styles from './Gauges.module.css';
 
 // ============================================================================

--- a/src/car/RearviewMirror.ts
+++ b/src/car/RearviewMirror.ts
@@ -31,7 +31,7 @@ export class RearviewMirror {
     private static readonly MIRROR_HEIGHT = 256;
 
     constructor(
-        private scene: THREE.Scene,
+        scene: THREE.Scene,
         private renderer: THREE.WebGLRenderer
     ) {
         // Create render target for the mirror
@@ -160,7 +160,7 @@ export class RearviewMirror {
      * Update mirror view based on car heading.
      * The mirror shows the view 180° behind the car.
      */
-    public updateOrientation(carHeading: number, headPitch: number): void {
+    public updateOrientation(_carHeading: number, _headPitch: number): void {
         // Mirror shows the view from behind the car (180° offset)
         // We don't actually rotate the camera - we just use the texture offset
         // The mirror always shows "behind" relative to car heading
@@ -208,7 +208,7 @@ export class RearviewMirror {
      */
     public toggleNightMode(): void {
         this.isNightMode = !this.isNightMode;
-        this.mirrorMaterial.uniforms.nightMode.value = this.isNightMode ? 1.0 : 0.0;
+        this.mirrorMaterial.uniforms.nightMode!.value = this.isNightMode ? 1.0 : 0.0;
     }
 
     /**

--- a/src/car/VehicleDynamics.ts
+++ b/src/car/VehicleDynamics.ts
@@ -88,9 +88,9 @@ export class VehicleDynamics {
 
         // Gearbox: find the band, run RPM up within it, drop on shift.
         let gearNum = 1;
-        while (gearNum < SHIFT_POINTS.length && this.speed > SHIFT_POINTS[gearNum]) gearNum++;
-        const lo = SHIFT_POINTS[gearNum - 1];
-        const hi = gearNum < SHIFT_POINTS.length ? SHIFT_POINTS[gearNum] : MAX_SPEED_KMH;
+        while (gearNum < SHIFT_POINTS.length && this.speed > SHIFT_POINTS[gearNum]!) gearNum++;
+        const lo = SHIFT_POINTS[gearNum - 1]!;
+        const hi = gearNum < SHIFT_POINTS.length ? SHIFT_POINTS[gearNum]! : MAX_SPEED_KMH;
         const bandFrac = Math.min(1, (this.speed - lo) / (hi - lo));
         const targetRpm = this.speed < 0.5
             ? IDLE_RPM

--- a/src/car/VehicleManager.ts
+++ b/src/car/VehicleManager.ts
@@ -134,7 +134,7 @@ export function getNextVehicle(current: VehicleType): VehicleType {
     const types = Object.keys(VEHICLES) as VehicleType[];
     const currentIndex = types.indexOf(current);
     const nextIndex = (currentIndex + 1) % types.length;
-    return types[nextIndex];
+    return types[nextIndex]!;
 }
 
 /**
@@ -144,7 +144,7 @@ export function getPreviousVehicle(current: VehicleType): VehicleType {
     const types = Object.keys(VEHICLES) as VehicleType[];
     const currentIndex = types.indexOf(current);
     const prevIndex = (currentIndex - 1 + types.length) % types.length;
-    return types[prevIndex];
+    return types[prevIndex]!;
 }
 
 /**

--- a/src/car/interior/CarInteriorAnimator.ts
+++ b/src/car/interior/CarInteriorAnimator.ts
@@ -4,7 +4,6 @@ import { RainSystem } from './RainSystem';
 import { DustMoteSystem } from './DustMoteSystem';
 import { WindowWeatherOverlay } from './WindowWeatherOverlay';
 import { InteriorMicroInteractions } from './InteriorMicroInteractions';
-import { CarInteriorGauges } from './CarInteriorGauges';
 import {
     GaugeRig,
     needleAngle,
@@ -51,9 +50,7 @@ export class CarInteriorAnimator {
   private targetSpeed: number = 0;
   private targetRpm: number = 0;
   private speedFrac: number = 0;
-  private speedVel: number = 0;
   private rpmFrac: number = 0;
-  private rpmVel: number = 0;
   private fuelLevel: number = 0.85;
   private tempFrac: number = 0.05;
   private gaugeClock: number = 0;
@@ -104,10 +101,10 @@ export class CarInteriorAnimator {
     this.microInteractions?.update(deltaTime);
 
     if (this.cupLiquidMaterial) {
-      this.cupLiquidMaterial.uniforms.time.value = this.ambientTime;
+      this.cupLiquidMaterial.uniforms.time!.value = this.ambientTime;
       const targetSlosh = THREE.MathUtils.clamp(carSpeedKmh / 45, 0, 1);
       this.cupSlosh += (targetSlosh - this.cupSlosh) * Math.min(deltaTime * 4, 1);
-      this.cupLiquidMaterial.uniforms.slosh.value = this.cupSlosh;
+      this.cupLiquidMaterial.uniforms.slosh!.value = this.cupSlosh;
     }
 
     this.syncWindAudio();
@@ -189,7 +186,6 @@ export class CarInteriorAnimator {
       if (this.reducedMotion) {
         this.speedFrac = speedTargetFrac;
         this.rpmFrac = rpmTargetFrac;
-        this.speedVel = this.rpmVel = 0;
         rig.speedNeedle.rotation.z = needleAngle(this.speedFrac);
         rig.tachoNeedle.rotation.z = needleAngle(this.rpmFrac);
       } else {

--- a/src/car/interior/CarInteriorBuilder.ts
+++ b/src/car/interior/CarInteriorBuilder.ts
@@ -392,7 +392,7 @@ export class CarInteriorBuilder {
 
     private buildWindshieldGlass(): void {
         const geometry = new THREE.PlaneGeometry(1.9, 0.75, 16, 8);
-        const pos = geometry.attributes.position;
+        const pos = geometry.attributes.position!;
         for (let i = 0; i < pos.count; i++) {
             const x = pos.getX(i);
             const y = pos.getY(i);

--- a/src/car/interior/CarInteriorGauges.ts
+++ b/src/car/interior/CarInteriorGauges.ts
@@ -53,7 +53,7 @@ const DIAL_SWEEP = Math.PI * 1.5;
 export class CarInteriorGauges {
     static build(
         interiorGroup: THREE.Group,
-        metalMaterial: THREE.MeshStandardMaterial,
+        _metalMaterial: THREE.MeshStandardMaterial,
         vehicleConfig: { accentColor: string },
         gpuProfile: { name: string },
         quality: 'high' | 'medium' | 'low'
@@ -135,7 +135,7 @@ export class CarInteriorGauges {
 
             if (isMajor) {
                 const labelRadius = r - size * 0.16;
-                const label = spec.majorLabels[i / spec.minorTicksPerMajor];
+                const label = spec.majorLabels[i / spec.minorTicksPerMajor]!;
                 ctx.fillStyle = inRedline ? '#ff6060' : 'rgba(255,255,255,0.85)';
                 ctx.font = `bold ${Math.round(size * 0.09)}px "Arial Narrow", Arial, sans-serif`;
                 ctx.textAlign = 'center';
@@ -215,7 +215,7 @@ export class CarInteriorGauges {
 
     private static buildGauges(
         interiorGroup: THREE.Group,
-        vehicleConfig: { accentColor: string },
+        _vehicleConfig: { accentColor: string },
         gpuProfile: { name: string },
         quality: 'high' | 'medium' | 'low'
     ): { speedometerNeedle: THREE.Mesh; tachometerNeedle: THREE.Mesh; gaugeRig: GaugeRig } {

--- a/src/car/interior/CarInteriorRenderer.ts
+++ b/src/car/interior/CarInteriorRenderer.ts
@@ -21,7 +21,7 @@ export class CarInteriorRenderer {
         }
     }
 
-    public setTargetFPS(fps: number): void {
+    public setTargetFPS(_fps: number): void {
         // Frame limiting is handled by the caller; this is a no-op placeholder
         // for future frame-rate capping integration.
     }

--- a/src/car/interior/CarInteriorSeatBuilder.ts
+++ b/src/car/interior/CarInteriorSeatBuilder.ts
@@ -7,7 +7,7 @@ export class CarInteriorSeatBuilder {
     constructor(
         private interiorGroup: THREE.Group,
         private materials: CarInteriorMaterials,
-        private vehicleConfig: VehicleConfig,
+        _vehicleConfig: VehicleConfig,
         private quality: 'high' | 'medium' | 'low',
         private geometryFactory: GeometryFactory
     ) {}
@@ -86,6 +86,7 @@ export class CarInteriorSeatBuilder {
 
         const driverCenterGeo = new THREE.PlaneGeometry(0.22, 0.45, 5, 9);
         const pos = driverCenterGeo.attributes.position;
+        if (!pos) return;
         for (let i = 0; i < pos.count; i++) {
             const x = pos.getX(i);
             const y = pos.getY(i);
@@ -103,6 +104,7 @@ export class CarInteriorSeatBuilder {
 
         const driverBottomCenterGeo = new THREE.PlaneGeometry(0.22, 0.35, 5, 7);
         const posB = driverBottomCenterGeo.attributes.position;
+        if (!posB) return;
         for (let i = 0; i < posB.count; i++) {
             const x = posB.getX(i);
             const y = posB.getY(i);
@@ -120,6 +122,7 @@ export class CarInteriorSeatBuilder {
 
         const passCenterGeo = new THREE.PlaneGeometry(0.22, 0.45, 5, 9);
         const posP = passCenterGeo.attributes.position;
+        if (!posP) return;
         for (let i = 0; i < posP.count; i++) {
             const x = posP.getX(i);
             const y = posP.getY(i);
@@ -137,6 +140,7 @@ export class CarInteriorSeatBuilder {
 
         const passBottomCenterGeo = new THREE.PlaneGeometry(0.22, 0.35, 5, 7);
         const posPB = passBottomCenterGeo.attributes.position;
+        if (!posPB) return;
         for (let i = 0; i < posPB.count; i++) {
             const x = posPB.getX(i);
             const y = posPB.getY(i);

--- a/src/car/interior/CenterDisplay.ts
+++ b/src/car/interior/CenterDisplay.ts
@@ -61,7 +61,6 @@ export class CenterDisplay {
         this.texture.anisotropy = gpuProfileName === 'high' ? 8 : 4;
         this.texture.colorSpace = THREE.SRGBColorSpace;
 
-        const accentHex = parseInt(this.accent.replace('#', '0x')) || 0x00ffcc;
         this.screenMat = new THREE.MeshStandardMaterial({
             map: this.texture,
             emissive: new THREE.Color(0xffffff),
@@ -115,7 +114,7 @@ export class CenterDisplay {
     /** Plane with a gentle horizontal bulge toward +Z. */
     private static curvedPlane(w: number, h: number, depth: number): THREE.PlaneGeometry {
         const geo = new THREE.PlaneGeometry(w, h, 24, 1);
-        const pos = geo.attributes.position;
+        const pos = geo.attributes.position!;
         const half = w / 2;
         for (let i = 0; i < pos.count; i++) {
             const nx = pos.getX(i) / half;
@@ -167,7 +166,7 @@ export class CenterDisplay {
 
     /** Advance to the next page; returns the new page. */
     cyclePage(): DisplayPage {
-        this.page = PAGES[(PAGES.indexOf(this.page) + 1) % PAGES.length];
+        this.page = PAGES[(PAGES.indexOf(this.page) + 1) % PAGES.length]!;
         this.render(true);
         return this.page;
     }
@@ -369,7 +368,7 @@ export class CenterDisplay {
             ctx.lineTo(x, ribbonY + (isCardinal ? 18 : 10));
             ctx.stroke();
             if (isCardinal) {
-                this.glowText('NESW'[Math.round(norm / 90) % 4], x, ribbonY - 8, 24, 'center');
+                this.glowText('NESW'[Math.round(norm / 90) % 4]!, x, ribbonY - 8, 24, 'center');
             }
         }
         ctx.restore();

--- a/src/car/interior/DustMoteSystem.ts
+++ b/src/car/interior/DustMoteSystem.ts
@@ -73,10 +73,10 @@ export class DustMoteSystem {
     const t = time * 0.35;
 
     for (let i = 0; i < this.count; i++) {
-      const phase = this.phases[i];
-      const bx = this.basePositions[i * 3];
-      const by = this.basePositions[i * 3 + 1];
-      const bz = this.basePositions[i * 3 + 2];
+      const phase = this.phases[i]!;
+      const bx = this.basePositions[i * 3]!;
+      const by = this.basePositions[i * 3 + 1]!;
+      const bz = this.basePositions[i * 3 + 2]!;
       attr.setXYZ(
         i,
         bx + Math.sin(t + phase) * 0.04,

--- a/src/car/interior/InteriorMicroInteractions.ts
+++ b/src/car/interior/InteriorMicroInteractions.ts
@@ -65,7 +65,7 @@ export class InteriorMicroInteractions {
     clientY: number,
     rect: DOMRect,
     camera: THREE.Camera,
-    root: THREE.Object3D
+    _root: THREE.Object3D
   ): InteriorInteractive | null {
     for (const item of this.items) {
       if (this.raycaster.hitTest(clientX, clientY, rect, camera, item.mesh, false)) {
@@ -108,7 +108,7 @@ export class InteriorMicroInteractions {
     return false;
   }
 
-  handlePointerMove(clientX: number, clientY: number): boolean {
+  handlePointerMove(clientX: number, _clientY: number): boolean {
     if (!this.activeDrag || this.activeDrag.interactive.kind !== 'knob') return false;
     const { interactive, startClientX, startRotation } = this.activeDrag;
     const delta = (clientX - startClientX) * 0.008;

--- a/src/car/interior/LODManager.ts
+++ b/src/car/interior/LODManager.ts
@@ -10,7 +10,6 @@ import { FrustumCuller } from '../../utils/performance';
 export class LODManager {
   private instances = new Map<string, THREE.InstancedMesh>();
   private detailMeshes: THREE.Mesh[] = [];
-  private dummy = new THREE.Object3D();
   private frustumCuller: FrustumCuller;
 
   constructor(frustumCuller: FrustumCuller) {

--- a/src/car/interior/MaterialFactory.ts
+++ b/src/car/interior/MaterialFactory.ts
@@ -40,7 +40,7 @@ function normalMapFromHeight(
     const img = ctx.createImageData(size, size);
     const d = img.data;
     const h = (x: number, y: number) =>
-      height[((y + size) % size) * size + ((x + size) % size)];
+      height[((y + size) % size) * size + ((x + size) % size)]!;
     for (let y = 0; y < size; y++) {
       for (let x = 0; x < size; x++) {
         const dx =

--- a/src/car/interior/RainSystem.ts
+++ b/src/car/interior/RainSystem.ts
@@ -72,20 +72,20 @@ export class RainSystem {
     const dt = Math.min(deltaTime, 0.1);
     for (let i = 0; i < this.count; i++) {
       // Slide down
-      this.positions[i * 3 + 1] -= this.velocities[i] * dt;
+      this.positions[i * 3 + 1]! -= this.velocities[i]! * dt;
 
       // Slight horizontal wiggle
-      this.positions[i * 3] += Math.sin(i * 7.3 + performance.now() * 0.001) * 0.0002;
+      this.positions[i * 3]! += Math.sin(i * 7.3 + performance.now() * 0.001) * 0.0002;
 
       // Reset if below windshield
-      if (this.positions[i * 3 + 1] < -0.3) {
+      if (this.positions[i * 3 + 1]! < -0.3) {
         this.resetDrop(i);
       }
 
       this.dummy.position.set(
-        this.positions[i * 3],
-        this.positions[i * 3 + 1],
-        this.positions[i * 3 + 2]
+        this.positions[i * 3]!,
+        this.positions[i * 3 + 1]!,
+        this.positions[i * 3 + 2]!
       );
       this.dummy.updateMatrix();
       this.mesh.setMatrixAt(i, this.dummy.matrix);
@@ -101,9 +101,9 @@ export class RainSystem {
     this.velocities[i] = 0.08 + Math.random() * 0.15;
 
     this.dummy.position.set(
-      this.positions[i * 3],
-      this.positions[i * 3 + 1],
-      this.positions[i * 3 + 2]
+      this.positions[i * 3]!,
+      this.positions[i * 3 + 1]!,
+      this.positions[i * 3 + 2]!
     );
     this.dummy.updateMatrix();
     this.mesh.setMatrixAt(i, this.dummy.matrix);

--- a/src/car/interior/VanityMirror.ts
+++ b/src/car/interior/VanityMirror.ts
@@ -20,7 +20,7 @@ export class VanityMirror {
   private static readonly HEIGHT = 160;
 
   constructor(
-    private readonly scene: THREE.Scene,
+    _scene: THREE.Scene,
     private readonly renderer: THREE.WebGLRenderer,
     mirrorPlane: THREE.Mesh
   ) {

--- a/src/car/interior/WindowWeatherOverlay.ts
+++ b/src/car/interior/WindowWeatherOverlay.ts
@@ -31,25 +31,25 @@ export class WindowWeatherOverlay {
 
   setWeather(rainNorm: number, fogNorm: number, humidity = 0): void {
     const u = this.material.uniforms;
-    u.rainIntensity.value = Math.max(0, Math.min(1, rainNorm));
+    u.rainIntensity!.value = Math.max(0, Math.min(1, rainNorm));
     const condensation = Math.max(0, Math.min(1, fogNorm * 0.65 + humidity * 0.35 + rainNorm * 0.15));
-    u.condensation.value = condensation;
+    u.condensation!.value = condensation;
     this.mesh.visible = rainNorm > 0.02 || condensation > 0.04;
   }
 
   setWipersActive(active: boolean, phase: number): void {
     const u = this.material.uniforms;
-    u.wiperActive.value = active;
+    u.wiperActive!.value = active;
     this.wiperPhase = phase;
-    u.wiperPhase.value = phase;
+    u.wiperPhase!.value = phase;
   }
 
   update(deltaTime: number): void {
     const u = this.material.uniforms;
-    u.time.value += deltaTime;
-    if (u.wiperActive.value) {
+    u.time!.value += deltaTime;
+    if (u.wiperActive!.value) {
       this.wiperPhase = (this.wiperPhase + deltaTime * 0.55) % 1;
-      u.wiperPhase.value = this.wiperPhase;
+      u.wiperPhase!.value = this.wiperPhase;
     }
   }
 

--- a/src/car/ui/AudioVisualizer.tsx
+++ b/src/car/ui/AudioVisualizer.tsx
@@ -46,7 +46,7 @@ export const AudioVisualizer: React.FC<AudioVisualizerProps> = React.memo(
       const barW = width / barCount - 2;
 
       for (let i = 0; i < barCount; i++) {
-        const v = data[i * step] / 255;
+        const v = data[i * step]! / 255;
         const h = Math.max(2, v * (height - 4));
         const x = i * (barW + 2);
         const y = height - h;

--- a/src/car/variants/ConvertibleMode.ts
+++ b/src/car/variants/ConvertibleMode.ts
@@ -87,26 +87,28 @@ export class WindParticleSystem {
     // Update wind speed based on car speed
     this.windSpeed = Math.max(10, carSpeed * 2);
 
-    const positions = this.particleGeometry.attributes.position.array as Float32Array;
+    const positionAttr = this.particleGeometry.attributes.position;
+    if (!positionAttr) return;
+    const positions = positionAttr.array as Float32Array;
 
     for (let i = 0; i < this.particleCount; i++) {
       const i3 = i * 3;
 
       // Update position based on velocity
-      positions[i3] += this.velocities[i3] * deltaTime;
-      positions[i3 + 1] += this.velocities[i3 + 1] * deltaTime;
-      positions[i3 + 2] += this.velocities[i3 + 2] * deltaTime;
+      positions[i3] = (positions[i3] ?? 0) + (this.velocities[i3] ?? 0) * deltaTime;
+      positions[i3 + 1] = (positions[i3 + 1] ?? 0) + (this.velocities[i3 + 1] ?? 0) * deltaTime;
+      positions[i3 + 2] = (positions[i3 + 2] ?? 0) + (this.velocities[i3 + 2] ?? 0) * deltaTime;
 
       // Decrease lifetime
-      this.lifetimes[i] -= deltaTime;
+      this.lifetimes[i] = (this.lifetimes[i] ?? 0) - deltaTime;
 
       // Reset if expired or passed the cabin
-      if (this.lifetimes[i] <= 0 || positions[i3 + 2] > 2) {
+      if ((this.lifetimes[i] ?? 0) <= 0 || (positions[i3 + 2] ?? 0) > 2) {
         this.resetParticle(i);
       }
     }
 
-    this.particleGeometry.attributes.position.needsUpdate = true;
+    positionAttr.needsUpdate = true;
   }
 
   /**
@@ -291,11 +293,9 @@ export class SportDashboard {
  * SportSeats - Sport bucket seats for convertible mode
  */
 export class SportSeats {
-  private interiorGroup: THREE.Group;
   private seatsGroup: THREE.Group;
 
-  constructor(interiorGroup: THREE.Group) {
-    this.interiorGroup = interiorGroup;
+  constructor(_interiorGroup: THREE.Group) {
     this.seatsGroup = new THREE.Group();
     this.buildSportSeats();
   }
@@ -405,15 +405,12 @@ type LocalVehicleType = VehicleType;
  * ConvertibleMode - Main class for managing convertible vehicle mode
  */
 export class ConvertibleMode {
-  private scene: THREE.Scene;
   private interiorGroup: THREE.Group;
   private roofGroup: THREE.Group;
   private windParticles: WindParticleSystem;
   private convertibleInterior: ConvertibleInterior;
   private sportDashboard: SportDashboard;
   private sportSeats: SportSeats;
-  private standardSeats: THREE.Group | null = null;
-  private standardDashboard: THREE.Group | null = null;
 
   private state: ConvertibleState = {
     isOpen: true,
@@ -429,7 +426,6 @@ export class ConvertibleMode {
     interiorGroup: THREE.Group,
     roofGroup: THREE.Group
   ) {
-    this.scene = scene;
     this.interiorGroup = interiorGroup;
     this.roofGroup = roofGroup;
 

--- a/src/car/variants/LimousineMode.ts
+++ b/src/car/variants/LimousineMode.ts
@@ -50,13 +50,7 @@ export class LimousineMode {
     private screensGroup: THREE.Group;
 
     // Materials
-    private luxuryLeatherMaterial!: THREE.MeshStandardMaterial;
-    private woodMaterial!: THREE.MeshStandardMaterial;
-    private chromeMaterial!: THREE.MeshStandardMaterial;
     private partitionGlassMaterial!: THREE.MeshPhysicalMaterial;
-    private screenMaterial!: THREE.MeshStandardMaterial;
-    private velvetMaterial!: THREE.MeshStandardMaterial;
-    private carpetMaterial!: THREE.MeshStandardMaterial;
 
     // Lights
     private moodLights: THREE.PointLight[] = [];
@@ -66,7 +60,6 @@ export class LimousineMode {
 
     // State
     private state: LimoState;
-    private partitionTargetY: number = 0;
     private animationId: number = 0;
 
     constructor(container: HTMLElement, initialState: Partial<LimoState> = {}) {
@@ -114,13 +107,7 @@ export class LimousineMode {
         this.barGroup = builder.barGroup;
         this.screensGroup = builder.screensGroup;
 
-        this.luxuryLeatherMaterial = builder.luxuryLeatherMaterial;
-        this.woodMaterial = builder.woodMaterial;
-        this.chromeMaterial = builder.chromeMaterial;
         this.partitionGlassMaterial = builder.partitionGlassMaterial;
-        this.screenMaterial = builder.screenMaterial;
-        this.velvetMaterial = builder.velvetMaterial;
-        this.carpetMaterial = builder.carpetMaterial;
 
         this.moodLights = builder.moodLights;
         this.barLight = builder.barLight;
@@ -152,11 +139,11 @@ export class LimousineMode {
             romantic: [0xff4466, 0xff6688, 0xff88aa, 0xffaacc],
         };
 
-        const colors = moodColors[this.state.moodLighting] || moodColors.relaxing;
+        const colors = (moodColors[this.state.moodLighting] || moodColors.relaxing)!;
         const intensity = this.state.entertainmentOn ? 0.8 : 0.4;
 
         this.moodLights.forEach((light, idx) => {
-            light.color.setHex(colors[idx % colors.length]);
+            light.color.setHex(colors[idx % colors.length]!);
             light.intensity = intensity;
         });
 
@@ -195,7 +182,7 @@ export class LimousineMode {
         };
 
         const emissiveIntensity = this.state.entertainmentOn ? 0.8 : 0.2;
-        const color = contentColors[this.state.screenContent] || contentColors.ambient;
+        const color = (contentColors[this.state.screenContent] || contentColors.ambient)!;
 
         this.screensGroup.children.forEach((child) => {
             if (child.name.includes('Screen')) {
@@ -280,7 +267,7 @@ export class LimousineMode {
         }
     }
 
-    public update(deltaTime: number): void {
+    public update(_deltaTime: number): void {
         if (this.state.entertainmentOn && this.state.moodLighting === 'party') {
             const time = performance.now() * 0.001;
             this.moodLights.forEach((light, idx) => {

--- a/src/car/variants/ScienceLabMode.ts
+++ b/src/car/variants/ScienceLabMode.ts
@@ -42,7 +42,6 @@ export class ScienceLabInterior {
 
     // Animation state
     private animationId: number = 0;
-    private time: number = 0;
     private fanRotationSpeed: number = 5;
     private blinkTime: number = 0;
 
@@ -64,7 +63,6 @@ export class ScienceLabInterior {
     private audioContext: AudioContext | null = null;
     private fanOscillator: OscillatorNode | null = null;
     private fanGain: GainNode | null = null;
-    private beepOscillator: OscillatorNode | null = null;
 
     // Materials
     private metalMaterial!: THREE.MeshStandardMaterial;
@@ -427,13 +425,13 @@ export class ScienceLabInterior {
         this.equipmentGroup.add(panel);
 
         // Create multiple instrument displays
-        const displayConfigs = [
+        const displayConfigs: { pos: [number, number, number]; color: number; label: string }[] = [
             { pos: [0.25, 1.3, -0.67], color: 0x00ff88, label: 'SPEC' },
             { pos: [0.5, 1.3, -0.67], color: 0x0088ff, label: 'DATA' },
             { pos: [0.75, 1.3, -0.67], color: 0xff8800, label: 'TEMP' },
         ];
 
-        displayConfigs.forEach((config, index) => {
+        displayConfigs.forEach((config) => {
             // Display frame
             const frameGeo = new THREE.BoxGeometry(0.18, 0.15, 0.02);
             const frame = new THREE.Mesh(frameGeo, this.darkPlasticMaterial);
@@ -728,7 +726,6 @@ export class ScienceLabInterior {
      * Update loop - animate equipment
      */
     public update(deltaTime: number): void {
-        this.time += deltaTime;
         this.blinkTime += deltaTime;
 
         // Animate fans

--- a/src/components/BookmarkPanel.tsx
+++ b/src/components/BookmarkPanel.tsx
@@ -20,7 +20,6 @@ interface BookmarkPanelProps {
 
 const BookmarkPanel: React.FC<BookmarkPanelProps> = ({
     bookmarks,
-    currentCoords,
     onTeleport,
     onAddBookmark,
     onRemoveBookmark,

--- a/src/components/GlobeView.tsx
+++ b/src/components/GlobeView.tsx
@@ -124,7 +124,6 @@ const GlobeView: React.FC<GlobeViewProps> = ({
     currentLng,
     currentHeading,
     pois,
-    bookmarks,
     mapsApiKey,
     onTeleportRequest,
     onEnterComplete,

--- a/src/components/MiniMap.tsx
+++ b/src/components/MiniMap.tsx
@@ -17,7 +17,6 @@ interface MiniMapProps {
 }
 
 const MiniMap: React.FC<MiniMapProps> = ({
-    apiKey,
     panorama,
     heading,
     routePath,
@@ -364,7 +363,7 @@ const MiniMap: React.FC<MiniMapProps> = ({
             }
         });
 
-    }, [breadcrumbs, map, panorama]); // Re-render when breadcrumbs change
+    }, [breadcrumbs, map, panorama, onTeleport]); // Re-render when breadcrumbs change
 
     // Render Route Path with optimization to reuse the Polyline object
     useEffect(() => {

--- a/src/components/StreetView.tsx
+++ b/src/components/StreetView.tsx
@@ -246,11 +246,13 @@ const StreetView: React.FC<StreetViewProps> = ({ onCanvasReady, apiKey, initialP
                     const len = canvases.length;
                     if (len === 0) return;
 
-                    let bestCanvas = canvases[0];
+                    // len === 0 already returned above, so index 0 is always present.
+                    let bestCanvas = canvases[0]!;
                     let maxArea = bestCanvas.width * bestCanvas.height;
 
                     for (let i = 1; i < len; i++) {
-                        const canvas = canvases[i];
+                        // i is bounded by len === canvases.length.
+                        const canvas = canvases[i]!;
                         const area = canvas.width * canvas.height;
                         if (area > maxArea) {
                             maxArea = area;

--- a/src/components/WebGPUCanvas.tsx
+++ b/src/components/WebGPUCanvas.tsx
@@ -365,7 +365,7 @@ const WebGPUCanvas: React.FC<WebGPUCanvasProps> = ({ onWebGPUStatus, onBackendIn
             active = false;
             cancelAnimationFrame(animationFrameId.current);
         };
-    }, []);
+    }, [currentRendererRef]);
 
     return (
         <canvas

--- a/src/effects/LightingEffects.ts
+++ b/src/effects/LightingEffects.ts
@@ -96,7 +96,7 @@ export class EquipmentGlowEffect {
         if (!isActive) {
             // Dim all materials when inactive
             this.materials.forEach((mat, i) => {
-                mat.emissiveIntensity = this.baseIntensities[i] * 0.3;
+                mat.emissiveIntensity = (this.baseIntensities[i] ?? 0) * 0.3;
             });
             return;
         }
@@ -106,7 +106,7 @@ export class EquipmentGlowEffect {
         // Pulsating effect
         this.materials.forEach((mat, i) => {
             const pulse = Math.sin(this.time * this.pulseSpeed + i * 0.5) * 0.15;
-            mat.emissiveIntensity = this.baseIntensities[i] + pulse;
+            mat.emissiveIntensity = (this.baseIntensities[i] ?? 0) + pulse;
         });
     }
 
@@ -242,11 +242,8 @@ export class LightingEffectsManager {
     private equipmentGlow: EquipmentGlowEffect;
     private emergencyLights: EmergencyLightEffect;
     private taskLights: TaskLightEffect[] = [];
-    private config: LightingEffectConfig;
 
-    constructor(scene: THREE.Scene, config: Partial<LightingEffectConfig> = {}) {
-        this.config = { ...DEFAULT_LIGHTING_CONFIG, ...config };
-
+    constructor(scene: THREE.Scene, _config: Partial<LightingEffectConfig> = {}) {
         this.uvEffect = new UVLightEffect(scene);
         this.equipmentGlow = new EquipmentGlowEffect();
         this.emergencyLights = new EmergencyLightEffect(scene);
@@ -271,8 +268,9 @@ export class LightingEffectsManager {
     }
 
     setTaskLightIntensity(intensity: number, index?: number): void {
-        if (index !== undefined && this.taskLights[index]) {
-            this.taskLights[index].setIntensity(intensity);
+        const light = index !== undefined ? this.taskLights[index] : undefined;
+        if (light) {
+            light.setIntensity(intensity);
         } else {
             this.taskLights.forEach(light => light.setIntensity(intensity));
         }

--- a/src/effects/PostProcessing.ts
+++ b/src/effects/PostProcessing.ts
@@ -445,18 +445,18 @@ export class PostProcessingPipeline {
                     break;
 
                 case 'vignette':
-                    this.vignetteMaterial.uniforms.tDiffuse.value = currentTexture;
+                    this.vignetteMaterial.uniforms.tDiffuse!.value = currentTexture;
                     this.renderFullscreen(this.vignetteMaterial, target);
                     break;
 
                 case 'chromatic':
-                    this.chromaticAberrationMaterial.uniforms.tDiffuse.value = currentTexture;
+                    this.chromaticAberrationMaterial.uniforms.tDiffuse!.value = currentTexture;
                     this.renderFullscreen(this.chromaticAberrationMaterial, target);
                     break;
 
                 case 'grain':
-                    this.filmGrainMaterial.uniforms.tDiffuse.value = currentTexture;
-                    this.filmGrainMaterial.uniforms.time.value = this.elapsedTime;
+                    this.filmGrainMaterial.uniforms.tDiffuse!.value = currentTexture;
+                    this.filmGrainMaterial.uniforms.time!.value = this.elapsedTime;
                     this.renderFullscreen(this.filmGrainMaterial, target);
                     break;
             }
@@ -494,8 +494,8 @@ export class PostProcessingPipeline {
         this.bloomBlurRT1.setSize(halfW, halfH);
         this.bloomBlurRT2.setSize(halfW, halfH);
 
-        this.blurMaterial.uniforms.resolution.value.set(halfW, halfH);
-        this.chromaticAberrationMaterial.uniforms.resolution.value.set(this.width, this.height);
+        this.blurMaterial.uniforms.resolution!.value.set(halfW, halfH);
+        this.chromaticAberrationMaterial.uniforms.resolution!.value.set(this.width, this.height);
     }
 
     // ---- Cleanup ------------------------------------------------------------
@@ -561,42 +561,42 @@ export class PostProcessingPipeline {
         const halfH = this.bloomBlurRT1.height;
 
         // Bright-pass extraction
-        this.brightPassMaterial.uniforms.tDiffuse.value = inputTexture;
-        this.brightPassMaterial.uniforms.threshold.value = this.config.bloomThreshold;
+        this.brightPassMaterial.uniforms.tDiffuse!.value = inputTexture;
+        this.brightPassMaterial.uniforms.threshold!.value = this.config.bloomThreshold;
         this.renderFullscreen(this.brightPassMaterial, this.bloomBrightRT);
 
         // Iterative separable Gaussian blur (radius controls iteration count)
         const iterations = Math.max(1, Math.min(5, Math.ceil(this.config.bloomRadius * 5)));
-        this.blurMaterial.uniforms.resolution.value.set(halfW, halfH);
+        this.blurMaterial.uniforms.resolution!.value.set(halfW, halfH);
 
         for (let i = 0; i < iterations; i++) {
             // Horizontal pass
-            this.blurMaterial.uniforms.tDiffuse.value =
+            this.blurMaterial.uniforms.tDiffuse!.value =
                 i === 0 ? this.bloomBrightRT.texture : this.bloomBlurRT2.texture;
-            this.blurMaterial.uniforms.direction.value.set(1.0, 0.0);
+            this.blurMaterial.uniforms.direction!.value.set(1.0, 0.0);
             this.renderFullscreen(this.blurMaterial, this.bloomBlurRT1);
 
             // Vertical pass
-            this.blurMaterial.uniforms.tDiffuse.value = this.bloomBlurRT1.texture;
-            this.blurMaterial.uniforms.direction.value.set(0.0, 1.0);
+            this.blurMaterial.uniforms.tDiffuse!.value = this.bloomBlurRT1.texture;
+            this.blurMaterial.uniforms.direction!.value.set(0.0, 1.0);
             this.renderFullscreen(this.blurMaterial, this.bloomBlurRT2);
         }
 
         // Additive composite (preserves original alpha)
-        this.bloomCompositeMaterial.uniforms.tDiffuse.value = inputTexture;
-        this.bloomCompositeMaterial.uniforms.tBloom.value = this.bloomBlurRT2.texture;
-        this.bloomCompositeMaterial.uniforms.strength.value = this.config.bloomStrength;
+        this.bloomCompositeMaterial.uniforms.tDiffuse!.value = inputTexture;
+        this.bloomCompositeMaterial.uniforms.tBloom!.value = this.bloomBlurRT2.texture;
+        this.bloomCompositeMaterial.uniforms.strength!.value = this.config.bloomStrength;
         this.renderFullscreen(this.bloomCompositeMaterial, outputTarget);
     }
 
     /** Pushes current config values into shader uniforms. */
     private syncUniforms(): void {
-        this.brightPassMaterial.uniforms.threshold.value = this.config.bloomThreshold;
-        this.bloomCompositeMaterial.uniforms.strength.value = this.config.bloomStrength;
-        this.vignetteMaterial.uniforms.strength.value = this.config.vignetteStrength;
-        this.vignetteMaterial.uniforms.offset.value = this.config.vignetteOffset;
-        this.filmGrainMaterial.uniforms.intensity.value = this.config.filmGrainIntensity;
-        this.chromaticAberrationMaterial.uniforms.strength.value =
+        this.brightPassMaterial.uniforms.threshold!.value = this.config.bloomThreshold;
+        this.bloomCompositeMaterial.uniforms.strength!.value = this.config.bloomStrength;
+        this.vignetteMaterial.uniforms.strength!.value = this.config.vignetteStrength;
+        this.vignetteMaterial.uniforms.offset!.value = this.config.vignetteOffset;
+        this.filmGrainMaterial.uniforms.intensity!.value = this.config.filmGrainIntensity;
+        this.chromaticAberrationMaterial.uniforms.strength!.value =
             this.config.chromaticAberrationStrength;
     }
 }

--- a/src/hooks/useAppKeyboardShortcuts.ts
+++ b/src/hooks/useAppKeyboardShortcuts.ts
@@ -70,7 +70,6 @@ export function buildAppKeyboardShortcuts(options: UseAppKeyboardShortcutsOption
     rainIntensity,
     wipersEnabled,
     toggleWipers,
-    headlightsOn,
     toggleHeadlights,
     toggleDomeLight,
     isRoofOpen,
@@ -96,7 +95,8 @@ export function buildAppKeyboardShortcuts(options: UseAppKeyboardShortcutsOption
       action: () => {
         const modes: TimeOfDay[] = ['day', 'sunrise', 'sunset', 'night'];
         const currentIndex = modes.indexOf(timeOfDay);
-        const nextMode = modes[(currentIndex + 1) % modes.length];
+        // Modulo of modes.length is always a valid index.
+        const nextMode = modes[(currentIndex + 1) % modes.length]!;
         applyTimeOfDayPreset(nextMode);
         announce(`Night mode: ${nextMode}`);
       },

--- a/src/hooks/useAutopilot.ts
+++ b/src/hooks/useAutopilot.ts
@@ -26,7 +26,7 @@ export function useAutopilot({
 
     waypoints.forEach(wp => panoCache.fetch(wp.lat, wp.lng).catch(() => {}));
 
-    await handleGlobeTeleport(waypoints[0].lat, waypoints[0].lng);
+    await handleGlobeTeleport(waypoints[0]!.lat, waypoints[0]!.lng);
 
     if (waypoints.length > 1) {
       let idx = 1;
@@ -40,7 +40,7 @@ export function useAutopilot({
           console.log('[Autopilot] Waiting for transition pause before next waypoint');
           return;
         }
-        const wp = waypoints[idx];
+        const wp = waypoints[idx]!;
         setNavPending(true);
         try {
           await teleportSafe(wp.lat, wp.lng);

--- a/src/hooks/usePerformanceMonitor.ts
+++ b/src/hooks/usePerformanceMonitor.ts
@@ -97,7 +97,7 @@ export function usePerformanceMonitor(
       };
     }
     
-    const current = times[times.length - 1];
+    const current = times[times.length - 1]!;
     const average = times.reduce((a, b) => a + b, 0) / times.length;
     const min = Math.min(...times);
     const max = Math.max(...times);

--- a/src/hooks/useStreetView.tsx
+++ b/src/hooks/useStreetView.tsx
@@ -73,7 +73,7 @@ interface StreetViewProviderProps {
 
 export const StreetViewProvider: React.FC<StreetViewProviderProps> = ({
   children,
-  initialPosition = { lat: 37.86926, lng: -122.254811 },
+  initialPosition: _initialPosition = { lat: 37.86926, lng: -122.254811 },
   initialHeading = 34,
   initialPitch = 10,
 }) => {
@@ -451,11 +451,12 @@ export const StreetViewProvider: React.FC<StreetViewProviderProps> = ({
   
   // Cleanup transition RAF on unmount
   useEffect(() => {
+    const readyPromiseTracker = readyPromiseRef.current;
     return () => {
       if (transitionRafRef.current !== null) {
         cancelAnimationFrame(transitionRafRef.current);
       }
-      readyPromiseRef.current.clear();
+      readyPromiseTracker.clear();
     };
   }, []);
   

--- a/src/hooks/useTouchControls.ts
+++ b/src/hooks/useTouchControls.ts
@@ -100,21 +100,22 @@ export function useTouchControls(options: UseTouchControlsOptions = {}): UseTouc
 
       if (touches.length === 1) {
         // Single finger - start drag
-        initialTouchRef.current = { x: touches[0].clientX, y: touches[0].clientY };
+        const t0 = touches[0]!;
+        initialTouchRef.current = { x: t0.clientX, y: t0.clientY };
         setGestureState((prev) => ({
           ...prev,
           isDragging: true,
           isPinching: false,
-          lastTouchX: touches[0].clientX,
-          lastTouchY: touches[0].clientY,
+          lastTouchX: t0.clientX,
+          lastTouchY: t0.clientY,
           velocityX: 0,
           velocityY: 0,
         }));
         velocityRef.current = { x: 0, y: 0 };
       } else if (touches.length === 2) {
         // Two fingers - start pinch
-        const distance = getTouchDistance(touches[0], touches[1]);
-        initialTouchRef.current = getTouchMidpoint(touches[0], touches[1]);
+        const distance = getTouchDistance(touches[0]!, touches[1]!);
+        initialTouchRef.current = getTouchMidpoint(touches[0]!, touches[1]!);
         setGestureState((prev) => ({
           ...prev,
           isDragging: false,
@@ -140,8 +141,9 @@ export function useTouchControls(options: UseTouchControlsOptions = {}): UseTouc
 
       if (touches.length === 1 && gestureState.isDragging) {
         // Single finger drag - pan
-        const deltaX = (touches[0].clientX - gestureState.lastTouchX) * panSensitivity;
-        const deltaY = (touches[0].clientY - gestureState.lastTouchY) * panSensitivity;
+        const t0 = touches[0]!;
+        const deltaX = (t0.clientX - gestureState.lastTouchX) * panSensitivity;
+        const deltaY = (t0.clientY - gestureState.lastTouchY) * panSensitivity;
 
         // Calculate velocity for momentum scrolling
         velocityRef.current = {
@@ -151,8 +153,8 @@ export function useTouchControls(options: UseTouchControlsOptions = {}): UseTouc
 
         setGestureState((prev) => ({
           ...prev,
-          lastTouchX: touches[0].clientX,
-          lastTouchY: touches[0].clientY,
+          lastTouchX: t0.clientX,
+          lastTouchY: t0.clientY,
           velocityX: velocityRef.current.x,
           velocityY: velocityRef.current.y,
         }));
@@ -160,14 +162,14 @@ export function useTouchControls(options: UseTouchControlsOptions = {}): UseTouc
         onPan?.(deltaX, deltaY);
       } else if (touches.length === 2 && gestureState.isPinching) {
         // Two finger pinch - zoom
-        const currentDistance = getTouchDistance(touches[0], touches[1]);
+        const currentDistance = getTouchDistance(touches[0]!, touches[1]!);
         const pinchRatio = currentDistance / gestureState.touchStartDistance;
         const zoomDelta = (pinchRatio - 1) * 100 * zoomSensitivity;
 
         onZoom?.(zoomDelta);
 
         // Update midpoint for reference
-        const midpoint = getTouchMidpoint(touches[0], touches[1]);
+        const midpoint = getTouchMidpoint(touches[0]!, touches[1]!);
         setGestureState((prev) => ({
           ...prev,
           lastTouchX: midpoint.x,
@@ -213,7 +215,7 @@ export function useTouchControls(options: UseTouchControlsOptions = {}): UseTouc
 
       // Check for tap (quick touch with minimal movement)
       if (e.changedTouches.length === 1 && touchDuration < 200 && initialTouchRef.current) {
-        const touch = e.changedTouches[0];
+        const touch = e.changedTouches[0]!;
         const moveDistance = Math.sqrt(
           Math.pow(touch.clientX - initialTouchRef.current.x, 2) +
           Math.pow(touch.clientY - initialTouchRef.current.y, 2)
@@ -256,7 +258,7 @@ export function useTouchControls(options: UseTouchControlsOptions = {}): UseTouc
    * Handle touch cancel
    */
   const handleTouchCancel = useCallback(
-    (e: React.TouchEvent) => {
+    (_e: React.TouchEvent) => {
       if (rafIdRef.current) {
         cancelAnimationFrame(rafIdRef.current);
         rafIdRef.current = null;

--- a/src/materials/PBRMaterials.ts
+++ b/src/materials/PBRMaterials.ts
@@ -134,10 +134,10 @@ export class VehiclePBRMaterials {
         for (let y = 0; y < size; y++) {
             for (let x = 0; x < size; x++) {
                 const i = (y * size + x) * 4;
-                const left = data[(y * size + ((x - 1 + size) % size)) * 4];
-                const right = data[(y * size + ((x + 1) % size)) * 4];
-                const up = data[(((y - 1 + size) % size) * size + x) * 4];
-                const down = data[(((y + 1) % size) * size + x) * 4];
+                const left = data[(y * size + ((x - 1 + size) % size)) * 4]!;
+                const right = data[(y * size + ((x + 1) % size)) * 4]!;
+                const up = data[(((y - 1 + size) % size) * size + x) * 4]!;
+                const down = data[(((y + 1) % size) * size + x) * 4]!;
                 const dx = (left - right) / 255 * strength;
                 const dy = (up - down) / 255 * strength;
                 const dz = 1.0;
@@ -176,9 +176,9 @@ export class VehiclePBRMaterials {
                         const falloff = (1 - dist) * (1 - dist);
                         const idx = (y * size + x) * 4;
                         const bump = falloff * 50;
-                        data[idx] = Math.min(255, data[idx] + bump);
-                        data[idx + 1] = Math.min(255, data[idx + 1] + bump);
-                        data[idx + 2] = Math.min(255, data[idx + 2] + bump);
+                        data[idx] = Math.min(255, data[idx]! + bump);
+                        data[idx + 1] = Math.min(255, data[idx + 1]! + bump);
+                        data[idx + 2] = Math.min(255, data[idx + 2]! + bump);
                     }
                 }
             }
@@ -236,9 +236,9 @@ export class VehiclePBRMaterials {
                             const ny = (py + dy + size) % size;
                             const idx = (ny * size + nx) * 4;
                             const darken = (1 - Math.sqrt(dx * dx + dy * dy) / pr) * 50;
-                            hImg.data[idx] = Math.max(0, hImg.data[idx] - darken);
-                            hImg.data[idx + 1] = Math.max(0, hImg.data[idx + 1] - darken);
-                            hImg.data[idx + 2] = Math.max(0, hImg.data[idx + 2] - darken);
+                            hImg.data[idx] = Math.max(0, hImg.data[idx]! - darken);
+                            hImg.data[idx + 1] = Math.max(0, hImg.data[idx + 1]! - darken);
+                            hImg.data[idx + 2] = Math.max(0, hImg.data[idx + 2]! - darken);
                         }
                     }
                 }
@@ -589,7 +589,7 @@ export class VehiclePBRMaterials {
                     for (let dy = -1; dy <= 1; dy++) {
                         for (let dx = -1; dx <= 1; dx++) {
                             const ni = ((y + dy) * size + (x + dx)) * 4;
-                            if (alphaImg.data[ni] > 0) neighborDust++;
+                            if (alphaImg.data[ni]! > 0) neighborDust++;
                         }
                     }
                     if (neighborDust >= 2 && Math.random() < 0.4) {

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -24,15 +24,11 @@ export class Renderer implements StreetViewRenderer {
     private uniformBuffer!: GPUBuffer;
 
     // Car mode effects
-    private carModeActive: boolean = false;
     private effectsBuffer?: GPUBuffer;
-    
+
     // === INLINE TRANSITION SYSTEM ===
-    // previousFrameTexture holds a GPU snapshot of the departing panorama.
     // The main shader (streetview.wgsl) mixes between previous and current
     // based on transitionProgress passed in the uniform buffer.
-    private previousFrameTexture?: GPUTexture;
-    private inlineTransitionProgress: number = 0.0;
     private holdActive: boolean = false;
     
     // === DUAL-PASS WEATHER SYSTEM ===
@@ -49,8 +45,6 @@ export class Renderer implements StreetViewRenderer {
     private weatherPostProcessor!: WeatherPostProcessor;
 
     // World-space pan tracking
-    private lastPanX: number = 0.5;
-    private lastPanY: number = 0.5;
     private capturePanX: number = 0.5;
     private capturePanY: number = 0.5;
 
@@ -279,7 +273,7 @@ export class Renderer implements StreetViewRenderer {
         });
     }
 
-    public resize(width: number, height: number) {
+    public resize(_width: number, _height: number) {
         if (this.isDestroyed) return;
         this.configureContext();
     }
@@ -311,8 +305,7 @@ export class Renderer implements StreetViewRenderer {
         this.bindGroup = undefined as any;
     }
 
-    public setCarMode(active: boolean): void {
-        this.carModeActive = active;
+    public setCarMode(_active: boolean): void {
     }
 
     public updateEffects(effectsData: Float32Array): void {
@@ -446,8 +439,6 @@ export class Renderer implements StreetViewRenderer {
         const panY = ((pitch ?? 0) + 90) / 180;
         this.capturePanX = panX;
         this.capturePanY = panY;
-        this.lastPanX = panX;
-        this.lastPanY = panY;
         this.holdActive = true;
         this.transitionManager?.setTransitionProgress(0.0);
     }
@@ -497,8 +488,6 @@ export class Renderer implements StreetViewRenderer {
             const panX = ((heading || 0) % 360) / 360;
             const panY = ((pitch || 0) + 90) / 180;
 
-            this.lastPanX = panX;
-            this.lastPanY = panY;
             this.transitionManager?.recordLastPan(panX, panY);
 
             const uniforms = new Float32Array([
@@ -615,7 +604,7 @@ export class Renderer implements StreetViewRenderer {
     }
 
     public renderStreetView(
-        mode: RenderMode,
+        _mode: RenderMode,
         source: CanvasImageSource | null,
         heading?: number,
         pitch?: number,

--- a/src/renderer/TransitionManager.ts
+++ b/src/renderer/TransitionManager.ts
@@ -17,14 +17,6 @@ export class TransitionManager {
         'zoom-chromatic': { duration: 500, param1: 2.5, param2: 1.0 },
     };
 
-    // World-space look-around: last rendered panX/Y (tracked every frame)
-    private lastPanX: number = 0.5;
-    private lastPanY: number = 0.5;
-    // Captured at snapshot time — sent to shader so it can compute the heading delta
-    private capturePanX: number = 0.5;
-    private capturePanY: number = 0.5;
-    private movementHeadingNorm: number = 0.5;
-
     // === INLINE TRANSITION SYSTEM ===
     private previousFrameTexture?: GPUTexture;
     private inlineTransitionProgress: number = 0.0;
@@ -106,12 +98,8 @@ export class TransitionManager {
         this.transitionProgress = 0.0;
     }
 
-    public capturePanorama(movementHeading: number, videoTexture: GPUTexture): void {
+    public capturePanorama(_movementHeading: number, videoTexture: GPUTexture): void {
         if (!this.device || !videoTexture) return;
-
-        this.movementHeadingNorm = Math.max(0.0, Math.min(1.0, movementHeading));
-        this.capturePanX = this.lastPanX;
-        this.capturePanY = this.lastPanY;
 
         if (!this.prevTexture ||
             this.prevTexture.width  !== videoTexture.width ||
@@ -207,17 +195,15 @@ export class TransitionManager {
         return this.previousFrameTexture;
     }
 
-    public recordLastPan(panX: number, panY: number): void {
-        this.lastPanX = panX;
-        this.lastPanY = panY;
+    public recordLastPan(_panX: number, _panY: number): void {
     }
 
     public renderTransitionPass(
         commandEncoder: GPUCommandEncoder,
         intermediateTextureView: GPUTextureView,
         videoTexture: GPUTexture,
-        mainPipeline: GPURenderPipeline,
-        mainBindGroup: GPUBindGroup
+        _mainPipeline: GPURenderPipeline,
+        _mainBindGroup: GPUBindGroup
     ): boolean {
         const transitionPipeline = this.activeTransition
             ? this.transitionPipelines.get(this.activeTransition)

--- a/src/renderer/WeatherPostProcessor.ts
+++ b/src/renderer/WeatherPostProcessor.ts
@@ -6,7 +6,6 @@ const NOISE_BUFFER_BYTES = NOISE_TILE_SIZE * NOISE_TILE_SIZE * 4;
 export class WeatherPostProcessor {
     private device: GPUDevice;
     private context: GPUCanvasContext;
-    private canvas: HTMLCanvasElement;
 
     private weatherPipeline!: GPURenderPipeline;
     private weatherBindGroup!: GPUBindGroup;
@@ -17,10 +16,9 @@ export class WeatherPostProcessor {
     private startTime: number = Date.now();
     private shaderEffectsEnabled: boolean = true;
 
-    constructor(device: GPUDevice, context: GPUCanvasContext, canvas: HTMLCanvasElement) {
+    constructor(device: GPUDevice, context: GPUCanvasContext, _canvas: HTMLCanvasElement) {
         this.device = device;
         this.context = context;
-        this.canvas = canvas;
 
         this.weatherSampler = this.device.createSampler({
             magFilter: 'linear',
@@ -147,8 +145,8 @@ export class WeatherPostProcessor {
 
     public getCameraParams(): { heading: number; pitch: number } {
         return {
-            heading: this.weatherParams[33],
-            pitch: this.weatherParams[34]
+            heading: this.weatherParams[33]!,
+            pitch: this.weatherParams[34]!
         };
     }
 

--- a/src/renderer/WebGLFallbackRenderer.ts
+++ b/src/renderer/WebGLFallbackRenderer.ts
@@ -331,7 +331,7 @@ export class WebGLFallbackRenderer implements StreetViewRenderer {
 
     public updateEffects(effectsData: Float32Array): void {
         if (effectsData.length > 8) {
-            this.weatherParams[32] = effectsData[8] || this.weatherParams[32];
+            this.weatherParams[32] = effectsData[8]! || this.weatherParams[32]!;
         }
     }
 
@@ -354,7 +354,7 @@ export class WebGLFallbackRenderer implements StreetViewRenderer {
 
     public updateWeatherParams(params: Float32Array): void {
         this.weatherParams.set(params.subarray(0, Math.min(40, params.length)));
-        this.shaderEffectsEnabled = this.weatherParams[32] >= 0.5;
+        this.shaderEffectsEnabled = this.weatherParams[32]! >= 0.5;
     }
 
     public updateCameraParams(heading: number, pitch: number): void {

--- a/src/services/maps/loader.test.ts
+++ b/src/services/maps/loader.test.ts
@@ -56,7 +56,7 @@ describe('loadMapsApi', () => {
 
     await promise;
 
-    const script = appendSpy.mock.calls[0][0] as HTMLScriptElement;
+    const script = appendSpy.mock.calls[0]![0] as HTMLScriptElement;
     const url = new URL(script.src);
     expect(url.origin).toBe('https://maps.googleapis.com');
     expect(url.pathname).toBe('/maps/api/js');

--- a/src/services/radioBrowserService.ts
+++ b/src/services/radioBrowserService.ts
@@ -126,8 +126,9 @@ export async function getTopStationForLocation(
     
     if (stations.length === 0) return null;
     
-    // Pick the highest-voted station with a resolved URL
-    const best = stations.find(s => s.urlResolved) || stations[0];
+    // Pick the highest-voted station with a resolved URL.
+    // stations.length === 0 already returned above, so index 0 is always present.
+    const best = stations.find(s => s.urlResolved) || stations[0]!;
     return best;
 }
 

--- a/src/store/loadingState.ts
+++ b/src/store/loadingState.ts
@@ -174,8 +174,8 @@ class LoadingStateManager {
     if (callbacks && callbacks.length > 0) {
       // Clear error state first
       this.clearError(type);
-      // Execute the most recent retry callback
-      const callback = callbacks[callbacks.length - 1];
+      // Execute the most recent retry callback (callbacks.length > 0 checked above).
+      const callback = callbacks[callbacks.length - 1]!;
       callback();
     }
   }

--- a/src/utils/memoryProfiler.ts
+++ b/src/utils/memoryProfiler.ts
@@ -67,12 +67,10 @@ export const MATERIAL_TEXTURE_PROPS = ['map', 'normalMap', 'roughnessMap', 'meta
 export class MemoryProfiler {
   private snapshots: MemorySnapshot[] = [];
   private maxHistorySize = 60; // Keep last 60 snapshots
-  private trackedObjects = new Map<string, THREE.Object3D>();
   private lastSnapshotTime = 0;
   private snapshotInterval = 1000; // ms
-  
+
   // WebGPU specific
-  private gpuDevice?: GPUDevice;
   private gpuBuffers = new Map<string, number>();
   private gpuTextures = new Map<string, number>();
   
@@ -83,8 +81,8 @@ export class MemoryProfiler {
   /**
    * Set GPU device for WebGPU memory tracking
    */
-  setGPUDevice(device: GPUDevice): void {
-    this.gpuDevice = device;
+  setGPUDevice(_device: GPUDevice): void {
+    // Reserved for future WebGPU-side memory tracking; not yet consumed.
   }
   
   /**
@@ -233,7 +231,8 @@ export class MemoryProfiler {
       };
     }
     
-    const current = this.snapshots[this.snapshots.length - 1];
+    // this.snapshots.length === 0 already returned above, so this index is always present.
+    const current = this.snapshots[this.snapshots.length - 1]!;
     
     // Find peak usage
     const peak = this.snapshots.reduce((max, snap) => 

--- a/src/utils/panoLocation.ts
+++ b/src/utils/panoLocation.ts
@@ -29,7 +29,8 @@ const COMPASS = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
 /** Quantize a bearing in degrees to an 8-point compass label. */
 export function headingToCompass(heading: number): string {
   const h = (((heading % 360) + 360) % 360);
-  return COMPASS[Math.round(h / 45) % 8];
+  // Math.round(h / 45) % 8 is always in [0,7], a valid index into COMPASS.
+  return COMPASS[Math.round(h / 45) % 8]!;
 }
 
 const cache = new Map<string, PanoLocationInfo>();

--- a/src/utils/panoramaStability.ts
+++ b/src/utils/panoramaStability.ts
@@ -144,8 +144,9 @@ export function getCanvasFingerprint(canvas: HTMLCanvasElement): string {
     let hash = 0;
     let brightness = 0;
     for (let i = 0; i < d.length; i += 4) {
-      hash = ((hash << 5) - hash) + d[i] + d[i + 1] + d[i + 2];
-      brightness += d[i] + d[i + 1] + d[i + 2];
+      // Each RGBA pixel is 4 bytes, so i, i+1, i+2 are always within bounds.
+      hash = ((hash << 5) - hash) + d[i]! + d[i + 1]! + d[i + 2]!;
+      brightness += d[i]! + d[i + 1]! + d[i + 2]!;
     }
     // Mostly black = probably still loading, but allow very dark valid frames
     // (e.g. nighttime/error screens) to pass so we don't hang forever.

--- a/src/utils/performance.ts
+++ b/src/utils/performance.ts
@@ -46,7 +46,7 @@ export function setupLOD(model: THREE.Group, config?: Partial<LODConfig>): THREE
 /**
  * Create simplified geometry by reducing vertex count
  */
-function createSimplifiedLOD(model: THREE.Group, ratio: number): THREE.Group {
+function createSimplifiedLOD(model: THREE.Group, _ratio: number): THREE.Group {
   const simplified = model.clone();
   
   simplified.traverse((child) => {
@@ -523,7 +523,7 @@ export interface GPUPerformanceProfile {
   lodDistance: number[];
 }
 
-export const GPU_PROFILES: Record<string, GPUPerformanceProfile> = {
+export const GPU_PROFILES: { high: GPUPerformanceProfile; medium: GPUPerformanceProfile; low: GPUPerformanceProfile } = {
   // High-end desktop (RTX 3080+, M1 Max)
   high: {
     name: 'high',

--- a/src/utils/streetViewProbe.test.ts
+++ b/src/utils/streetViewProbe.test.ts
@@ -16,18 +16,18 @@ describe('streetViewProbe timeline', () => {
     streetViewProbe.holdArmed();
     const timeline = streetViewProbe.getTimeline();
     expect(timeline).toHaveLength(1);
-    expect(timeline[0].firstStableAt).toBeNull();
-    expect(timeline[0].releasedAt).toBeNull();
+    expect(timeline[0]!.firstStableAt).toBeNull();
+    expect(timeline[0]!.releasedAt).toBeNull();
   });
 
   it('records firstStable only once per hold cycle', () => {
     streetViewProbe.holdArmed();
     streetViewProbe.firstStable();
-    const firstStableAt = streetViewProbe.getTimeline()[0].firstStableAt;
+    const firstStableAt = streetViewProbe.getTimeline()[0]!.firstStableAt;
     expect(firstStableAt).not.toBeNull();
 
     streetViewProbe.firstStable();
-    expect(streetViewProbe.getTimeline()[0].firstStableAt).toBe(firstStableAt);
+    expect(streetViewProbe.getTimeline()[0]!.firstStableAt).toBe(firstStableAt);
   });
 
   it('computes holdDurationMs on release and clears the active entry', () => {
@@ -35,7 +35,7 @@ describe('streetViewProbe timeline', () => {
     streetViewProbe.firstStable();
     streetViewProbe.released();
 
-    const entry = streetViewProbe.getTimeline()[0];
+    const entry = streetViewProbe.getTimeline()[0]!;
     expect(entry.releasedAt).not.toBeNull();
     expect(entry.holdDurationMs).toBe(entry.releasedAt! - entry.armedAt);
 
@@ -77,8 +77,8 @@ describe('streetViewProbe.warnLeak', () => {
     streetViewProbe.warnLeak('uploadLiveSource called while holdActive');
     const warnings = streetViewProbe.getWarnings();
     expect(warnings).toHaveLength(1);
-    expect(warnings[0].message).toBe('uploadLiveSource called while holdActive');
-    expect(typeof warnings[0].at).toBe('number');
+    expect(warnings[0]!.message).toBe('uploadLiveSource called while holdActive');
+    expect(typeof warnings[0]!.at).toBe('number');
   });
 
   it('caps the warning log so a runaway regression cannot leak memory', () => {
@@ -157,7 +157,7 @@ describe('streetViewProbe.checkPixelDrift', () => {
     streetViewProbe.checkPixelDrift(makeCanvas());
     const warnings = streetViewProbe.getWarnings();
     expect(warnings.length).toBeGreaterThanOrEqual(1);
-    expect(warnings[warnings.length - 1].message).toMatch(/possible live GMaps content leak/);
+    expect(warnings[warnings.length - 1]!.message).toMatch(/possible live GMaps content leak/);
   });
 
   it('resets the drift baseline when disabling and re-enabling pixel watch', () => {

--- a/src/utils/streetViewProbe.ts
+++ b/src/utils/streetViewProbe.ts
@@ -64,7 +64,8 @@ function sampleBrightness(canvas: HTMLCanvasElement): number | null {
     const d = sampleCtx.getImageData(0, 0, 4, 4).data;
     let brightness = 0;
     for (let i = 0; i < d.length; i += 4) {
-      brightness += d[i] + d[i + 1] + d[i + 2];
+      // Each RGBA pixel is 4 bytes, so i, i+1, i+2 are always within bounds.
+      brightness += d[i]! + d[i + 1]! + d[i + 2]!;
     }
     return brightness / (d.length / 4);
   } catch {

--- a/src/wasm/__tests__/wasm.test.ts
+++ b/src/wasm/__tests__/wasm.test.ts
@@ -30,7 +30,7 @@ describe('noise2d', () => {
       [0, 0], [0.5, 0.5], [1.5, 2.5], [-3.7, 8.1], [100, 200],
     ];
     for (const [x, y] of testCoords) {
-      const n = wasm.noise2d(x, y);
+      const n = wasm.noise2d(x!, y!);
       expect(n).toBeGreaterThanOrEqual(-1);
       expect(n).toBeLessThanOrEqual(1);
     }

--- a/src/wasm/index.ts
+++ b/src/wasm/index.ts
@@ -100,15 +100,19 @@ function _jsSeed(s: number): void {
   for (let i = 255; i > 0; i--) {
     state = ((state * 1664525) + 1013904223) >>> 0;
     const j = ((state >>> 16) & 0x7fff) % (i + 1);
-    const t = tmp[i]; tmp[i] = tmp[j]; tmp[j] = t;
+    // i in [1,255] and j in [0,i], both always valid indices into tmp.
+    const t = tmp[i]!; tmp[i] = tmp[j]!; tmp[j] = t;
   }
   _perm = new Uint8Array(512);
-  for (let i = 0; i < 256; i++) _perm[i] = _perm[i + 256] = tmp[i];
+  // i in [0,255] is always a valid index into tmp.
+  for (let i = 0; i < 256; i++) _perm[i] = _perm[i + 256] = tmp[i]!;
 }
 
 function _jsGrad2(h: number, dx: number, dy: number): number {
-  const g = GRAD2[h & 7];
-  return g[0] * dx + g[1] * dy;
+  // h & 7 is always in [0,7], a valid index into GRAD2.
+  const g = GRAD2[h & 7]!;
+  // Every GRAD2 entry is a 2-element [x, y] pair.
+  return g[0]! * dx + g[1]! * dy;
 }
 
 function _jsNoise2d(x: number, y: number): number {
@@ -120,12 +124,13 @@ function _jsNoise2d(x: number, y: number): number {
   const v = _fade(fy);
   const X = ix & 255;
   const Y = iy & 255;
-  const pX = _perm[X];
-  const pX1 = _perm[X + 1];
-  const n00 = _jsGrad2(_perm[pX + Y], fx, fy);
-  const n10 = _jsGrad2(_perm[pX1 + Y], fx - 1, fy);
-  const n01 = _jsGrad2(_perm[pX + Y + 1], fx, fy - 1);
-  const n11 = _jsGrad2(_perm[pX1 + Y + 1], fx - 1, fy - 1);
+  // X, X + 1 in [0,256] are always valid indices into the 512-entry _perm table.
+  const pX = _perm[X]!;
+  const pX1 = _perm[X + 1]!;
+  const n00 = _jsGrad2(_perm[pX + Y]!, fx, fy);
+  const n10 = _jsGrad2(_perm[pX1 + Y]!, fx - 1, fy);
+  const n01 = _jsGrad2(_perm[pX + Y + 1]!, fx, fy - 1);
+  const n11 = _jsGrad2(_perm[pX1 + Y + 1]!, fx - 1, fy - 1);
   return _lerp(_lerp(n00, n10, u), _lerp(n01, n11, u), v);
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2020",
     "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
+      "DOM",
+      "DOM.Iterable",
+      "ES2020"
     ],
     "allowJs": true,
     "skipLibCheck": true,
@@ -13,12 +13,15 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
-    "module": "esnext",
+    "module": "ESNext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noUncheckedIndexedAccess": true
   },
   "include": [
     "src"


### PR DESCRIPTION
## Summary

- Raises `tsconfig.json` `target` from `es5` to `ES2020` (`lib: [DOM, DOM.Iterable, ES2020]`, `module: ESNext`) so authored code can rely on native WebGPU/async/ESM syntax without unnecessary polyfills. Babel/browserslist still gates the actual production transpilation, so this only changes what the TypeScript layer itself allows/emits type info for.
- Enables `noUnusedLocals`, `noUnusedParameters`, and `noUncheckedIndexedAccess`, and fixes all resulting fallout (originally ~280 errors across ~50 files):
  - Deleted genuinely dead private fields/locals/imports (e.g. unused material aliases in `LimousineMode`/`ConvertibleMode` that were already applied directly inside their builder classes, duplicate imports, unused mirror/clock scaffolding).
  - Prefixed still-required-but-unused parameters with `_` where a signature can't change (e.g. `Renderer.resize`, `TransitionManager.recordLastPan`).
  - Guarded array/map index reads that `noUncheckedIndexedAccess` now types as `T | undefined`, either with an early-return/continue guard or (only where the index is provably in range — e.g. loop bounded by the same array's `.length`, or a fixed known shader-uniform key) a non-null assertion with a short comment explaining why it's safe.
- Fixes the ESLint warnings CRA was surfacing on every build: unused imports/vars in `App.tsx`, `Controls.tsx`, `DashboardLayout.tsx`, `DashboardUI.tsx`, `Gauges.tsx`, `CarInteriorAnimator.ts`, `CenterDisplay.ts`, `useAppKeyboardShortcuts.ts`; missing-dependency warnings in `MiniMap.tsx` and `WebGPUCanvas.tsx`; and a ref-cleanup timing issue in `useStreetView.tsx`.
- Adds `npm run typecheck` (`tsc --noEmit`) and runs it as its own CI step ahead of tests/build.

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `CI=false npm run build` — compiles successfully with zero ESLint warnings
- [x] `CI=true npx react-scripts test --watchAll=false` — 154 tests passed across 15 suites


---
_Generated by [Claude Code](https://claude.ai/code/session_01VeZxXLgkNGRZw5vRw3xppX)_