### PR TITLE
Add Historical Timeline: scrub Street View capture dates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,12 @@ import {
   RendererBackendIndicator,
   WebGPUCanvas,
   LoadingOverlay,
+  HistoricalTimeline,
+  ComparisonView,
 } from './components';
+import { useHistoricalTimeline } from './hooks/useHistoricalTimeline';
+import { useHistoricalCompare } from './hooks/useHistoricalCompare';
+import { formatImageDate } from './utils/historicalImagery';
 
 // Hooks
 import { useBookmarks } from './hooks/useBookmarks';
@@ -101,8 +106,8 @@ if (!INITIAL_MAPS_KEY) {
  */
 function InnerApp() {
   // Connect to contexts
-  const { setCanvas, setPanorama, panorama, heading, pitch, canvas, isTransitioning, isPanoramaReady } = useStreetView();
-  const { advanceSafe, teleportSafe, panoCache } = useAdvanceSafe();
+  const { setCanvas, setPanorama, panorama, heading, pitch, canvas, isTransitioning, isPanoramaReady, renderer, readyPromise } = useStreetView();
+  const { advanceSafe, teleportSafe, teleportToPanoSafe, panoCache } = useAdvanceSafe();
   const { viewMode, toggleViewMode } = useViewMode();
   const {
     rainIntensity,
@@ -195,6 +200,7 @@ function InnerApp() {
   const [isColorGradingPanelOpen, setIsColorGradingPanelOpen] = useState(false);
   const [isWeatherPanelOpen, setIsWeatherPanelOpen] = useState(false);
   const [isAccessibilityPanelOpen, setIsAccessibilityPanelOpen] = useState(false);
+  const [isHistoricalTimelineOpen, setIsHistoricalTimelineOpen] = useState(false);
   const [showPerformanceStats, setShowPerformanceStats] = useState(false);
   
   // Accessibility
@@ -228,6 +234,29 @@ function InnerApp() {
   const { history, removeFromHistory, clearHistory } = useLocationHistory();
   const { snapshots, removeSnapshot, updateSnapshotName, downloadSnapshot, clearAllSnapshots } = useSnapshots();
   const globeMode = useGlobeMode();
+
+  // Historical Timeline ("time travel") — scrub through capture dates near the current location.
+  const {
+    entries: historicalEntries,
+    isLoading: isHistoricalLoading,
+    error: historicalError,
+    hasTimeline: hasHistoricalTimeline,
+    currentIndex: historicalCurrentIndex,
+    currentPanoId: historicalCurrentPanoId,
+  } = useHistoricalTimeline(panorama);
+  const {
+    compare: compareHistorical,
+    exitCompare: exitHistoricalCompare,
+    comparison: historicalComparison,
+    isCapturing: isCapturingComparison,
+  } = useHistoricalCompare({
+    renderer,
+    teleportToPanoSafe,
+    readyPromise,
+    getCurrentPanoId: () => panorama?.getPano() || null,
+  });
+  const historicalAfterEntry = historicalEntries.find((e) => e.panoId === historicalCurrentPanoId);
+  const historicalAfterLabel = historicalAfterEntry ? formatImageDate(historicalAfterEntry.imageDate) : 'Current';
   
   // Audio ref for radio
   const audioRef = useRef<HTMLAudioElement | null>(null);
@@ -732,6 +761,17 @@ function InnerApp() {
         </div>
       )}
 
+      {/* Historical Imagery comparison — before/after swipe overlay */}
+      {isConnected && historicalComparison && (
+        <ComparisonView
+          beforeUrl={historicalComparison.beforeUrl}
+          afterUrl={historicalComparison.afterUrl}
+          beforeEntry={historicalComparison.beforeEntry}
+          afterLabel={historicalAfterLabel}
+          onClose={exitHistoricalCompare}
+        />
+      )}
+
       {/* Global UI Panels */}
       {isConnected && (
         <>
@@ -751,6 +791,8 @@ function InnerApp() {
             setIsColorGradingPanelOpen={setIsColorGradingPanelOpen}
             isWeatherPanelOpen={isWeatherPanelOpen}
             setIsWeatherPanelOpen={setIsWeatherPanelOpen}
+            isHistoricalTimelineOpen={isHistoricalTimelineOpen}
+            setIsHistoricalTimelineOpen={setIsHistoricalTimelineOpen}
             viewMode={viewMode}
             toggleViewMode={toggleViewMode}
             onGlobeToggle={globeMode.toggle}
@@ -859,6 +901,24 @@ function InnerApp() {
             />
           )}
           
+          {/* Historical Timeline — scrub through capture dates near the current location */}
+          {isHistoricalTimelineOpen && (
+            <HistoricalTimeline
+              isOpen={isHistoricalTimelineOpen}
+              onClose={() => setIsHistoricalTimelineOpen(false)}
+              entries={historicalEntries}
+              isLoading={isHistoricalLoading}
+              error={historicalError}
+              hasTimeline={hasHistoricalTimeline}
+              currentIndex={historicalCurrentIndex}
+              isTransitioning={isTransitioning || isCapturingComparison}
+              onSelectDate={(entry) => teleportToPanoSafe(entry.panoId)}
+              onCompare={compareHistorical}
+              isComparing={!!historicalComparison}
+              onExitCompare={exitHistoricalCompare}
+            />
+          )}
+
           {/* Accessibility Panel */}
           {isAccessibilityPanelOpen && (
             <AccessibilityPanel

--- a/src/components/AppToolbar.tsx
+++ b/src/components/AppToolbar.tsx
@@ -16,6 +16,8 @@ export interface AppToolbarProps {
   setIsColorGradingPanelOpen: (v: boolean) => void;
   isWeatherPanelOpen: boolean;
   setIsWeatherPanelOpen: (v: boolean) => void;
+  isHistoricalTimelineOpen: boolean;
+  setIsHistoricalTimelineOpen: (v: boolean) => void;
   viewMode: 'freelook' | 'car';
   toggleViewMode: () => void;
   onGlobeToggle: () => void;
@@ -37,6 +39,8 @@ const AppToolbar: React.FC<AppToolbarProps> = ({
   setIsColorGradingPanelOpen,
   isWeatherPanelOpen,
   setIsWeatherPanelOpen,
+  isHistoricalTimelineOpen,
+  setIsHistoricalTimelineOpen,
   viewMode,
   toggleViewMode,
   onGlobeToggle,
@@ -106,6 +110,13 @@ const AppToolbar: React.FC<AppToolbarProps> = ({
         onClick={e => { e.stopPropagation(); setIsWeatherPanelOpen(!isWeatherPanelOpen); }}
       >
         🌧 Weather
+      </button>
+      <button
+        className={`control-btn${isHistoricalTimelineOpen ? ' disconnect' : ''}`}
+        style={{ minWidth: 110 }}
+        onClick={e => { e.stopPropagation(); setIsHistoricalTimelineOpen(!isHistoricalTimelineOpen); }}
+      >
+        🕰 Time Travel
       </button>
       <button
         className="control-btn"

--- a/src/components/ComparisonView.tsx
+++ b/src/components/ComparisonView.tsx
@@ -1,0 +1,202 @@
+import React, { useCallback, useRef, useState } from 'react';
+import { formatImageDate, type HistoricalPanoEntry } from '../utils/historicalImagery';
+
+export interface ComparisonViewProps {
+  beforeUrl: string;
+  afterUrl: string;
+  beforeEntry: HistoricalPanoEntry;
+  afterLabel: string;
+  onClose: () => void;
+}
+
+/**
+ * Before/after swipe overlay over two already-captured canvas snapshots.
+ * Both snapshots share the heading/pitch they were captured at (teleportToPano
+ * never touches POV), so the comparison is POV-matched without needing a
+ * second live-linked render context.
+ */
+const ComparisonView: React.FC<ComparisonViewProps> = ({
+  beforeUrl,
+  afterUrl,
+  beforeEntry,
+  afterLabel,
+  onClose,
+}) => {
+  const [splitPercent, setSplitPercent] = useState(50);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const draggingRef = useRef(false);
+
+  const updateFromClientX = useCallback((clientX: number) => {
+    const el = containerRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const pct = ((clientX - rect.left) / rect.width) * 100;
+    setSplitPercent(Math.max(0, Math.min(100, pct)));
+  }, []);
+
+  const handlePointerDown = useCallback((e: React.PointerEvent) => {
+    draggingRef.current = true;
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    updateFromClientX(e.clientX);
+  }, [updateFromClientX]);
+
+  const handlePointerMove = useCallback((e: React.PointerEvent) => {
+    if (!draggingRef.current) return;
+    updateFromClientX(e.clientX);
+  }, [updateFromClientX]);
+
+  const handlePointerUp = useCallback(() => {
+    draggingRef.current = false;
+  }, []);
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Before and after comparison"
+      onMouseDown={(e) => e.stopPropagation()}
+      onKeyDown={(e) => e.stopPropagation()}
+      style={{
+        position: 'absolute',
+        inset: 0,
+        zIndex: 200,
+        background: '#000',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <div
+        ref={containerRef}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        style={{
+          position: 'relative',
+          flex: 1,
+          overflow: 'hidden',
+          cursor: 'ew-resize',
+          touchAction: 'none',
+        }}
+      >
+        {/* After (current) — full width base layer */}
+        <img
+          src={afterUrl}
+          alt={`Current view (${afterLabel})`}
+          style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover' }}
+          draggable={false}
+        />
+
+        {/* Before (historical) — clipped to the split position */}
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            width: `${splitPercent}%`,
+            overflow: 'hidden',
+          }}
+        >
+          <img
+            src={beforeUrl}
+            alt={`Historical view (${formatImageDate(beforeEntry.imageDate)})`}
+            style={{
+              position: 'absolute',
+              inset: 0,
+              width: containerRef.current ? containerRef.current.clientWidth : '100%',
+              height: '100%',
+              objectFit: 'cover',
+            }}
+            draggable={false}
+          />
+        </div>
+
+        {/* Divider handle */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            bottom: 0,
+            left: `${splitPercent}%`,
+            width: 2,
+            backgroundColor: '#4FC3F7',
+            transform: 'translateX(-1px)',
+            pointerEvents: 'none',
+            boxShadow: '0 0 8px rgba(79,195,247,0.8)',
+          }}
+        />
+        <div
+          style={{
+            position: 'absolute',
+            top: '50%',
+            left: `${splitPercent}%`,
+            transform: 'translate(-50%, -50%)',
+            width: 32,
+            height: 32,
+            borderRadius: '50%',
+            backgroundColor: '#4FC3F7',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#000',
+            fontSize: 14,
+            fontWeight: 700,
+            pointerEvents: 'none',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.5)',
+          }}
+        >
+          ⇄
+        </div>
+
+        {/* Date labels */}
+        <div style={{ position: 'absolute', top: 16, left: 16, ...labelStyle }}>
+          {formatImageDate(beforeEntry.imageDate)}
+        </div>
+        <div style={{ position: 'absolute', top: 16, right: 16, ...labelStyle }}>
+          {afterLabel}
+        </div>
+      </div>
+
+      <div
+        style={{
+          padding: '10px 16px',
+          backgroundColor: 'rgba(20, 28, 38, 0.96)',
+          borderTop: '1px solid #2a4a6a',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          fontFamily: 'monospace',
+        }}
+      >
+        <span style={{ color: '#666', fontSize: '10px' }}>
+          {beforeEntry.copyright || '© Google'} — drag to compare
+        </span>
+        <button
+          onClick={onClose}
+          style={{
+            padding: '6px 14px',
+            border: '1px solid #555',
+            borderRadius: '4px',
+            backgroundColor: 'rgba(0,0,0,0.5)',
+            color: '#ccc',
+            cursor: 'pointer',
+            fontSize: '11px',
+            fontFamily: 'monospace',
+          }}
+        >
+          Close comparison
+        </button>
+      </div>
+    </div>
+  );
+};
+
+const labelStyle: React.CSSProperties = {
+  padding: '4px 10px',
+  borderRadius: 4,
+  backgroundColor: 'rgba(0,0,0,0.6)',
+  color: '#fff',
+  fontSize: 12,
+  fontFamily: 'monospace',
+  fontWeight: 700,
+};
+
+export default ComparisonView;

--- a/src/components/HistoricalTimeline.tsx
+++ b/src/components/HistoricalTimeline.tsx
@@ -1,0 +1,214 @@
+import React, { useMemo, useState } from 'react';
+import { formatImageDate, type HistoricalPanoEntry } from '../utils/historicalImagery';
+
+export interface HistoricalTimelineProps {
+  isOpen: boolean;
+  onClose: () => void;
+  entries: HistoricalPanoEntry[];
+  isLoading: boolean;
+  error: string | null;
+  hasTimeline: boolean;
+  currentIndex: number;
+  /** Disabled while a hold-pause hop is already in flight. */
+  isTransitioning: boolean;
+  onSelectDate: (entry: HistoricalPanoEntry) => void;
+  /** Compare-mode support (optional — panel still works as a plain scrubber without it). */
+  onCompare?: (entry: HistoricalPanoEntry) => void;
+  isComparing?: boolean;
+  onExitCompare?: () => void;
+}
+
+const HistoricalTimeline: React.FC<HistoricalTimelineProps> = ({
+  isOpen,
+  onClose,
+  entries,
+  isLoading,
+  error,
+  hasTimeline,
+  currentIndex,
+  isTransitioning,
+  onSelectDate,
+  onCompare,
+  isComparing = false,
+  onExitCompare,
+}) => {
+  const [sliderIndex, setSliderIndex] = useState<number | null>(null);
+
+  const activeIndex = sliderIndex ?? (currentIndex >= 0 ? currentIndex : entries.length - 1);
+  const activeEntry = entries[activeIndex] ?? null;
+
+  const trackDots = useMemo(
+    () => entries.map((e, i) => ({ entry: e, index: i })),
+    [entries]
+  );
+
+  if (!isOpen) return null;
+
+  const handleSlide = (index: number) => {
+    setSliderIndex(index);
+  };
+
+  const handleCommit = (index: number) => {
+    const entry = entries[index];
+    if (!entry || entry.panoId === entries[currentIndex]?.panoId) return;
+    onSelectDate(entry);
+  };
+
+  const dotStyle = (active: boolean): React.CSSProperties => ({
+    width: 8,
+    height: 8,
+    borderRadius: '50%',
+    backgroundColor: active ? '#4FC3F7' : 'rgba(255,255,255,0.35)',
+    flexShrink: 0,
+  });
+
+  return (
+    <div
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+      onKeyDown={(e) => e.stopPropagation()}
+      style={{
+        position: 'absolute',
+        left: '50%',
+        bottom: '24px',
+        transform: 'translateX(-50%)',
+        width: 'min(560px, calc(100vw - 40px))',
+        backgroundColor: 'rgba(20, 28, 38, 0.96)',
+        borderRadius: '12px',
+        border: '1px solid #2a4a6a',
+        zIndex: 100,
+        overflow: 'hidden',
+        boxShadow: '0 8px 32px rgba(0,0,0,0.6)',
+        fontFamily: 'monospace',
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          padding: '12px 16px',
+          borderBottom: '1px solid #2a4a6a',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          backgroundColor: 'rgba(0,0,0,0.3)',
+        }}
+      >
+        <h3 style={{ margin: 0, color: '#4FC3F7', fontSize: '14px', letterSpacing: '0.5px' }}>
+          🕰️ Historical Imagery
+        </h3>
+        <button
+          onClick={onClose}
+          aria-label="Close historical timeline"
+          style={{
+            background: 'none',
+            border: 'none',
+            color: '#aaa',
+            fontSize: '20px',
+            cursor: 'pointer',
+            padding: '0 5px',
+            lineHeight: 1,
+          }}
+        >
+          ×
+        </button>
+      </div>
+
+      <div style={{ padding: '14px 16px' }}>
+        {isLoading && (
+          <div style={{ color: '#aaa', fontSize: '12px', marginBottom: 10 }}>
+            Scanning nearby imagery…
+          </div>
+        )}
+
+        {error && (
+          <div style={{ color: '#ff8a80', fontSize: '12px', marginBottom: 10 }}>
+            {error}
+          </div>
+        )}
+
+        {!isLoading && !error && !hasTimeline && (
+          <div style={{ color: '#ccc', fontSize: '12px', lineHeight: 1.5 }}>
+            {entries.length === 1
+              ? `Only one capture date (${formatImageDate(entries[0]!.imageDate)}) is available near this location.`
+              : 'No historical imagery found near this location.'}
+          </div>
+        )}
+
+        {hasTimeline && (
+          <>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'baseline',
+                marginBottom: 8,
+              }}
+            >
+              <span style={{ color: '#fff', fontSize: '18px', fontWeight: 700 }}>
+                {activeEntry ? formatImageDate(activeEntry.imageDate) : ''}
+              </span>
+              <span style={{ color: '#777', fontSize: '11px' }}>
+                {activeIndex + 1} / {entries.length}
+              </span>
+            </div>
+
+            <input
+              type="range"
+              min={0}
+              max={entries.length - 1}
+              step={1}
+              value={activeIndex}
+              disabled={isTransitioning}
+              onChange={(e) => handleSlide(parseInt(e.target.value, 10))}
+              onMouseUp={(e) => handleCommit(parseInt((e.target as HTMLInputElement).value, 10))}
+              onTouchEnd={(e) => handleCommit(parseInt((e.target as HTMLInputElement).value, 10))}
+              onKeyUp={(e) => handleCommit(parseInt((e.target as HTMLInputElement).value, 10))}
+              style={{ width: '100%', accentColor: '#4FC3F7', opacity: isTransitioning ? 0.5 : 1 }}
+              aria-label="Scrub through available capture dates"
+            />
+
+            {/* Density dots along the track */}
+            <div style={{ display: 'flex', gap: 4, marginTop: 4, marginBottom: 12 }}>
+              {trackDots.map(({ index }) => (
+                <div key={index} style={dotStyle(index === activeIndex)} />
+              ))}
+            </div>
+
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+              {onCompare && (
+                <button
+                  onClick={() =>
+                    isComparing ? onExitCompare?.() : activeEntry && onCompare(activeEntry)
+                  }
+                  disabled={isTransitioning || !activeEntry || activeIndex === currentIndex}
+                  style={{
+                    padding: '6px 12px',
+                    border: `1px solid ${isComparing ? '#4FC3F7' : '#555'}`,
+                    borderRadius: '4px',
+                    backgroundColor: isComparing ? 'rgba(79,195,247,0.25)' : 'rgba(0,0,0,0.5)',
+                    color: isComparing ? '#4FC3F7' : '#ccc',
+                    cursor: (isTransitioning || !activeEntry) ? 'default' : 'pointer',
+                    fontSize: '11px',
+                    fontFamily: 'monospace',
+                    opacity: (isTransitioning || !activeEntry || activeIndex === currentIndex) ? 0.5 : 1,
+                  }}
+                >
+                  {isComparing ? 'Exit compare' : '⇄ Compare with current'}
+                </button>
+              )}
+            </div>
+          </>
+        )}
+
+        {/* Attribution — required by Google's Street View ToS whenever imagery is displayed */}
+        {activeEntry && (
+          <div style={{ marginTop: 12, color: '#666', fontSize: '10px' }}>
+            {activeEntry.copyright || '© Google'}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default HistoricalTimeline;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -32,3 +32,5 @@ export { default as AccessibilityPanel } from './AccessibilityPanel';
 export { default as ScoutCard } from './ScoutCard';
 export { default as AppToolbar } from './AppToolbar';
 export { default as AppBanners } from './AppBanners';
+export { default as HistoricalTimeline } from './HistoricalTimeline';
+export { default as ComparisonView } from './ComparisonView';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -39,6 +39,11 @@ export {
 export { usePanoramaCache } from './usePanoramaCache';
 export { useAdvanceSafe } from './useAdvanceSafe';
 
+// Historical Timeline ("time travel") hooks
+export { useHistoricalImagery, type UseHistoricalImageryResult } from './useHistoricalImagery';
+export { useHistoricalTimeline, type UseHistoricalTimelineResult } from './useHistoricalTimeline';
+export { useHistoricalCompare, type HistoricalComparison } from './useHistoricalCompare';
+
 // Loading integration helpers
 export {
   useStreetViewLoading,

--- a/src/hooks/useAdvanceSafe.ts
+++ b/src/hooks/useAdvanceSafe.ts
@@ -23,7 +23,7 @@ export interface TeleportSafeOptions {
  *  - Returns a Promise that resolves when the transition has finished.
  */
 export function useAdvanceSafe() {
-  const { isPanoramaReady, readyPromise, advance, teleport } = useStreetView();
+  const { isPanoramaReady, readyPromise, advance, teleport, teleportToPano } = useStreetView();
   const panoCache = usePanoramaCache();
 
   const advanceSafe = useCallback(
@@ -73,5 +73,15 @@ export function useAdvanceSafe() {
     [isPanoramaReady, readyPromise, teleport, panoCache]
   );
 
-  return { advanceSafe, teleportSafe, panoCache };
+  const teleportToPanoSafe = useCallback(
+    async (panoId: string) => {
+      if (!isPanoramaReady) {
+        await readyPromise();
+      }
+      teleportToPano(panoId);
+    },
+    [isPanoramaReady, readyPromise, teleportToPano]
+  );
+
+  return { advanceSafe, teleportSafe, teleportToPanoSafe, panoCache };
 }

--- a/src/hooks/useHistoricalCompare.ts
+++ b/src/hooks/useHistoricalCompare.ts
@@ -1,0 +1,74 @@
+import { useState, useCallback } from 'react';
+import type { HistoricalPanoEntry } from '../utils/historicalImagery';
+import type { StreetViewRenderer } from '../renderer/RendererBackend';
+
+export interface HistoricalComparison {
+  beforeUrl: string;
+  afterUrl: string;
+  beforeEntry: HistoricalPanoEntry;
+}
+
+export interface UseHistoricalCompareParams {
+  renderer: StreetViewRenderer | null;
+  teleportToPanoSafe: (panoId: string) => Promise<void>;
+  readyPromise: () => Promise<void>;
+  getCurrentPanoId: () => string | null;
+}
+
+/**
+ * Before/after comparison as a single-GPU-context swipe overlay: captures the
+ * live WebGPU canvas as "after", hold-pause hops to the historical panorama,
+ * captures it as "before", then hops straight back — no second live render
+ * context is ever created (the dual-context path from the feature plan is a
+ * separate, deferred piece of work; see docs/feature_expansion_plan.md §2.2).
+ */
+export function useHistoricalCompare({
+  renderer,
+  teleportToPanoSafe,
+  readyPromise,
+  getCurrentPanoId,
+}: UseHistoricalCompareParams) {
+  const [comparison, setComparison] = useState<HistoricalComparison | null>(null);
+  const [isCapturing, setIsCapturing] = useState(false);
+  const [captureError, setCaptureError] = useState<string | null>(null);
+
+  const compare = useCallback(
+    async (entry: HistoricalPanoEntry) => {
+      if (!renderer) {
+        setCaptureError('Renderer not ready for comparison capture.');
+        return;
+      }
+      const originalPanoId = getCurrentPanoId();
+      if (!originalPanoId || originalPanoId === entry.panoId) return;
+
+      setIsCapturing(true);
+      setCaptureError(null);
+      try {
+        const afterUrl = renderer.getCanvasDataURL();
+
+        await teleportToPanoSafe(entry.panoId);
+        await readyPromise();
+        // Let the release crossfade finish painting before reading the canvas back.
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        const beforeUrl = renderer.getCanvasDataURL();
+
+        await teleportToPanoSafe(originalPanoId);
+        await readyPromise();
+
+        setComparison({ beforeUrl, afterUrl, beforeEntry: entry });
+      } catch (e) {
+        setCaptureError(e instanceof Error ? e.message : 'Failed to capture comparison');
+      } finally {
+        setIsCapturing(false);
+      }
+    },
+    [renderer, teleportToPanoSafe, readyPromise, getCurrentPanoId]
+  );
+
+  const exitCompare = useCallback(() => {
+    setComparison(null);
+    setCaptureError(null);
+  }, []);
+
+  return { compare, exitCompare, comparison, isCapturing, captureError };
+}

--- a/src/hooks/useHistoricalImagery.ts
+++ b/src/hooks/useHistoricalImagery.ts
@@ -1,0 +1,69 @@
+import { useState, useEffect, useRef } from 'react';
+import { getHistoricalImagery, type HistoricalPanoEntry } from '../utils/historicalImagery';
+
+export interface UseHistoricalImageryResult {
+  entries: HistoricalPanoEntry[];
+  isLoading: boolean;
+  error: string | null;
+  /** True once entries has >= 2 distinct dates (acceptance criterion for a usable timeline). */
+  hasTimeline: boolean;
+}
+
+const DEBOUNCE_MS = 400;
+
+/**
+ * Crawls nearby Street View panoramas for distinct capture dates whenever
+ * (lat, lng) settles on a new position. Debounced so rapid navigation
+ * (cruise mode, dragging the mini-map) doesn't spam StreetViewService.
+ *
+ * `currentPanoId` / `currentImageDate` (from the already-loaded panorama)
+ * are merged in as a guaranteed entry so the timeline always includes
+ * "now" even if the nearby-crawl doesn't happen to resample it.
+ */
+export function useHistoricalImagery(
+  lat: number | null,
+  lng: number | null,
+  currentPanoId?: string | null,
+  currentImageDate?: string | null
+): UseHistoricalImageryResult {
+  const [entries, setEntries] = useState<HistoricalPanoEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    if (lat == null || lng == null) return;
+
+    const requestId = ++requestIdRef.current;
+    const timer = setTimeout(async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const crawled = await getHistoricalImagery(lat, lng);
+        if (requestIdRef.current !== requestId) return; // superseded by a newer position
+
+        let merged = crawled;
+        if (currentPanoId && currentImageDate) {
+          const alreadyPresent = crawled.some((e) => e.imageDate === currentImageDate);
+          if (!alreadyPresent) {
+            merged = [
+              ...crawled,
+              { panoId: currentPanoId, imageDate: currentImageDate, lat, lng, copyright: null },
+            ].sort((a, b) => a.imageDate.localeCompare(b.imageDate));
+          }
+        }
+        setEntries(merged);
+      } catch (e) {
+        if (requestIdRef.current !== requestId) return;
+        setError(e instanceof Error ? e.message : 'Failed to load historical imagery');
+        setEntries([]);
+      } finally {
+        if (requestIdRef.current === requestId) setIsLoading(false);
+      }
+    }, DEBOUNCE_MS);
+
+    return () => clearTimeout(timer);
+  }, [lat, lng, currentPanoId, currentImageDate]);
+
+  return { entries, isLoading, error, hasTimeline: entries.length >= 2 };
+}

--- a/src/hooks/useHistoricalTimeline.ts
+++ b/src/hooks/useHistoricalTimeline.ts
@@ -1,0 +1,66 @@
+import { useState, useEffect, useMemo } from 'react';
+import { resolvePanoLocation } from '../utils/panoLocation';
+import { useHistoricalImagery } from './useHistoricalImagery';
+import type { HistoricalPanoEntry } from '../utils/historicalImagery';
+
+export interface UseHistoricalTimelineResult {
+  entries: HistoricalPanoEntry[];
+  isLoading: boolean;
+  error: string | null;
+  hasTimeline: boolean;
+  /** Index of the panorama currently on screen within `entries` (-1 if not present). */
+  currentIndex: number;
+  currentPanoId: string | null;
+}
+
+/**
+ * Combines the current panorama's own capture date (via `resolvePanoLocation`,
+ * cached per pano id) with a nearby-imagery crawl (`useHistoricalImagery`) to
+ * produce the full list of dates the `<HistoricalTimeline />` slider scrubs
+ * through.
+ */
+export function useHistoricalTimeline(
+  panorama: google.maps.StreetViewPanorama | null
+): UseHistoricalTimelineResult {
+  const [currentPanoId, setCurrentPanoId] = useState<string | null>(null);
+  const [currentImageDate, setCurrentImageDate] = useState<string | null>(null);
+  const [lat, setLat] = useState<number | null>(null);
+  const [lng, setLng] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!panorama) return;
+    let cancelled = false;
+
+    const position = panorama.getPosition();
+    if (position) {
+      setLat(position.lat());
+      setLng(position.lng());
+    }
+    setCurrentPanoId(panorama.getPano() || null);
+
+    resolvePanoLocation(panorama)
+      .then((info) => {
+        if (cancelled || !info) return;
+        setCurrentImageDate(info.captureDate);
+        if (info.lat != null) setLat(info.lat);
+        if (info.lng != null) setLng(info.lng);
+      })
+      .catch(() => { /* keep whatever synchronous info we already have */ });
+
+    return () => { cancelled = true; };
+  }, [panorama, panorama?.getPano()]); // eslint-disable-line react-hooks/exhaustive-deps -- re-resolve on every pano hop
+
+  const { entries, isLoading, error, hasTimeline } = useHistoricalImagery(
+    lat,
+    lng,
+    currentPanoId,
+    currentImageDate
+  );
+
+  const currentIndex = useMemo(
+    () => entries.findIndex((e) => e.panoId === currentPanoId),
+    [entries, currentPanoId]
+  );
+
+  return { entries, isLoading, error, hasTimeline, currentIndex, currentPanoId };
+}

--- a/src/hooks/useStreetView.tsx
+++ b/src/hooks/useStreetView.tsx
@@ -39,6 +39,8 @@ export interface StreetViewState {
   // Navigation
   advance: (direction: 'forward' | 'backward' | 'left' | 'right', currentHeading?: number) => void;
   teleport: (lat: number, lng: number, targetHeading?: number, targetPitch?: number) => void;
+  /** Jump straight to a known panorama id (e.g. a historical capture) with the same hold-pause treatment. */
+  teleportToPano: (panoId: string) => void;
   
   // Transition state
   isTransitioning: boolean;
@@ -293,7 +295,18 @@ export const StreetViewProvider: React.FC<StreetViewProviderProps> = ({
       setPitch(targetPitch);
     }
   }, [isTransitioning, armHold, setHeading, setPitch]);
-  
+
+  // Jump directly to a known panorama id (historical capture, saved bookmark
+  // pano, etc). Heading/pitch are left untouched so a POV comparison stays
+  // apples-to-apples across dates. Same hold-pause treatment as advance/teleport.
+  const teleportToPano = useCallback((panoId: string) => {
+    const pano = panoramaRef.current;
+    if (!pano || isTransitioning || !panoId) return;
+
+    armHold();
+    pano.setPano(panoId);
+  }, [isTransitioning, armHold]);
+
   // Listen for panorama changes
   useEffect(() => {
     const pano = panoramaRef.current;
@@ -478,6 +491,7 @@ export const StreetViewProvider: React.FC<StreetViewProviderProps> = ({
     setPosition,
     advance,
     teleport,
+    teleportToPano,
     isTransitioning,
     setIsTransitioning,
     isPanoramaReady,

--- a/src/utils/historicalImagery.test.ts
+++ b/src/utils/historicalImagery.test.ts
@@ -1,0 +1,133 @@
+import {
+  offsetLatLng,
+  buildSamplePoints,
+  dedupeByDate,
+  formatImageDate,
+  readHistoricalCache,
+  writeHistoricalCache,
+  type HistoricalPanoEntry,
+} from './historicalImagery';
+
+describe('offsetLatLng', () => {
+  it('moves north for bearing 0', () => {
+    const { lat, lng } = offsetLatLng(0, 0, 100, 0);
+    expect(lat).toBeGreaterThan(0);
+    expect(lng).toBeCloseTo(0, 5);
+  });
+
+  it('moves east for bearing 90', () => {
+    const { lat, lng } = offsetLatLng(0, 0, 100, 90);
+    expect(lng).toBeGreaterThan(0);
+    expect(lat).toBeCloseTo(0, 5);
+  });
+
+  it('returns the origin for zero distance', () => {
+    const { lat, lng } = offsetLatLng(37.5, -122.3, 0, 45);
+    expect(lat).toBeCloseTo(37.5, 6);
+    expect(lng).toBeCloseTo(-122.3, 6);
+  });
+});
+
+describe('buildSamplePoints', () => {
+  it('includes the center point first', () => {
+    const points = buildSamplePoints(10, 20);
+    expect(points[0]).toEqual({ lat: 10, lng: 20 });
+  });
+
+  it('produces sampleCount + 1 points', () => {
+    const points = buildSamplePoints(10, 20, { sampleCount: 6 });
+    expect(points).toHaveLength(7);
+  });
+
+  it('spreads ring points away from the center', () => {
+    const points = buildSamplePoints(10, 20, { radiusMeters: 25, sampleCount: 4 });
+    for (const p of points.slice(1)) {
+      expect(p.lat !== 10 || p.lng !== 20).toBe(true);
+    }
+  });
+});
+
+describe('dedupeByDate', () => {
+  const entry = (panoId: string, imageDate: string): HistoricalPanoEntry => ({
+    panoId,
+    imageDate,
+    lat: 0,
+    lng: 0,
+    copyright: null,
+  });
+
+  it('keeps only the first entry per distinct date', () => {
+    const result = dedupeByDate([
+      entry('a', '2020-01'),
+      entry('b', '2020-01'),
+      entry('c', '2021-06'),
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result.map((e) => e.panoId)).toEqual(['a', 'c']);
+  });
+
+  it('drops entries with an empty imageDate', () => {
+    const result = dedupeByDate([entry('a', ''), entry('b', '2022-03')]);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.panoId).toBe('b');
+  });
+
+  it('sorts chronologically ascending', () => {
+    const result = dedupeByDate([
+      entry('c', '2022-01'),
+      entry('a', '2018-05'),
+      entry('b', '2020-11'),
+    ]);
+    expect(result.map((e) => e.imageDate)).toEqual(['2018-05', '2020-11', '2022-01']);
+  });
+
+  it('returns an empty array for no entries', () => {
+    expect(dedupeByDate([])).toEqual([]);
+  });
+});
+
+describe('formatImageDate', () => {
+  it('formats year-month into a readable label', () => {
+    expect(formatImageDate('2022-05')).toBe('May 2022');
+  });
+
+  it('formats a year-only string', () => {
+    expect(formatImageDate('2019')).toBe('2019');
+  });
+
+  it('passes through unrecognized formats untouched', () => {
+    expect(formatImageDate('not-a-date')).toBe('not-a-date');
+  });
+});
+
+describe('historical imagery localStorage cache', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns null when nothing is cached', () => {
+    expect(readHistoricalCache(1, 2)).toBeNull();
+  });
+
+  it('round-trips entries through the cache', () => {
+    const entries: HistoricalPanoEntry[] = [
+      { panoId: 'p1', imageDate: '2021-01', lat: 1, lng: 2, copyright: '© Google' },
+    ];
+    writeHistoricalCache(1, 2, entries);
+    expect(readHistoricalCache(1, 2)).toEqual(entries);
+  });
+
+  it('expires stale cache entries', () => {
+    const entries: HistoricalPanoEntry[] = [
+      { panoId: 'p1', imageDate: '2021-01', lat: 1, lng: 2, copyright: null },
+    ];
+    writeHistoricalCache(1, 2, entries);
+    const realNow = Date.now;
+    Date.now = () => realNow() + 8 * 24 * 60 * 60 * 1000; // 8 days later
+    try {
+      expect(readHistoricalCache(1, 2)).toBeNull();
+    } finally {
+      Date.now = realNow;
+    }
+  });
+});

--- a/src/utils/historicalImagery.ts
+++ b/src/utils/historicalImagery.ts
@@ -1,0 +1,220 @@
+/**
+ * historicalImagery.ts
+ *
+ * Data acquisition for the Historical Timeline ("time travel") feature.
+ *
+ * Google's Street View JS API has no endpoint that lists every historical
+ * capture for a location. The only usable levers are:
+ *   - `StreetViewPanoramaData.imageDate` on whichever panorama a query
+ *     resolves to (works for both `{ pano }` and `{ location }` lookups).
+ *   - Nearby panoramas within a small radius sometimes resolve to a
+ *     *different* capture (Google occasionally keeps an older pano reachable
+ *     a few meters from the newest one along the same stretch of road).
+ *
+ * `crawlHistoricalImagery` samples a small ring of points around the given
+ * center (plus the center itself) and dedupes whatever distinct
+ * `imageDate` values come back. This is a best-effort scan, not a complete
+ * archive — most locations will only ever yield 1-2 distinct dates.
+ */
+
+export interface HistoricalPanoEntry {
+  panoId: string;
+  /** Capture date string from Google, e.g. "2022-05". */
+  imageDate: string;
+  lat: number;
+  lng: number;
+  /** Attribution string Google requires be shown alongside the imagery. */
+  copyright: string | null;
+}
+
+export interface CrawlOptions {
+  /** Ring radius in meters to sample around the center point. Default 10m. */
+  radiusMeters?: number;
+  /** Number of points sampled around the ring (plus the center). Default 8. */
+  sampleCount?: number;
+  /** Passed through to StreetViewService.getPanorama's `radius` param. */
+  searchRadiusMeters?: number;
+}
+
+const DEFAULT_OPTIONS: Required<CrawlOptions> = {
+  radiusMeters: 10,
+  sampleCount: 8,
+  searchRadiusMeters: 50,
+};
+
+const EARTH_RADIUS_METERS = 6371000;
+
+/** Offsets a lat/lng by `distanceMeters` along `bearingDeg` (0 = north, clockwise). */
+export function offsetLatLng(
+  lat: number,
+  lng: number,
+  distanceMeters: number,
+  bearingDeg: number
+): { lat: number; lng: number } {
+  const bearing = (bearingDeg * Math.PI) / 180;
+  const latRad = (lat * Math.PI) / 180;
+  const lngRad = (lng * Math.PI) / 180;
+  const angularDistance = distanceMeters / EARTH_RADIUS_METERS;
+
+  const newLatRad = Math.asin(
+    Math.sin(latRad) * Math.cos(angularDistance) +
+      Math.cos(latRad) * Math.sin(angularDistance) * Math.cos(bearing)
+  );
+  const newLngRad =
+    lngRad +
+    Math.atan2(
+      Math.sin(bearing) * Math.sin(angularDistance) * Math.cos(latRad),
+      Math.cos(angularDistance) - Math.sin(latRad) * Math.sin(newLatRad)
+    );
+
+  return { lat: (newLatRad * 180) / Math.PI, lng: (newLngRad * 180) / Math.PI };
+}
+
+/** Builds the ring of sample points (center first) used by the crawl. */
+export function buildSamplePoints(
+  centerLat: number,
+  centerLng: number,
+  opts: CrawlOptions = {}
+): Array<{ lat: number; lng: number }> {
+  const { radiusMeters, sampleCount } = { ...DEFAULT_OPTIONS, ...opts };
+  const points = [{ lat: centerLat, lng: centerLng }];
+  for (let i = 0; i < sampleCount; i++) {
+    const bearing = (360 / sampleCount) * i;
+    points.push(offsetLatLng(centerLat, centerLng, radiusMeters, bearing));
+  }
+  return points;
+}
+
+/**
+ * Dedupe a list of raw (panoId, imageDate) results down to one entry per
+ * distinct `imageDate`, keeping the first (closest-sampled) occurrence, and
+ * sorts the result chronologically ascending.
+ */
+export function dedupeByDate(entries: HistoricalPanoEntry[]): HistoricalPanoEntry[] {
+  const seen = new Map<string, HistoricalPanoEntry>();
+  for (const entry of entries) {
+    if (!entry.imageDate) continue;
+    if (!seen.has(entry.imageDate)) {
+      seen.set(entry.imageDate, entry);
+    }
+  }
+  return Array.from(seen.values()).sort((a, b) => a.imageDate.localeCompare(b.imageDate));
+}
+
+function queryPanorama(
+  service: google.maps.StreetViewService,
+  location: { lat: number; lng: number },
+  searchRadiusMeters: number
+): Promise<HistoricalPanoEntry | null> {
+  return new Promise((resolve) => {
+    service.getPanorama(
+      { location: new google.maps.LatLng(location.lat, location.lng), radius: searchRadiusMeters },
+      (data, status) => {
+        if (status !== google.maps.StreetViewStatus.OK || !data?.location?.pano) {
+          resolve(null);
+          return;
+        }
+        const panoData = data as google.maps.StreetViewPanoramaData;
+        const latLng = panoData.location?.latLng;
+        resolve({
+          panoId: panoData.location!.pano!,
+          imageDate: panoData.imageDate ?? '',
+          lat: latLng ? latLng.lat() : location.lat,
+          lng: latLng ? latLng.lng() : location.lng,
+          copyright: panoData.copyright ?? null,
+        });
+      }
+    );
+  });
+}
+
+/**
+ * Samples a small ring around (centerLat, centerLng) and returns the
+ * distinct capture dates found, sorted chronologically. Never rejects —
+ * network/quota failures for individual sample points are swallowed.
+ */
+export async function crawlHistoricalImagery(
+  centerLat: number,
+  centerLng: number,
+  opts: CrawlOptions = {}
+): Promise<HistoricalPanoEntry[]> {
+  if (typeof google === 'undefined' || !google.maps) return [];
+  const merged = { ...DEFAULT_OPTIONS, ...opts };
+  const service = new google.maps.StreetViewService();
+  const points = buildSamplePoints(centerLat, centerLng, merged);
+
+  const results = await Promise.all(
+    points.map((p) => queryPanorama(service, p, merged.searchRadiusMeters).catch(() => null))
+  );
+
+  const found = results.filter((r): r is HistoricalPanoEntry => r !== null && !!r.imageDate);
+  return dedupeByDate(found);
+}
+
+// --- localStorage cache (keyed by a coarse lat/lng grid cell) -------------
+
+const CACHE_KEY_PREFIX = 'webgpu_streetview_historical_';
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const GRID_PRECISION = 4; // ~11m grid cells at the equator
+
+interface CacheRecord {
+  entries: HistoricalPanoEntry[];
+  cachedAt: number;
+}
+
+function cellKey(lat: number, lng: number): string {
+  return `${CACHE_KEY_PREFIX}${lat.toFixed(GRID_PRECISION)}_${lng.toFixed(GRID_PRECISION)}`;
+}
+
+export function readHistoricalCache(lat: number, lng: number): HistoricalPanoEntry[] | null {
+  try {
+    const raw = localStorage.getItem(cellKey(lat, lng));
+    if (!raw) return null;
+    const record: CacheRecord = JSON.parse(raw);
+    if (Date.now() - record.cachedAt > CACHE_TTL_MS) return null;
+    return record.entries;
+  } catch {
+    return null;
+  }
+}
+
+export function writeHistoricalCache(lat: number, lng: number, entries: HistoricalPanoEntry[]): void {
+  try {
+    const record: CacheRecord = { entries, cachedAt: Date.now() };
+    localStorage.setItem(cellKey(lat, lng), JSON.stringify(record));
+  } catch {
+    // Storage full or unavailable — caching is a pure optimization, skip silently.
+  }
+}
+
+/**
+ * Cached wrapper around `crawlHistoricalImagery`: serves a fresh cache hit
+ * without touching the network, otherwise crawls and populates the cache.
+ */
+export async function getHistoricalImagery(
+  centerLat: number,
+  centerLng: number,
+  opts: CrawlOptions = {}
+): Promise<HistoricalPanoEntry[]> {
+  const cached = readHistoricalCache(centerLat, centerLng);
+  if (cached) return cached;
+
+  const entries = await crawlHistoricalImagery(centerLat, centerLng, opts);
+  writeHistoricalCache(centerLat, centerLng, entries);
+  return entries;
+}
+
+/** Formats "2022-05" -> "May 2022", or passes through partial/odd formats untouched. */
+export function formatImageDate(imageDate: string): string {
+  const match = /^(\d{4})(?:-(\d{2}))?$/.exec(imageDate);
+  if (!match) return imageDate;
+  const [, year, month] = match;
+  if (!month) return year!;
+  const monthNames = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ];
+  const idx = parseInt(month, 10) - 1;
+  const label = monthNames[idx] ?? month;
+  return `${label} ${year}`;
+}


### PR DESCRIPTION
## Summary

Implements the "time travel" feature described in `docs/feature_expansion_plan.md` §2 (Historical Imagery) and the accompanying vision doc: users can scrub through available Google Street View capture dates at their current location and compare a historical view against the current one.

- **`src/utils/historicalImagery.ts`** — Street View's JS API has no endpoint that lists historical captures directly, so this samples a small ring of nearby panoramas (center + 8 points at 10m) via `StreetViewService`, dedupes the distinct `imageDate` values found, and sorts them chronologically. Results are cached in `localStorage` (7-day TTL, lat/lng grid key) following the same pattern already used by `useBookmarks`/`useLocationHistory` elsewhere in the app (no new `idb` dependency).
- **`useHistoricalImagery` / `useHistoricalTimeline`** — hooks that debounce the crawl on position changes and merge in the current panorama's own capture date (via the existing `resolvePanoLocation()` cache in `panoLocation.ts`).
- **`useStreetView.teleportToPano()`** — new navigation action reusing the existing hold-pause `armHold()` infrastructure (#105–#108) so switching dates never flashes blurry tile pop-in. `teleportToPanoSafe()` was added alongside the existing `advanceSafe`/`teleportSafe` wrappers in `useAdvanceSafe`.
- **`<HistoricalTimeline />`** — range-slider panel (year/month labels, per-date density dots, empty state, Google attribution/copyright) wired into `AppToolbar` (🕰 Time Travel) and `App.tsx`, styled to match the existing `WeatherPanel`/panel conventions.
- **`<ComparisonView />` + `useHistoricalCompare`** — before/after swipe comparison. Rather than standing up a second live WebGPU context (the plan's §2.2 dual-context option, which doubles GPU memory), it captures two canvas snapshots via the already-existing `renderer.getCanvasDataURL()` — one before and one after a hold-pause hop to the historical pano — and swipes between them. True dual-context linked-POV comparison is left as a documented follow-up per the plan's own "foundation first" dependency note.

## Acceptance criteria

- [x] Timeline shows ≥ 2 dates when historical panos exist near current location
- [x] Transitions use hold-pause (no blurry tile pop-in) — via `teleportToPano`
- [x] Comparison mode — implemented as a snapshot-based swipe overlay (both snapshots share the same heading/pitch since `teleportToPano` never touches POV); full live dual-context linking deferred
- [x] Graceful empty state when only one date available
- [x] Attribution/copyright displayed per Google ToS

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx react-scripts test --watchAll=false` — 170/170 tests pass across 16 suites (16 new tests in `historicalImagery.test.ts` covering the crawl offset math, dedupe/sort logic, date formatting, and the localStorage cache)
- [x] `npx react-scripts build` — compiles successfully
- [ ] Manual browser verification (requires a live Google Maps API key + a location with multiple historical captures — not available in this sandboxed session)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FBS8HD2goXijaeR4zK94JX)_