### PR TITLE
Stop bundling Cesium into main.js; drop dead @xenova/transformers dep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,24 @@ jobs:
         env:
           CI: false
 
+      - name: Bundle size report
+        # Visibility only — does not fail the build. Watches for regressions
+        # like Cesium (or another heavy dep) creeping back into main.js; see
+        # docs/DEVELOPER_CONTEXT.md#6-chunk-strategy-bundle-size.
+        run: |
+          echo "### JS bundle sizes (gzip)" | tee -a "$GITHUB_STEP_SUMMARY"
+          npx --no-install source-map-explorer 'build/static/js/*.js' --html /tmp/bundle-report.html || true
+          for f in build/static/js/*.js; do
+            gzip -c "$f" | wc -c | awk -v f="$f" '{printf "%s: %.1f kB\n", f, $1/1024}'
+          done | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload bundle report
+        uses: actions/upload-artifact@v4
+        with:
+          name: bundle-report
+          path: /tmp/bundle-report.html
+          if-no-files-found: ignore
+
   # Optional parity check: rebuild the WASM module through the full C++/Emscripten
   # path (cpp/src/noise_module.cpp) instead of the hand-written WAT source, so a
   # regression in the C++ implementation doesn't go unnoticed. Not required for

--- a/docs/DEVELOPER_CONTEXT.md
+++ b/docs/DEVELOPER_CONTEXT.md
@@ -85,4 +85,35 @@ This application is a WebGPU-accelerated Street View viewer. It acts as a wrappe
 3.  `useEffect` in `App` calls `panorama.setPov({ heading })`.
 4.  Google Maps rotates the hidden view.
 5.  The hidden canvas updates its pixels.
+
+## 6. Chunk Strategy (Bundle Size)
+
+The FreeLook route (the app's default first paint) must never download the CesiumJS
+globe stack. Two rules keep it that way:
+
+*   **Never statically `import` the `cesium` npm package.** `GlobeView.tsx` and
+    `MiniMap.tsx`'s globe view both talk to a global `Cesium` object
+    (`declare const Cesium: any;`) that's injected at runtime by
+    `loadCesiumSDK()` in `src/hooks/useGlobeMode.ts` — a `<script>`/`<link>` tag
+    pointed at the jsDelivr CDN build of Cesium, loaded on first entry into
+    Globe View (or the mini-map's globe toggle), never before. Re-introducing
+    `import * as Cesium from 'cesium'` anywhere puts the whole globe stack back
+    into `main.js` for every user, because webpack has no `"sideEffects": false`
+    hint to safely tree-shake an unused-but-imported module.
+*   **`GlobeView` is deliberately not re-exported from `src/components/index.ts`.**
+    `App.tsx` imports it as `const GlobeView = lazy(() => import('./components/GlobeView'));`
+    and renders it inside `<Suspense fallback={null}>`, so it ships as its own
+    chunk (`729.*.chunk.js` at last measurement, a few KB gzipped since it has
+    no bundled Cesium code) instead of inline in `main.js`. Re-exporting it from
+    the barrel would defeat the code-split — anything importing the barrel
+    would pull `GlobeView` back into its own chunk eagerly.
+*   **`@xenova/transformers` was removed** (was listed in `package.json` with
+    zero imports anywhere in `src/` — pure dead weight on every `npm install`).
+    Re-add it only alongside the feature that actually uses it, pinned to a
+    real version (never `"latest"`).
+*   **Checking for regressions:** run `npm run build`, then either grep the
+    output for stack-specific tokens (`grep -c Cesium build/static/js/main.*.js`
+    should be ~0-1, just the CDN URL string) or run
+    `npx source-map-explorer 'build/static/js/*.js'` for a visual breakdown.
+    `npm run analyze` wraps the latter.
 6.  `Renderer.ts` uploads the new pixels in the next render pass.

--- a/package.json
+++ b/package.json
@@ -8,15 +8,12 @@
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
-    "@types/cesium": "^1.67.14",
     "@types/jest": "^27.5.2",
     "@types/node": "^16.18.126",
     "@types/react": "^19.1.11",
     "@types/react-dom": "^19.1.8",
     "@webgpu/types": "^0.1.64",
-    "@xenova/transformers": "latest",
     "ajv": "^8.18.0",
-    "cesium": "^1.140.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-scripts": "^5.0.1",
@@ -34,7 +31,8 @@
     "typecheck": "tsc --noEmit",
     "eject": "react-scripts eject",
     "validate:maps-key": "node -e \"\nconst k=process.env.REACT_APP_MAPS_API_KEY||''; const bad=!k||/placeholder|your_|replace/i.test(k);\nconsole.log(bad ? '❌ Key missing or placeholder' : '✅ Key looks configured ('+k.length+' chars)');\nprocess.exit(bad?1:0);\n\"",
-    "probe:hold-pause": "node scripts/hold-pause-probe.mjs"
+    "probe:hold-pause": "node scripts/hold-pause-probe.mjs",
+    "analyze": "source-map-explorer 'build/static/js/*.js' --html /tmp/bundle-report.html"
   },
   "eslintConfig": {
     "extends": [
@@ -59,6 +57,7 @@
     "@types/suncalc": "^1.9.2",
     "@types/three": "^0.160.0",
     "playwright": "^1.60.0",
+    "source-map-explorer": "^2.5.3",
     "typescript": "^4.9.5",
     "wabt": "^1.0.39"
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, lazy, Suspense } from 'react';
 import StreetView, { type MapsLoadStatus } from './components/StreetView';
 import WelcomeModal from './components/WelcomeModal';
 import type { RendererBackendType } from './renderer/RendererBackend';
@@ -27,7 +27,6 @@ import {
   ColorGradingPanel,
   WeatherPanel,
   AccessibilityPanel,
-  GlobeView,
   PerformanceStatsOverlay,
   RendererBackendIndicator,
   WebGPUCanvas,
@@ -35,6 +34,7 @@ import {
   HistoricalTimeline,
   ComparisonView,
 } from './components';
+
 import { useHistoricalTimeline } from './hooks/useHistoricalTimeline';
 import { useHistoricalCompare } from './hooks/useHistoricalCompare';
 import { formatImageDate } from './utils/historicalImagery';
@@ -62,6 +62,9 @@ import BuildBadge from './components/BuildBadge';
 import { getMemoryProfiler, MemoryStats } from './utils/memoryProfiler';
 import { clearAuthFailure, loadMapsApi, onMapsAuthFailure, removeFailedBootstrap } from './services/maps/loader';
 
+// GlobeView pulls in the CesiumJS globe overlay; lazy-load it as its own
+// chunk so users who never leave FreeLook don't pay for it on first paint.
+const GlobeView = lazy(() => import('./components/GlobeView'));
 
 // Google Maps API Key resolution (matches go.1ink.us — baked into the JS bundle):
 //  1. REACT_APP_MAPS_API_KEY — set at `npm run build` via .env.local / CI env var
@@ -949,6 +952,7 @@ function InnerApp() {
             </div>
           )}
           {globeMode.isVisible && (
+            <Suspense fallback={null}>
             <GlobeView
               transition={globeMode.transition}
               currentLat={panorama?.getPosition()?.lat() ?? 39.2575}
@@ -973,6 +977,7 @@ function InnerApp() {
               onExitComplete={globeMode.onExitComplete}
               onStartJourney={handleStartJourney}
             />
+            </Suspense>
           )}
         </>
       )}

--- a/src/components/MiniMap.tsx
+++ b/src/components/MiniMap.tsx
@@ -1,9 +1,14 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
-import * as Cesium from 'cesium';
-import 'cesium/Build/Cesium/Widgets/widgets.css';
+import { loadCesiumSDK } from '../hooks/useGlobeMode';
 
 // Import crypto companies config
 import { CRYPTO_COMPANIES } from '../config/cryptoCompanies';
+
+// Cesium is loaded from CDN at runtime (see loadCesiumSDK), not bundled —
+// keeps the ~4MB globe stack out of the main chunk for users who never
+// switch to globe view.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare const Cesium: any;
 
 interface MiniMapProps {
     apiKey: string;
@@ -27,12 +32,12 @@ const MiniMap: React.FC<MiniMapProps> = ({
     const mapRef = useRef<HTMLDivElement>(null);
     const cesiumRef = useRef<HTMLDivElement>(null);
     const [map, setMap] = useState<google.maps.Map | null>(null);
-    const [cesiumViewer, setCesiumViewer] = useState<Cesium.Viewer | null>(null);
+    const [cesiumViewer, setCesiumViewer] = useState<any>(null);
     const [marker, setMarker] = useState<google.maps.marker.AdvancedMarkerElement | null>(null);
     const [breadcrumbs, setBreadcrumbs] = useState<google.maps.LatLng[]>([]);
     const breadcrumbMarkersRef = useRef<google.maps.marker.AdvancedMarkerElement[]>([]);
     const routeLineRef = useRef<google.maps.Polyline | null>(null);
-    const cryptoMarkersRef = useRef<(google.maps.marker.AdvancedMarkerElement | Cesium.Entity)[]>([]);
+    const cryptoMarkersRef = useRef<(google.maps.marker.AdvancedMarkerElement | any)[]>([]);
 
     /** Create a heading-aware marker element */
     const createMarkerContent = (rotation: number): HTMLElement => {
@@ -168,6 +173,9 @@ const MiniMap: React.FC<MiniMapProps> = ({
             if (viewMode !== 'globe' || !cesiumRef.current || cesiumViewer) return;
 
             try {
+                await loadCesiumSDK();
+                if (viewMode !== 'globe' || !cesiumRef.current) return; // bailed out while loading
+
                 Cesium.Ion.defaultAccessToken = process.env.REACT_APP_CESIUM_ION_TOKEN || '';
 
                 const viewer = new Cesium.Viewer(cesiumRef.current, {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,10 @@
 /**
  * Components index - Export all components
+ *
+ * GlobeView is intentionally NOT re-exported here: consumers must
+ * `React.lazy(() => import('./GlobeView'))` it directly so webpack code-splits
+ * it into its own chunk instead of pulling it into every barrel importer's
+ * bundle. See docs/DEVELOPER_CONTEXT.md#chunk-strategy.
  */
 
 export { 
@@ -27,7 +32,6 @@ export { default as ColorGradingPanel } from './ColorGradingPanel';
 export { default as PerformanceStatsOverlay } from './PerformanceStatsOverlay';
 export { default as RendererBackendIndicator } from './RendererBackendIndicator';
 export { default as WeatherPanel } from './WeatherPanel';
-export { default as GlobeView } from './GlobeView';
 export { default as AccessibilityPanel } from './AccessibilityPanel';
 export { default as ScoutCard } from './ScoutCard';
 export { default as AppToolbar } from './AppToolbar';

--- a/src/hooks/useGlobeMode.ts
+++ b/src/hooks/useGlobeMode.ts
@@ -5,7 +5,12 @@ export type GlobeTransition = 'inactive' | 'loading' | 'entering' | 'active' | '
 // Singleton load promise so multiple calls don't spawn duplicate <script> tags
 let cesiumLoadPromise: Promise<void> | null = null;
 
-function loadCesiumSDK(): Promise<void> {
+/**
+ * Loads the Cesium SDK from a CDN `<script>`/`<link>` tag instead of bundling
+ * the `cesium` npm package, so the ~4MB globe stack never ships in the main
+ * webpack chunk. Shared by GlobeView and MiniMap's globe view.
+ */
+export function loadCesiumSDK(): Promise<void> {
     if (cesiumLoadPromise) return cesiumLoadPromise;
     cesiumLoadPromise = new Promise<void>((resolve, reject) => {
         if ((window as Window & { Cesium?: unknown }).Cesium) {


### PR DESCRIPTION
## Summary

- `MiniMap.tsx` statically `import * as Cesium from 'cesium'`. Because it was re-exported eagerly through `components/index.ts` → `App.tsx`, the entire CesiumJS globe stack loaded on first paint even though `MiniMap` isn't rendered anywhere in the app today. It now uses the same CDN-loaded global `Cesium` approach `GlobeView.tsx` already relies on (`loadCesiumSDK()`, now exported from `useGlobeMode.ts`), so the `cesium` npm package is never statically imported anywhere in `src/`.
- Removed the now-unused `cesium` / `@types/cesium` dependencies.
- Removed `@xenova/transformers` (`"latest"`, zero imports anywhere in `src/` — dead weight on every `npm install`).
- `GlobeView` is now lazy-loaded in `App.tsx` via `React.lazy` + `Suspense`, and no longer re-exported from the `components` barrel, so it code-splits into its own chunk instead of riding along with every barrel import.
- Added an `analyze` script (`source-map-explorer`) and a non-blocking bundle-size report step in CI (prints gzip sizes + uploads an HTML report artifact).
- Documented the chunk strategy in `docs/DEVELOPER_CONTEXT.md` so this doesn't regress.

## Verification

- `grep -c Cesium build/static/js/main.*.js` → 1 (just the CDN URL string in `useGlobeMode.ts`), confirming the `cesium` package is no longer statically bundled.
- `GlobeView` now ships as its own ~4.3 kB gzip chunk (`729.*.chunk.js`) rather than inline in `main.js`.
- `npm run typecheck`, `npm test` (170/170 passing), and `npm run build` (incl. `scripts/verify-build.sh`) all pass.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test -- --watchAll=false` (170 tests passing)
- [x] `npm run build` succeeds, `verify-build.sh` passes
- [x] Confirmed `cesium` package absent from `main.js` via grep
- [ ] Manual smoke test in browser: FreeLook loads without a Cesium network request; Globe View still works after lazy load

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EZGCjjjZ9iaRxsyrPqKovW)_