### PR TITLE
Add Street View Tour recording, playback, and export/import

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import {
   LoadingOverlay,
   HistoricalTimeline,
   ComparisonView,
+  TourPanel,
 } from './components';
 
 import { useHistoricalTimeline } from './hooks/useHistoricalTimeline';
@@ -43,6 +44,7 @@ import { formatImageDate } from './utils/historicalImagery';
 import { useBookmarks } from './hooks/useBookmarks';
 import { useLocationHistory } from './hooks/useLocationHistory';
 import { useSnapshots } from './hooks/useSnapshots';
+import { useTours, type CurrentPOV } from './hooks/useTours';
 import { useGlobeMode } from './hooks/useGlobeMode';
 import {
   useKeyboardShortcuts,
@@ -109,7 +111,7 @@ if (!INITIAL_MAPS_KEY) {
  */
 function InnerApp() {
   // Connect to contexts
-  const { setCanvas, setPanorama, panorama, heading, pitch, canvas, isTransitioning, isPanoramaReady, renderer, readyPromise } = useStreetView();
+  const { setCanvas, setPanorama, panorama, heading, pitch, zoom, canvas, isTransitioning, isPanoramaReady, renderer, readyPromise, locationName, setHeading, setPitch, setZoom } = useStreetView();
   const { advanceSafe, teleportSafe, teleportToPanoSafe, panoCache } = useAdvanceSafe();
   const { viewMode, toggleViewMode } = useViewMode();
   const {
@@ -204,6 +206,7 @@ function InnerApp() {
   const [isWeatherPanelOpen, setIsWeatherPanelOpen] = useState(false);
   const [isAccessibilityPanelOpen, setIsAccessibilityPanelOpen] = useState(false);
   const [isHistoricalTimelineOpen, setIsHistoricalTimelineOpen] = useState(false);
+  const [isTourPanelOpen, setIsTourPanelOpen] = useState(false);
   const [showPerformanceStats, setShowPerformanceStats] = useState(false);
   
   // Accessibility
@@ -236,6 +239,24 @@ function InnerApp() {
   } = useBookmarks();
   const { history, removeFromHistory, clearHistory } = useLocationHistory();
   const { snapshots, removeSnapshot, updateSnapshotName, downloadSnapshot, clearAllSnapshots } = useSnapshots();
+  const {
+    tours,
+    isRecording: isTourRecording,
+    isPaused: isTourPaused,
+    draftWaypoints: tourDraftWaypoints,
+    startRecording: startTourRecording,
+    pauseRecording: pauseTourRecording,
+    resumeRecording: resumeTourRecording,
+    stopRecording: stopTourRecording,
+    cancelRecording: cancelTourRecording,
+    addWaypointFromCurrent: addTourWaypoint,
+    deleteTour,
+    renameTour,
+    updateTourSettings,
+    downloadTourJson,
+    downloadTourKml,
+    importTourFromJson,
+  } = useTours();
   const globeMode = useGlobeMode();
 
   // Historical Timeline ("time travel") — scrub through capture dates near the current location.
@@ -501,6 +522,18 @@ function InnerApp() {
     });
   };
   
+  const getCurrentPOV = useCallback((): CurrentPOV | null => {
+    if (!panorama) return null;
+    const pos = panorama.getPosition();
+    const panoId = panorama.getPano();
+    if (!pos || !panoId) return null;
+    return {
+      panoId,
+      position: { lat: pos.lat(), lng: pos.lng() },
+      pov: { heading, pitch, zoom },
+    };
+  }, [panorama, heading, pitch, zoom]);
+
   const handleGlobeTeleport = useGlobeTeleport({
     teleportSafe,
     applyTimeOfDayPreset,
@@ -540,6 +573,8 @@ function InnerApp() {
     setIsAccessibilityPanelOpen,
     isWeatherPanelOpen,
     setIsWeatherPanelOpen,
+    isTourPanelOpen,
+    setIsTourPanelOpen,
     viewMode,
     toggleViewMode,
     rainIntensity,
@@ -796,6 +831,8 @@ function InnerApp() {
             setIsWeatherPanelOpen={setIsWeatherPanelOpen}
             isHistoricalTimelineOpen={isHistoricalTimelineOpen}
             setIsHistoricalTimelineOpen={setIsHistoricalTimelineOpen}
+            isTourPanelOpen={isTourPanelOpen}
+            setIsTourPanelOpen={setIsTourPanelOpen}
             viewMode={viewMode}
             toggleViewMode={toggleViewMode}
             onGlobeToggle={globeMode.toggle}
@@ -932,6 +969,37 @@ function InnerApp() {
             />
           )}
           
+          {/* Tour Panel — record/play shareable Street View tours */}
+          {isTourPanelOpen && (
+            <TourPanel
+              isOpen={isTourPanelOpen}
+              onClose={() => setIsTourPanelOpen(false)}
+              tours={tours}
+              isRecording={isTourRecording}
+              isPaused={isTourPaused}
+              draftWaypoints={tourDraftWaypoints}
+              getCurrentPOV={getCurrentPOV}
+              currentLocationLabel={locationName}
+              onStartRecording={(name, getPOV) => startTourRecording(name, getPOV)}
+              onPauseRecording={pauseTourRecording}
+              onResumeRecording={resumeTourRecording}
+              onStopRecording={stopTourRecording}
+              onCancelRecording={cancelTourRecording}
+              onAddWaypoint={addTourWaypoint}
+              onDeleteTour={deleteTour}
+              onRenameTour={renameTour}
+              onUpdateTourSettings={updateTourSettings}
+              onDownloadTourJson={downloadTourJson}
+              onDownloadTourKml={downloadTourKml}
+              onImportTourFromJson={importTourFromJson}
+              teleportToPano={teleportToPanoSafe}
+              setHeading={setHeading}
+              setPitch={setPitch}
+              setZoom={setZoom}
+              isPanoramaReady={isPanoramaReady}
+            />
+          )}
+
           {/* Globe View — CesiumJS 3D globe overlay */}
           {/* Show a loading screen while Cesium SDK downloads from CDN */}
           {globeMode.transition === 'loading' && (

--- a/src/components/AccessibilityPanel.tsx
+++ b/src/components/AccessibilityPanel.tsx
@@ -437,6 +437,7 @@ const ShortcutsList: React.FC<{ settings: AccessibilitySettings }> = ({ settings
             'TOGGLE_CRUISE',
             'TOGGLE_COLOR_GRADING',
             'TOGGLE_ACCESSIBILITY',
+            'TOGGLE_TOUR',
         ],
         'Car Mode': [
             'RECENTER_HEAD',

--- a/src/components/AppToolbar.tsx
+++ b/src/components/AppToolbar.tsx
@@ -18,6 +18,8 @@ export interface AppToolbarProps {
   setIsWeatherPanelOpen: (v: boolean) => void;
   isHistoricalTimelineOpen: boolean;
   setIsHistoricalTimelineOpen: (v: boolean) => void;
+  isTourPanelOpen: boolean;
+  setIsTourPanelOpen: (v: boolean) => void;
   viewMode: 'freelook' | 'car';
   toggleViewMode: () => void;
   onGlobeToggle: () => void;
@@ -41,6 +43,8 @@ const AppToolbar: React.FC<AppToolbarProps> = ({
   setIsWeatherPanelOpen,
   isHistoricalTimelineOpen,
   setIsHistoricalTimelineOpen,
+  isTourPanelOpen,
+  setIsTourPanelOpen,
   viewMode,
   toggleViewMode,
   onGlobeToggle,
@@ -117,6 +121,13 @@ const AppToolbar: React.FC<AppToolbarProps> = ({
         onClick={e => { e.stopPropagation(); setIsHistoricalTimelineOpen(!isHistoricalTimelineOpen); }}
       >
         🕰 Time Travel
+      </button>
+      <button
+        className={`control-btn${isTourPanelOpen ? ' disconnect' : ''}`}
+        style={{ minWidth: 110 }}
+        onClick={e => { e.stopPropagation(); setIsTourPanelOpen(!isTourPanelOpen); }}
+      >
+        🗺 Tours
       </button>
       <button
         className="control-btn"

--- a/src/components/TourPanel.tsx
+++ b/src/components/TourPanel.tsx
@@ -1,0 +1,299 @@
+import React, { useRef, useEffect, useState } from 'react';
+import { Tour, TourWaypoint, CurrentPOV, TourTransitionType } from '../hooks/useTours';
+import { useFocusTrap } from '../hooks/useKeyboardShortcuts';
+import TourRecorder from './TourRecorder';
+import TourPlayer from './TourPlayer';
+
+interface TourPanelProps {
+    isOpen: boolean;
+    onClose: () => void;
+
+    tours: Tour[];
+    isRecording: boolean;
+    isPaused: boolean;
+    draftWaypoints: TourWaypoint[];
+    getCurrentPOV: () => CurrentPOV | null;
+    currentLocationLabel?: string;
+    onStartRecording: (name: string, getCurrentPOV: () => CurrentPOV | null) => void;
+    onPauseRecording: () => void;
+    onResumeRecording: () => void;
+    onStopRecording: (name: string) => void;
+    onCancelRecording: () => void;
+    onAddWaypoint: (dwellTimeMs: number, annotation?: string) => void;
+
+    onDeleteTour: (id: string) => void;
+    onRenameTour: (id: string, name: string) => void;
+    onUpdateTourSettings: (id: string, updates: Partial<Pick<Tour, 'transitionType' | 'autoPlaySpeed'>>) => void;
+    onDownloadTourJson: (tour: Tour) => void;
+    onDownloadTourKml: (tour: Tour) => void;
+    onImportTourFromJson: (jsonText: string) => void;
+
+    teleportToPano: (panoId: string) => Promise<void>;
+    setHeading: (heading: number) => void;
+    setPitch: (pitch: number) => void;
+    setZoom: (zoom: number) => void;
+    isPanoramaReady: boolean;
+}
+
+type TabKey = 'library' | 'record' | 'play';
+
+const tabBtnStyle = (active: boolean): React.CSSProperties => ({
+    flex: 1,
+    padding: '10px',
+    background: active ? '#4CAF50' : 'rgba(255,255,255,0.08)',
+    color: '#fff',
+    border: 'none',
+    cursor: 'pointer',
+    fontSize: '13px',
+    fontWeight: 'bold',
+});
+
+const TourPanel: React.FC<TourPanelProps> = ({
+    isOpen,
+    onClose,
+    tours,
+    isRecording,
+    isPaused,
+    draftWaypoints,
+    getCurrentPOV,
+    currentLocationLabel,
+    onStartRecording,
+    onPauseRecording,
+    onResumeRecording,
+    onStopRecording,
+    onCancelRecording,
+    onAddWaypoint,
+    onDeleteTour,
+    onRenameTour,
+    onUpdateTourSettings,
+    onDownloadTourJson,
+    onDownloadTourKml,
+    onImportTourFromJson,
+    teleportToPano,
+    setHeading,
+    setPitch,
+    setZoom,
+    isPanoramaReady,
+}) => {
+    const panelRef = useRef<HTMLDivElement>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const [tab, setTab] = useState<TabKey>('library');
+    const [selectedTourId, setSelectedTourId] = useState<string | null>(null);
+    const [importError, setImportError] = useState<string | null>(null);
+
+    useFocusTrap(panelRef, isOpen);
+
+    useEffect(() => {
+        if (!isOpen) return;
+        const handleEscape = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onClose();
+        };
+        window.addEventListener('keydown', handleEscape);
+        return () => window.removeEventListener('keydown', handleEscape);
+    }, [isOpen, onClose]);
+
+    if (!isOpen) return null;
+
+    const selectedTour = tours.find(t => t.id === selectedTourId) || null;
+
+    const handleImportFile = (file: File) => {
+        setImportError(null);
+        file.text().then(text => {
+            try {
+                onImportTourFromJson(text);
+            } catch (err) {
+                setImportError(err instanceof Error ? err.message : 'Failed to import tour');
+            }
+        });
+    };
+
+    return (
+        <div
+            ref={panelRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="tour-panel-title"
+            onClick={(e) => e.stopPropagation()}
+            style={{
+                position: 'absolute',
+                top: '80px',
+                right: '20px',
+                width: '400px',
+                maxHeight: 'calc(100vh - 120px)',
+                backgroundColor: 'rgba(30, 30, 30, 0.95)',
+                borderRadius: '12px',
+                border: '1px solid #444',
+                zIndex: 100,
+                overflow: 'hidden',
+                display: 'flex',
+                flexDirection: 'column',
+                boxShadow: '0 8px 32px rgba(0,0,0,0.5)',
+            }}
+        >
+            <div style={{
+                padding: '15px',
+                borderBottom: '1px solid #444',
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                backgroundColor: 'rgba(0,0,0,0.3)',
+            }}>
+                <h2 id="tour-panel-title" style={{ margin: 0, color: '#fff', fontSize: '16px' }}>
+                    🗺 Tours ({tours.length})
+                </h2>
+                <button
+                    onClick={onClose}
+                    aria-label="Close tour panel"
+                    style={{ background: 'none', border: 'none', color: '#aaa', fontSize: '20px', cursor: 'pointer', padding: '0 5px' }}
+                >
+                    ×
+                </button>
+            </div>
+
+            <div style={{ display: 'flex' }}>
+                <button style={tabBtnStyle(tab === 'library')} onClick={() => setTab('library')}>Library</button>
+                <button style={tabBtnStyle(tab === 'record')} onClick={() => setTab('record')}>
+                    {isRecording ? '● Recording' : 'Record'}
+                </button>
+                <button style={tabBtnStyle(tab === 'play')} disabled={!selectedTour} onClick={() => setTab('play')}>Play</button>
+            </div>
+
+            <div style={{ padding: '15px', overflowY: 'auto', flex: 1 }}>
+                {tab === 'library' && (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+                        <div style={{ display: 'flex', gap: '8px' }}>
+                            <button
+                                onClick={() => fileInputRef.current?.click()}
+                                style={{ flex: 1, padding: '8px', backgroundColor: '#2196F3', color: '#fff', border: 'none', borderRadius: '6px', cursor: 'pointer', fontSize: '13px' }}
+                            >
+                                📥 Import JSON
+                            </button>
+                            <input
+                                ref={fileInputRef}
+                                type="file"
+                                accept="application/json"
+                                style={{ display: 'none' }}
+                                onChange={(e) => {
+                                    const file = e.target.files?.[0];
+                                    if (file) handleImportFile(file);
+                                    e.target.value = '';
+                                }}
+                            />
+                        </div>
+                        {importError && (
+                            <div style={{ color: '#ff8a8a', fontSize: '12px' }}>⚠️ {importError}</div>
+                        )}
+
+                        {tours.length === 0 ? (
+                            <div style={{ padding: '30px', textAlign: 'center', color: '#888', fontSize: '14px' }}>
+                                No tours yet.<br />Record one to get started!
+                            </div>
+                        ) : (
+                            <div role="list" aria-label="Saved tours">
+                                {tours.map(tour => (
+                                    <div
+                                        key={tour.id}
+                                        role="listitem"
+                                        style={{
+                                            padding: '10px',
+                                            marginBottom: '8px',
+                                            border: `1px solid ${selectedTourId === tour.id ? '#4CAF50' : '#333'}`,
+                                            borderRadius: '6px',
+                                            backgroundColor: 'rgba(255,255,255,0.03)',
+                                        }}
+                                    >
+                                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                                            <input
+                                                value={tour.name}
+                                                onChange={(e) => onRenameTour(tour.id, e.target.value)}
+                                                onKeyDown={(e) => e.stopPropagation()}
+                                                aria-label={`Tour name: ${tour.name}`}
+                                                style={{ flex: 1, background: 'transparent', border: 'none', color: '#fff', fontSize: '14px', fontWeight: 'bold' }}
+                                            />
+                                            <span style={{ color: '#888', fontSize: '11px' }}>{tour.waypoints.length} pts</span>
+                                        </div>
+
+                                        <div style={{ display: 'flex', gap: '8px', margin: '6px 0', fontSize: '12px', color: '#aaa', flexWrap: 'wrap' }}>
+                                            <label>
+                                                Transition:
+                                                <select
+                                                    value={tour.transitionType}
+                                                    onChange={(e) => onUpdateTourSettings(tour.id, { transitionType: e.target.value as TourTransitionType })}
+                                                    style={{ marginLeft: '4px', backgroundColor: '#333', color: '#fff', border: '1px solid #555', borderRadius: '4px' }}
+                                                >
+                                                    <option value="hold-pause">Hold-pause</option>
+                                                    <option value="fade">Fade</option>
+                                                </select>
+                                            </label>
+                                        </div>
+
+                                        <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+                                            <button
+                                                onClick={() => { setSelectedTourId(tour.id); setTab('play'); }}
+                                                disabled={tour.waypoints.length === 0}
+                                                style={{ padding: '5px 10px', backgroundColor: '#4CAF50', color: '#fff', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: '12px' }}
+                                            >
+                                                ▶ Play
+                                            </button>
+                                            <button
+                                                onClick={() => onDownloadTourJson(tour)}
+                                                style={{ padding: '5px 10px', backgroundColor: '#2196F3', color: '#fff', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: '12px' }}
+                                            >
+                                                JSON
+                                            </button>
+                                            <button
+                                                onClick={() => onDownloadTourKml(tour)}
+                                                style={{ padding: '5px 10px', backgroundColor: '#2196F3', color: '#fff', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: '12px' }}
+                                            >
+                                                KML
+                                            </button>
+                                            <button
+                                                onClick={() => {
+                                                    if (window.confirm(`Delete tour "${tour.name}"?`)) {
+                                                        onDeleteTour(tour.id);
+                                                        if (selectedTourId === tour.id) setSelectedTourId(null);
+                                                    }
+                                                }}
+                                                style={{ padding: '5px 10px', backgroundColor: '#d9534f', color: '#fff', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: '12px' }}
+                                            >
+                                                ×
+                                            </button>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                )}
+
+                {tab === 'record' && (
+                    <TourRecorder
+                        isRecording={isRecording}
+                        isPaused={isPaused}
+                        draftWaypoints={draftWaypoints}
+                        currentLocationLabel={currentLocationLabel}
+                        onStart={(name) => onStartRecording(name, getCurrentPOV)}
+                        onPause={onPauseRecording}
+                        onResume={onResumeRecording}
+                        onStop={(name) => { onStopRecording(name); setTab('library'); }}
+                        onCancel={() => { onCancelRecording(); setTab('library'); }}
+                        onAddWaypoint={onAddWaypoint}
+                    />
+                )}
+
+                {tab === 'play' && selectedTour && (
+                    <TourPlayer
+                        tour={selectedTour}
+                        teleportToPano={teleportToPano}
+                        setHeading={setHeading}
+                        setPitch={setPitch}
+                        setZoom={setZoom}
+                        isPanoramaReady={isPanoramaReady}
+                    />
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default TourPanel;

--- a/src/components/TourPlayer.tsx
+++ b/src/components/TourPlayer.tsx
@@ -1,0 +1,171 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { Tour } from '../hooks/useTours';
+
+interface TourPlayerProps {
+    tour: Tour;
+    teleportToPano: (panoId: string) => Promise<void>;
+    setHeading: (heading: number) => void;
+    setPitch: (pitch: number) => void;
+    setZoom: (zoom: number) => void;
+    isPanoramaReady: boolean;
+}
+
+const btnStyle: React.CSSProperties = {
+    padding: '8px 14px',
+    border: 'none',
+    borderRadius: '6px',
+    color: '#fff',
+    fontSize: '13px',
+    fontWeight: 'bold',
+    cursor: 'pointer',
+};
+
+const SPEEDS = [0.5, 1, 1.5, 2];
+
+const TourPlayer: React.FC<TourPlayerProps> = ({
+    tour,
+    teleportToPano,
+    setHeading,
+    setPitch,
+    setZoom,
+    isPanoramaReady,
+}) => {
+    const [currentIndex, setCurrentIndex] = useState(0);
+    const [isPlaying, setIsPlaying] = useState(false);
+    const [speed, setSpeed] = useState(() => (SPEEDS.includes(tour.autoPlaySpeed) ? tour.autoPlaySpeed : 1));
+    const [isFullscreen, setIsFullscreen] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const speedRef = useRef(speed);
+    speedRef.current = speed;
+    const runTokenRef = useRef(0);
+
+    // Reset playback position whenever a different tour is loaded.
+    useEffect(() => {
+        setCurrentIndex(0);
+        setIsPlaying(false);
+    }, [tour.id]);
+
+    const visitWaypoint = useCallback(async (index: number) => {
+        const wp = tour.waypoints[index];
+        if (!wp) return;
+        await teleportToPano(wp.panoId);
+        setHeading(wp.pov.heading);
+        setPitch(wp.pov.pitch);
+        setZoom(wp.pov.zoom);
+    }, [tour.waypoints, teleportToPano, setHeading, setPitch, setZoom]);
+
+    // Playback loop: advances through waypoints from currentIndex while isPlaying.
+    useEffect(() => {
+        if (!isPlaying) return;
+        const token = ++runTokenRef.current;
+
+        const run = async () => {
+            let idx = currentIndex;
+            while (idx < tour.waypoints.length) {
+                if (runTokenRef.current !== token) return;
+                await visitWaypoint(idx);
+                if (runTokenRef.current !== token) return;
+                setCurrentIndex(idx);
+
+                const wp = tour.waypoints[idx]!;
+                const effectiveDwell = tour.transitionType === 'hold-pause'
+                    ? wp.dwellTimeMs
+                    : Math.min(wp.dwellTimeMs, 800);
+                await new Promise(resolve => setTimeout(resolve, effectiveDwell / speedRef.current));
+                if (runTokenRef.current !== token) return;
+                idx++;
+            }
+            if (runTokenRef.current === token) setIsPlaying(false);
+        };
+        run();
+        return () => {
+            runTokenRef.current = token + 1;
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isPlaying]);
+
+    useEffect(() => {
+        const onFsChange = () => setIsFullscreen(!!document.fullscreenElement);
+        document.addEventListener('fullscreenchange', onFsChange);
+        return () => document.removeEventListener('fullscreenchange', onFsChange);
+    }, []);
+
+    const toggleFullscreen = () => {
+        if (document.fullscreenElement) {
+            document.exitFullscreen();
+        } else {
+            containerRef.current?.requestFullscreen?.().catch(() => {});
+        }
+    };
+
+    const handleScrub = (index: number) => {
+        setIsPlaying(false);
+        runTokenRef.current++;
+        setCurrentIndex(index);
+        visitWaypoint(index);
+    };
+
+    const waypointCount = tour.waypoints.length;
+
+    return (
+        <div ref={containerRef} style={{ display: 'flex', flexDirection: 'column', gap: '10px', backgroundColor: isFullscreen ? '#111' : 'transparent', padding: isFullscreen ? '20px' : 0 }}>
+            <div style={{ color: '#ccc', fontSize: '13px' }}>
+                Waypoint {waypointCount === 0 ? 0 : currentIndex + 1} / {waypointCount}
+                {tour.waypoints[currentIndex]?.annotation ? ` — ${tour.waypoints[currentIndex]!.annotation}` : ''}
+            </div>
+
+            <input
+                type="range"
+                min={0}
+                max={Math.max(0, waypointCount - 1)}
+                value={currentIndex}
+                disabled={waypointCount === 0}
+                onChange={(e) => handleScrub(Number(e.target.value))}
+                aria-label="Tour scrub bar"
+                style={{ width: '100%' }}
+            />
+
+            <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
+                <button
+                    style={{ ...btnStyle, backgroundColor: '#4CAF50' }}
+                    disabled={waypointCount === 0 || !isPanoramaReady}
+                    onClick={() => {
+                        if (currentIndex >= waypointCount - 1 && !isPlaying) setCurrentIndex(0);
+                        setIsPlaying(p => !p);
+                    }}
+                    aria-label={isPlaying ? 'Pause tour' : 'Play tour'}
+                >
+                    {isPlaying ? '⏸ Pause' : '▶ Play'}
+                </button>
+                <button
+                    style={{ ...btnStyle, backgroundColor: '#555' }}
+                    onClick={() => { setIsPlaying(false); runTokenRef.current++; setCurrentIndex(0); }}
+                    aria-label="Stop tour"
+                >
+                    ■ Stop
+                </button>
+
+                <label style={{ color: '#aaa', fontSize: '12px', display: 'flex', alignItems: 'center', gap: '4px' }}>
+                    Speed:
+                    <select
+                        value={speed}
+                        onChange={(e) => setSpeed(Number(e.target.value))}
+                        style={{ padding: '4px', backgroundColor: '#333', color: '#fff', border: '1px solid #555', borderRadius: '4px' }}
+                    >
+                        {SPEEDS.map(s => <option key={s} value={s}>{s}×</option>)}
+                    </select>
+                </label>
+
+                <button
+                    style={{ ...btnStyle, backgroundColor: '#2196F3' }}
+                    onClick={toggleFullscreen}
+                    aria-label="Toggle fullscreen playback"
+                >
+                    {isFullscreen ? '⤢ Exit Fullscreen' : '⛶ Fullscreen'}
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default TourPlayer;

--- a/src/components/TourRecorder.tsx
+++ b/src/components/TourRecorder.tsx
@@ -1,0 +1,151 @@
+import React, { useState } from 'react';
+import { TourWaypoint } from '../hooks/useTours';
+
+interface TourRecorderProps {
+    isRecording: boolean;
+    isPaused: boolean;
+    draftWaypoints: TourWaypoint[];
+    currentLocationLabel?: string;
+    onStart: (name: string) => void;
+    onPause: () => void;
+    onResume: () => void;
+    onStop: (name: string) => void;
+    onCancel: () => void;
+    onAddWaypoint: (dwellTimeMs: number, annotation?: string) => void;
+}
+
+const btnStyle: React.CSSProperties = {
+    padding: '8px 14px',
+    border: 'none',
+    borderRadius: '6px',
+    color: '#fff',
+    fontSize: '13px',
+    fontWeight: 'bold',
+    cursor: 'pointer',
+};
+
+const TourRecorder: React.FC<TourRecorderProps> = ({
+    isRecording,
+    isPaused,
+    draftWaypoints,
+    currentLocationLabel,
+    onStart,
+    onPause,
+    onResume,
+    onStop,
+    onCancel,
+    onAddWaypoint,
+}) => {
+    const [tourName, setTourName] = useState('');
+    const [dwellSeconds, setDwellSeconds] = useState(4);
+    const [annotation, setAnnotation] = useState('');
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+            {!isRecording ? (
+                <form
+                    onSubmit={(e) => {
+                        e.preventDefault();
+                        onStart(tourName.trim() || `Tour ${new Date().toLocaleDateString()}`);
+                    }}
+                    style={{ display: 'flex', gap: '8px' }}
+                >
+                    <input
+                        type="text"
+                        placeholder="Tour name..."
+                        value={tourName}
+                        onChange={(e) => setTourName(e.target.value)}
+                        onKeyDown={(e) => e.stopPropagation()}
+                        aria-label="New tour name"
+                        style={{
+                            flex: 1,
+                            padding: '8px 12px',
+                            border: '1px solid #555',
+                            borderRadius: '4px',
+                            backgroundColor: '#333',
+                            color: '#fff',
+                            fontSize: '14px',
+                        }}
+                    />
+                    <button type="submit" style={{ ...btnStyle, backgroundColor: '#4CAF50' }} aria-label="Start recording tour">
+                        ● Record
+                    </button>
+                </form>
+            ) : (
+                <>
+                    <div style={{ color: '#ccc', fontSize: '13px' }}>
+                        {isPaused ? '⏸ Paused' : '● Recording'} — {draftWaypoints.length} waypoint{draftWaypoints.length === 1 ? '' : 's'}
+                        {currentLocationLabel ? ` · ${currentLocationLabel}` : ''}
+                    </div>
+
+                    <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
+                        <label style={{ color: '#aaa', fontSize: '12px' }}>
+                            Dwell (s):
+                            <input
+                                type="number"
+                                min={1}
+                                max={60}
+                                value={dwellSeconds}
+                                onChange={(e) => setDwellSeconds(Math.max(1, Number(e.target.value) || 1))}
+                                onKeyDown={(e) => e.stopPropagation()}
+                                style={{ width: '54px', marginLeft: '6px', padding: '4px', backgroundColor: '#333', color: '#fff', border: '1px solid #555', borderRadius: '4px' }}
+                            />
+                        </label>
+                        <input
+                            type="text"
+                            placeholder="Annotation (optional)..."
+                            value={annotation}
+                            onChange={(e) => setAnnotation(e.target.value)}
+                            onKeyDown={(e) => e.stopPropagation()}
+                            aria-label="Waypoint annotation"
+                            style={{ flex: 1, minWidth: '120px', padding: '6px 10px', border: '1px solid #555', borderRadius: '4px', backgroundColor: '#333', color: '#fff', fontSize: '13px' }}
+                        />
+                        <button
+                            style={{ ...btnStyle, backgroundColor: '#2196F3' }}
+                            onClick={() => { onAddWaypoint(dwellSeconds * 1000, annotation.trim() || undefined); setAnnotation(''); }}
+                            aria-label="Add waypoint at current view"
+                        >
+                            + Waypoint
+                        </button>
+                    </div>
+
+                    <div style={{ display: 'flex', gap: '8px' }}>
+                        {isPaused ? (
+                            <button style={{ ...btnStyle, backgroundColor: '#4CAF50' }} onClick={onResume} aria-label="Resume recording">
+                                ▶ Resume
+                            </button>
+                        ) : (
+                            <button style={{ ...btnStyle, backgroundColor: '#f0ad4e' }} onClick={onPause} aria-label="Pause recording">
+                                ⏸ Pause
+                            </button>
+                        )}
+                        <button
+                            style={{ ...btnStyle, backgroundColor: '#d9534f' }}
+                            onClick={() => onStop(tourName.trim() || `Tour ${new Date().toLocaleDateString()}`)}
+                            disabled={draftWaypoints.length === 0}
+                            aria-label="Stop and save tour"
+                        >
+                            ■ Stop &amp; Save
+                        </button>
+                        <button style={{ ...btnStyle, backgroundColor: '#555' }} onClick={onCancel} aria-label="Cancel recording">
+                            ✕ Cancel
+                        </button>
+                    </div>
+
+                    {draftWaypoints.length > 0 && (
+                        <div style={{ maxHeight: '160px', overflowY: 'auto', border: '1px solid #333', borderRadius: '6px' }}>
+                            {draftWaypoints.map((wp, i) => (
+                                <div key={wp.id} style={{ padding: '6px 10px', borderBottom: '1px solid #333', fontSize: '12px', color: '#ccc', display: 'flex', justifyContent: 'space-between' }}>
+                                    <span>{i + 1}. {wp.position.lat.toFixed(4)}, {wp.position.lng.toFixed(4)}</span>
+                                    <span style={{ color: '#888' }}>{(wp.dwellTimeMs / 1000).toFixed(0)}s{wp.annotation ? ` · ${wp.annotation}` : ''}</span>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </>
+            )}
+        </div>
+    );
+};
+
+export default TourRecorder;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -38,3 +38,6 @@ export { default as AppToolbar } from './AppToolbar';
 export { default as AppBanners } from './AppBanners';
 export { default as HistoricalTimeline } from './HistoricalTimeline';
 export { default as ComparisonView } from './ComparisonView';
+export { default as TourPanel } from './TourPanel';
+export { default as TourRecorder } from './TourRecorder';
+export { default as TourPlayer } from './TourPlayer';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -11,6 +11,13 @@ export { useBookmarks } from './useBookmarks';
 export { useLocationHistory } from './useLocationHistory';
 export { useSnapshots } from './useSnapshots';
 export { useVehicleSettings } from './useVehicleSettings';
+export {
+  useTours,
+  type Tour,
+  type TourWaypoint,
+  type TourTransitionType,
+  type CurrentPOV,
+} from './useTours';
 
 // Mobile responsiveness hooks
 export { useTouchControls, type UseTouchControlsOptions, type TouchGestureState } from './useTouchControls';

--- a/src/hooks/useAppKeyboardShortcuts.ts
+++ b/src/hooks/useAppKeyboardShortcuts.ts
@@ -22,6 +22,8 @@ export interface UseAppKeyboardShortcutsOptions {
   setIsAccessibilityPanelOpen: (v: boolean) => void;
   isWeatherPanelOpen: boolean;
   setIsWeatherPanelOpen: (v: boolean) => void;
+  isTourPanelOpen: boolean;
+  setIsTourPanelOpen: (v: boolean) => void;
   viewMode: 'freelook' | 'car';
   toggleViewMode: () => void;
   rainIntensity: number;
@@ -65,6 +67,8 @@ export function buildAppKeyboardShortcuts(options: UseAppKeyboardShortcutsOption
     setIsAccessibilityPanelOpen,
     isWeatherPanelOpen,
     setIsWeatherPanelOpen,
+    isTourPanelOpen,
+    setIsTourPanelOpen,
     viewMode,
     toggleViewMode,
     rainIntensity,
@@ -171,6 +175,14 @@ export function buildAppKeyboardShortcuts(options: UseAppKeyboardShortcutsOption
       },
     },
     {
+      key: 't',
+      description: 'Toggle tour panel',
+      action: () => {
+        setIsTourPanelOpen(!isTourPanelOpen);
+        announce(`Tour panel ${!isTourPanelOpen ? 'opened' : 'closed'}`);
+      },
+    },
+    {
       key: 'c',
       description: 'Toggle car mode',
       action: () => {
@@ -237,6 +249,7 @@ export function buildAppKeyboardShortcuts(options: UseAppKeyboardShortcutsOption
         else if (isHistoryPanelOpen) setIsHistoryPanelOpen(false);
         else if (isSnapshotGalleryOpen) setIsSnapshotGalleryOpen(false);
         else if (isColorGradingPanelOpen) setIsColorGradingPanelOpen(false);
+        else if (isTourPanelOpen) setIsTourPanelOpen(false);
         else if (isMapOpen) setIsMapOpen(false);
       },
       preventDefault: false,

--- a/src/hooks/useKeyboardShortcuts.tsx
+++ b/src/hooks/useKeyboardShortcuts.tsx
@@ -65,6 +65,7 @@ export const KEYBOARD_SHORTCUTS = {
     TOGGLE_CRUISE: { key: 'r', description: 'Toggle cruise mode' },
     TOGGLE_COLOR_GRADING: { key: 'e', description: 'Toggle color grading panel' },
     TOGGLE_ACCESSIBILITY: { key: 'a', description: 'Toggle accessibility panel' },
+    TOGGLE_TOUR: { key: 't', description: 'Toggle tour recorder/player panel' },
     RECENTER_HEAD: { key: 'c', description: 'Recenter head position' },
     TOGGLE_HEAD_COUPLING: { key: 'h', description: 'Toggle head coupling mode' },
     STEER_LEFT: { key: 'a', description: 'Steer left' },

--- a/src/hooks/useTours.ts
+++ b/src/hooks/useTours.ts
@@ -1,0 +1,348 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+export interface TourWaypoint {
+    id: string;
+    panoId: string;
+    position: { lat: number; lng: number };
+    pov: { heading: number; pitch: number; zoom: number };
+    dwellTimeMs: number;
+    annotation?: string;
+    snapshotId?: string;
+}
+
+export type TourTransitionType = 'hold-pause' | 'fade';
+
+export interface Tour {
+    id: string;
+    name: string;
+    description?: string;
+    waypoints: TourWaypoint[];
+    transitionType: TourTransitionType;
+    autoPlaySpeed: number;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface CurrentPOV {
+    panoId: string;
+    position: { lat: number; lng: number };
+    pov: { heading: number; pitch: number; zoom: number };
+}
+
+const STORAGE_KEY = 'webgpu_streetview_tours';
+const DEFAULT_DWELL_MS = 4000;
+const MIN_WAYPOINT_INTERVAL_MS = 3000;
+
+function makeId(): string {
+    return `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+}
+
+function isValidTour(value: unknown): value is Tour {
+    if (!value || typeof value !== 'object') return false;
+    const t = value as Record<string, unknown>;
+    return (
+        typeof t.id === 'string' &&
+        typeof t.name === 'string' &&
+        Array.isArray(t.waypoints) &&
+        t.waypoints.every((w) => {
+            if (!w || typeof w !== 'object') return false;
+            const wp = w as Record<string, unknown>;
+            return (
+                typeof wp.panoId === 'string' &&
+                typeof wp.position === 'object' && wp.position !== null &&
+                typeof (wp.position as any).lat === 'number' &&
+                typeof (wp.position as any).lng === 'number' &&
+                typeof wp.pov === 'object' && wp.pov !== null &&
+                typeof wp.dwellTimeMs === 'number'
+            );
+        }) &&
+        (t.transitionType === 'hold-pause' || t.transitionType === 'fade') &&
+        typeof t.autoPlaySpeed === 'number'
+    );
+}
+
+export function useTours() {
+    const [tours, setTours] = useState<Tour[]>([]);
+    const [isLoaded, setIsLoaded] = useState(false);
+
+    // Recording state
+    const [isRecording, setIsRecording] = useState(false);
+    const [isPaused, setIsPaused] = useState(false);
+    const [draftName, setDraftName] = useState('');
+    const [draftWaypoints, setDraftWaypoints] = useState<TourWaypoint[]>([]);
+    const recordingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const getCurrentPOVRef = useRef<(() => CurrentPOV | null) | null>(null);
+
+    useEffect(() => {
+        try {
+            const stored = localStorage.getItem(STORAGE_KEY);
+            if (stored) {
+                const parsed = JSON.parse(stored);
+                if (Array.isArray(parsed)) {
+                    setTours(parsed.filter(isValidTour));
+                }
+            }
+        } catch (error) {
+            console.error('Failed to load tours:', error);
+        }
+        setIsLoaded(true);
+    }, []);
+
+    useEffect(() => {
+        if (isLoaded) {
+            try {
+                localStorage.setItem(STORAGE_KEY, JSON.stringify(tours));
+            } catch (error) {
+                console.error('Failed to save tours:', error);
+            }
+        }
+    }, [tours, isLoaded]);
+
+    const addWaypointFromCurrent = useCallback((dwellTimeMs: number = DEFAULT_DWELL_MS, annotation?: string) => {
+        const current = getCurrentPOVRef.current?.();
+        if (!current) return;
+        setDraftWaypoints(prev => {
+            const last = prev[prev.length - 1];
+            if (last && last.panoId === current.panoId) return prev;
+            const wp: TourWaypoint = {
+                id: makeId(),
+                panoId: current.panoId,
+                position: current.position,
+                pov: current.pov,
+                dwellTimeMs,
+                ...(annotation ? { annotation } : {}),
+            };
+            return [...prev, wp];
+        });
+    }, []);
+
+    const startRecording = useCallback((name: string, getCurrentPOV: () => CurrentPOV | null, intervalMs: number = 0) => {
+        setDraftName(name);
+        setDraftWaypoints([]);
+        getCurrentPOVRef.current = getCurrentPOV;
+        setIsRecording(true);
+        setIsPaused(false);
+
+        if (recordingIntervalRef.current) {
+            clearInterval(recordingIntervalRef.current);
+            recordingIntervalRef.current = null;
+        }
+        if (intervalMs >= MIN_WAYPOINT_INTERVAL_MS) {
+            recordingIntervalRef.current = setInterval(() => {
+                addWaypointFromCurrent(DEFAULT_DWELL_MS);
+            }, intervalMs);
+        }
+        // Capture the starting position immediately.
+        addWaypointFromCurrent(DEFAULT_DWELL_MS);
+    }, [addWaypointFromCurrent]);
+
+    const pauseRecording = useCallback(() => {
+        setIsPaused(true);
+        if (recordingIntervalRef.current) {
+            clearInterval(recordingIntervalRef.current);
+            recordingIntervalRef.current = null;
+        }
+    }, []);
+
+    const resumeRecording = useCallback(() => {
+        setIsPaused(false);
+    }, []);
+
+    const cancelRecording = useCallback(() => {
+        if (recordingIntervalRef.current) {
+            clearInterval(recordingIntervalRef.current);
+            recordingIntervalRef.current = null;
+        }
+        getCurrentPOVRef.current = null;
+        setIsRecording(false);
+        setIsPaused(false);
+        setDraftWaypoints([]);
+        setDraftName('');
+    }, []);
+
+    const stopRecording = useCallback((finalName?: string): string | null => {
+        if (recordingIntervalRef.current) {
+            clearInterval(recordingIntervalRef.current);
+            recordingIntervalRef.current = null;
+        }
+        getCurrentPOVRef.current = null;
+        setIsRecording(false);
+        setIsPaused(false);
+
+        if (draftWaypoints.length === 0) {
+            setDraftWaypoints([]);
+            setDraftName('');
+            return null;
+        }
+
+        const now = new Date().toISOString();
+        const newTour: Tour = {
+            id: makeId(),
+            name: (finalName ?? draftName).trim() || `Tour ${new Date().toLocaleDateString()}`,
+            waypoints: draftWaypoints,
+            transitionType: 'hold-pause',
+            autoPlaySpeed: 1,
+            createdAt: now,
+            updatedAt: now,
+        };
+        setTours(prev => [newTour, ...prev]);
+        setDraftWaypoints([]);
+        setDraftName('');
+        return newTour.id;
+    }, [draftName, draftWaypoints]);
+
+    const deleteTour = useCallback((id: string) => {
+        setTours(prev => prev.filter(t => t.id !== id));
+    }, []);
+
+    const renameTour = useCallback((id: string, name: string) => {
+        setTours(prev => prev.map(t => t.id === id ? { ...t, name, updatedAt: new Date().toISOString() } : t));
+    }, []);
+
+    const updateTourSettings = useCallback((id: string, updates: Partial<Pick<Tour, 'transitionType' | 'autoPlaySpeed' | 'description'>>) => {
+        setTours(prev => prev.map(t => t.id === id ? { ...t, ...updates, updatedAt: new Date().toISOString() } : t));
+    }, []);
+
+    const removeWaypoint = useCallback((tourId: string, waypointId: string) => {
+        setTours(prev => prev.map(t => t.id === tourId
+            ? { ...t, waypoints: t.waypoints.filter(w => w.id !== waypointId), updatedAt: new Date().toISOString() }
+            : t));
+    }, []);
+
+    const updateWaypoint = useCallback((tourId: string, waypointId: string, updates: Partial<Omit<TourWaypoint, 'id'>>) => {
+        setTours(prev => prev.map(t => t.id === tourId
+            ? {
+                ...t,
+                waypoints: t.waypoints.map(w => w.id === waypointId ? { ...w, ...updates } : w),
+                updatedAt: new Date().toISOString(),
+            }
+            : t));
+    }, []);
+
+    const moveWaypoint = useCallback((tourId: string, waypointId: string, direction: 'up' | 'down') => {
+        setTours(prev => prev.map(t => {
+            if (t.id !== tourId) return t;
+            const idx = t.waypoints.findIndex(w => w.id === waypointId);
+            if (idx === -1) return t;
+            const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
+            if (swapIdx < 0 || swapIdx >= t.waypoints.length) return t;
+            const waypoints = [...t.waypoints];
+            [waypoints[idx], waypoints[swapIdx]] = [waypoints[swapIdx]!, waypoints[idx]!];
+            return { ...t, waypoints, updatedAt: new Date().toISOString() };
+        }));
+    }, []);
+
+    const exportTourJson = useCallback((tour: Tour): string => {
+        return JSON.stringify(tour, null, 2);
+    }, []);
+
+    const downloadTourJson = useCallback((tour: Tour) => {
+        const blob = new Blob([JSON.stringify(tour, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `${tour.name.replace(/[^a-z0-9-_ ]/gi, '_') || 'tour'}.json`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+    }, []);
+
+    const downloadTourKml = useCallback((tour: Tour) => {
+        const blob = new Blob([tourToKml(tour)], { type: 'application/vnd.google-earth.kml+xml' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `${tour.name.replace(/[^a-z0-9-_ ]/gi, '_') || 'tour'}.kml`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+    }, []);
+
+    const importTourFromJson = useCallback((jsonText: string): string => {
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(jsonText);
+        } catch {
+            throw new Error('Invalid JSON file');
+        }
+        if (!isValidTour(parsed)) {
+            throw new Error('File does not contain a valid tour');
+        }
+        const now = new Date().toISOString();
+        const imported: Tour = {
+            ...parsed,
+            id: makeId(),
+            waypoints: parsed.waypoints.map(w => ({ ...w, id: w.id || makeId() })),
+            createdAt: parsed.createdAt || now,
+            updatedAt: now,
+        };
+        setTours(prev => [imported, ...prev]);
+        return imported.id;
+    }, []);
+
+    return {
+        tours,
+        isLoaded,
+        deleteTour,
+        renameTour,
+        updateTourSettings,
+        removeWaypoint,
+        updateWaypoint,
+        moveWaypoint,
+        exportTourJson,
+        downloadTourJson,
+        downloadTourKml,
+        importTourFromJson,
+
+        // Recording
+        isRecording,
+        isPaused,
+        draftName,
+        draftWaypoints,
+        startRecording,
+        pauseRecording,
+        resumeRecording,
+        cancelRecording,
+        stopRecording,
+        addWaypointFromCurrent,
+    };
+}
+
+function escapeXml(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;');
+}
+
+function tourToKml(tour: Tour): string {
+    const placemarks = tour.waypoints.map((wp, i) => `
+    <Placemark>
+      <name>${escapeXml(`${i + 1}. ${tour.name}`)}</name>
+      ${wp.annotation ? `<description>${escapeXml(wp.annotation)}</description>` : ''}
+      <Point>
+        <coordinates>${wp.position.lng},${wp.position.lat},0</coordinates>
+      </Point>
+    </Placemark>`).join('');
+
+    const lineCoords = tour.waypoints.map(wp => `${wp.position.lng},${wp.position.lat},0`).join(' ');
+
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document>
+    <name>${escapeXml(tour.name)}</name>
+    ${tour.description ? `<description>${escapeXml(tour.description)}</description>` : ''}
+    <Placemark>
+      <name>${escapeXml(tour.name)} route</name>
+      <LineString>
+        <tessellate>1</tessellate>
+        <coordinates>${lineCoords}</coordinates>
+      </LineString>
+    </Placemark>${placemarks}
+  </Document>
+</kml>`;
+}


### PR DESCRIPTION
## Summary

Adds a "Tour" feature that turns a Street View session into a shareable, replayable drive:

- **`useTours` hook** — CRUD for tours, localStorage persistence, and a recorder (start/pause/resume/stop/cancel, manual or interval-based waypoint capture).
- **`TourRecorder`** — record controls, per-waypoint dwell time + annotation, live waypoint list.
- **`TourPlayer`** — play/pause/stop, scrub bar, speed control (0.5×–2×), fullscreen, honors each tour's `transitionType` (`hold-pause` holds the recorded dwell time; `fade` shortens it for a continuous feel).
- **`TourPanel`** — the panel that ties it together (Library / Record / Play tabs), including JSON import/export (round-trip safe) and KML export for Google Earth.
- Wired into `AppToolbar` (🗺 Tours button), the `t` keyboard shortcut, and the Accessibility panel's shortcuts list.
- Works in both free-look and car mode since playback drives the shared `StreetView` context (`teleportToPanoSafe` + heading/pitch/zoom), independent of view mode.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `CI=true npx react-scripts build` — compiles with no warnings/errors
- [x] `CI=true npx react-scripts test --watchAll=false` — 170/170 tests pass
- [ ] Manual: record a multi-waypoint tour, verify playback POV accuracy, and confirm JSON export/import round-trips waypoint data


---
_Generated by [Claude Code](https://claude.ai/code/session_01LoVQps3ikSUnqwNvN4fkNW)_