### PR TITLE
Add compute-shader weather post-processor alongside fragment path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,7 +293,7 @@ App.tsx
 
 The intermediate HDR texture is lazily created and resized in `ensureIntermediateTexture()` when canvas dimensions change. Do not cache `GPUTextureView` across frames.
 
-A compute variant `weather-post-compute.wgsl` exists for potential compute-pipeline integration. It uses an `extraBuffer` storage array (index 0–36) mapped to the same weather parameters and exposes additional bindings for depth textures and data textures.
+**Pass 2b (opt-in)** — `weather-post-compute.wgsl` via `ComputeWeatherPostProcessor.ts`, selected with `?weather=compute` or the `ultra` visual quality preset. Same effects as Pass 2, but as a `@workgroup_size(16,16,1)` compute shader writing an `rgba32float` storage texture, followed by a `textureLoad` blit render pass to the swap-chain surface. Uses an `extraBuffer` storage array (index 0–39) mapped to the same `WeatherParamIndex` layout as Pass 2, and exposes additional `image_video_effects`-compatible bindings for depth textures, data textures, and a `plasmaBuffer` storage array — currently bound to 1x1 dummy resources, reserved for future WASM-fed noise tiles (#128), volumetric fog, and GPU particles. See "Weather Post-Process: Fragment vs Compute" in `docs/RENDERER_FALLBACK.md`.
 
 ### WebGL2 Fallback / Debug Renderer
 
@@ -440,7 +440,7 @@ The live demo at `test.1ink.us/streetview` historically showed "This page can't 
 **Never** rely on a single baked key for multiple hosts with different restrictions. Always prefer the runtime override for the official demo. Do not commit new keys.
 
 ### 6. Shader Uniform Layouts
-`weather-post.wgsl` expects a 40-float (160-byte) uniform buffer:
+`weather-post.wgsl` (fragment pass, active by default) and `weather-post-compute.wgsl` (compute pass, opt-in via `?weather=compute` — see `docs/RENDERER_FALLBACK.md`) both expect the same 40-float (160-byte) parameter layout. The single source of truth is `src/renderer/weatherUniformLayout.ts` (`WeatherParamIndex`) — both `WeatherPostProcessor.ts` and `ComputeWeatherPostProcessor.ts` import it instead of hardcoding indices:
 ```
 [0-5]   vibrance, saturation, contrast, exposure, temperature, tint
 [6-10]  time, rainIntensity, snowIntensity, wind, speed
@@ -450,7 +450,7 @@ The live demo at `test.1ink.us/streetview` historically showed "This page can't 
 [22-31] fogIntensity, fogDensity, fogHeight, fogColorIndex, lightShaftsIntensity, heatShimmerIntensity, lensFlareIntensity, chromaticAberration, dustIntensity, humidityHaze
 [32]    shaderEffectsEnabled
 [33-34] cameraHeading, cameraPitch
-[35]    padding
+[35]    wasmNoiseEnabled
 [36]    sunrise
 [37]    anamorphicStreak
 [38-39] padding
@@ -465,7 +465,7 @@ The main `streetview.wgsl` uniform buffer is 8 floats (32 bytes):
 [7]     padding
 ```
 
-Changing either layout without updating both `Renderer.ts`, `WebGPUCanvas.tsx`, and the WGSL files will break rendering.
+Changing either layout without updating `weatherUniformLayout.ts`, `Renderer.ts`, `WebGPUCanvas.tsx`, and both weather WGSL files will break rendering.
 
 ### 7. Google Maps Canvas Opacity Requirement
 The hidden Street View container must maintain `opacity: 1`. Google Maps stops updating its internal render canvas when opacity is low. Visibility is controlled via `zIndex` and `pointerEvents`, never `opacity`.

--- a/docs/RENDERER_FALLBACK.md
+++ b/docs/RENDERER_FALLBACK.md
@@ -68,6 +68,36 @@ window.streetViewRendererDebug.getDebugOptions();
 
 The isolation value is stored in `localStorage` as `streetview.effect`. `wireframe` is a screen-space UV/grid overlay because the Street View renderer is a fullscreen pass, not a mesh renderer.
 
+## Weather Post-Process: Fragment vs Compute
+
+The WebGPU backend's second pass (weather rain/snow/fog/color grading) has two implementations that render the same effects from the same 40-float parameter layout:
+
+- **Fragment** (default): `src/renderer/WeatherPostProcessor.ts` + `public/shaders/weather-post.wgsl`. A single fullscreen-triangle render pass sampling the HDR intermediate texture.
+- **Compute**: `src/renderer/ComputeWeatherPostProcessor.ts` + `public/shaders/weather-post-compute.wgsl`. A compute pass (`@workgroup_size(16, 16, 1)`) writes into an `rgba32float` storage texture, followed by a cheap `textureLoad` blit render pass to the canvas. It exposes `image_video_effects`-compatible bindings for depth textures, data textures, and a `plasmaBuffer` storage array — currently bound to 1x1 dummy resources, reserved for future WASM-fed noise tiles (#128), volumetric fog, and GPU particles that want storage-buffer access a fragment pass can't offer efficiently.
+
+Both read the same `40-float` weather parameter layout, defined once in `src/renderer/weatherUniformLayout.ts` (`WeatherParamIndex`) and mirrored in both WGSL files' comments — see "Shader Uniform Layouts" in `AGENTS.md`.
+
+Select the pipeline with:
+
+```text
+?weather=compute
+?weather=fragment
+```
+
+or persist a choice from DevTools:
+
+```js
+window.streetViewRendererDebug.setWeatherMode('compute');
+window.streetViewRendererDebug.setWeatherMode('fragment');
+window.streetViewRendererDebug.getWeatherMode();
+```
+
+Like `setBackend`, `setWeatherMode` persists to `localStorage` (`streetview.weatherMode`) and reloads the page. With no explicit URL flag or stored preference, the mode falls back to the detected visual quality preset's `weatherPostProcessMode` (`src/config/visualPresets.ts`) — every preset defaults to `'fragment'` except `ultra`, which defaults to `'compute'`.
+
+**This is WebGPU-only.** The WebGL2 fallback renderer remains fragment-only (a single-pass SDR approximation) — there is no WebGL2 compute path, and `?weather=compute` has no effect when the WebGL2 backend is active.
+
+Known gap: the compute path does not yet sample the WASM-computed 64x64 noise tile (`wasmNoiseTile` in `weather-post.wgsl`) that the fragment path uses for dust-cloud turbulence — `wasmNoiseEnabled` is read but has no visual effect in the compute shader yet. Rain, snow, fog, color grading, night/headlight lighting, and astronomical effects are otherwise at parity between the two paths.
+
 ## Parity Notes
 
 The WebGL2 backend is intentionally approximate. It is meant for debugging panorama sampling, weather parameter wiring, color grading controls, and car overlay compositing in environments where WebGPU is unavailable or too opaque for automation.

--- a/public/shaders/weather-post-compute.wgsl
+++ b/public/shaders/weather-post-compute.wgsl
@@ -2,14 +2,21 @@
 // Compatible with image_video_effects WGSL compute pipeline
 // Maps original WeatherParams into extraBuffer for cross-shader portability
 //
-// extraBuffer layout (indices):
+// extraBuffer layout (indices) — must match src/renderer/weatherUniformLayout.ts,
+// the WeatherParams struct in weather-post.wgsl, and WeatherPostProcessor.ts:
 // 0:vibrance 1:saturation 2:contrast 3:exposure 4:temperature 5:tint
 // 6:time 7:rainIntensity 8:snowIntensity 9:wind 10:speed
 // 11:nightIntensity 12:headlightsOn 13:highBeam 14:headlightHeading 15:headlightPitch
 // 16:domeLightOn 17:domeLightIntensity 18:sunAzimuth 19:sunAltitude 20:moonAzimuth 21:moonAltitude
 // 22:fogIntensity 23:fogDensity 24:fogHeight 25:fogColorIndex 26:lightShaftsIntensity
 // 27:heatShimmerIntensity 28:lensFlareIntensity 29:chromaticAberration 30:dustIntensity
-// 31:humidityHaze 32:shaderEffectsEnabled 33:cameraHeading 34:cameraPitch 35:sunrise 36:anamorphicStreak
+// 31:humidityHaze 32:shaderEffectsEnabled 33:cameraHeading 34:cameraPitch 35:wasmNoiseEnabled
+// 36:sunrise 37:anamorphicStreak 38-39:padding
+//
+// NOTE: the compute path does not currently bind the 64x64 WASM noise tile
+// (see weather-post.wgsl's `wasmNoiseTile` storage buffer / #128), so
+// wasmNoiseEnabled is read but has no effect here yet — dust cloud density
+// stays uniform instead of following WASM-driven turbulence.
 
 // --- STANDARD image_video_effects HEADER ---
 @group(0) @binding(0) var u_sampler: sampler;
@@ -74,8 +81,9 @@ fn p_humidityHaze() -> f32    { return ep(31); }
 fn p_shaderEffectsEnabled() -> f32 { return ep(32); }
 fn p_cameraHeading() -> f32   { return ep(33); }
 fn p_cameraPitch() -> f32     { return ep(34); }
-fn p_sunrise() -> f32         { return ep(35); }
-fn p_anamorphicStreak() -> f32 { return ep(36); }
+fn p_wasmNoiseEnabled() -> f32 { return ep(35); }
+fn p_sunrise() -> f32         { return ep(36); }
+fn p_anamorphicStreak() -> f32 { return ep(37); }
 
 // ============================================================================
 // NOISE AND UTILITY FUNCTIONS

--- a/src/config/visualPresets.ts
+++ b/src/config/visualPresets.ts
@@ -38,6 +38,16 @@ export interface VisualPreset {
   depthOfFieldEnabled: boolean;
   motionBlurEnabled: boolean;
 
+  /**
+   * WebGPU weather post-process pipeline: 'fragment' (default, streetview.wgsl
+   * -> weather-post.wgsl) or 'compute' (weather-post-compute.wgsl, storage-buffer
+   * based — see docs/RENDERER_FALLBACK.md and ComputeWeatherPostProcessor.ts).
+   * A `?weather=compute`/`?weather=fragment` URL flag or persisted
+   * localStorage choice always overrides this default. Ignored by the
+   * WebGL2 fallback renderer, which is fragment-only.
+   */
+  weatherPostProcessMode: 'fragment' | 'compute';
+
   // Lighting
   maxLights: number;
   ambientOcclusion: boolean;
@@ -61,6 +71,7 @@ export const PRESETS: Record<QualityLevel, VisualPreset> = {
   low: {
     name: 'Low',
     quality: 'low',
+    weatherPostProcessMode: 'fragment',
 
     textureResolution: 64,
     anisotropy: 1,
@@ -97,6 +108,7 @@ export const PRESETS: Record<QualityLevel, VisualPreset> = {
   medium: {
     name: 'Medium',
     quality: 'medium',
+    weatherPostProcessMode: 'fragment',
 
     textureResolution: 128,
     anisotropy: 4,
@@ -133,6 +145,7 @@ export const PRESETS: Record<QualityLevel, VisualPreset> = {
   high: {
     name: 'High',
     quality: 'high',
+    weatherPostProcessMode: 'fragment',
 
     textureResolution: 256,
     anisotropy: 8,
@@ -169,6 +182,7 @@ export const PRESETS: Record<QualityLevel, VisualPreset> = {
   ultra: {
     name: 'Ultra',
     quality: 'ultra',
+    weatherPostProcessMode: 'compute',
 
     textureResolution: 512,
     anisotropy: 16,

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="react-scripts" />
 /// <reference types="@webgpu/types" />
 
-import type { RendererBackendPreference, RendererEffectIsolation } from './renderer/RendererBackend';
+import type { RendererBackendPreference, RendererEffectIsolation, WeatherPostProcessMode } from './renderer/RendererBackend';
 
 declare global {
   interface Window {
@@ -9,6 +9,7 @@ declare global {
     usingWebGPU?: boolean;
     usingWebGL?: boolean;
     rendererFallbackReason?: string;
+    weatherPostProcessMode?: WeatherPostProcessMode;
     streetViewRendererDebug?: {
       getBackend: () => {
         rendererType?: 'webgpu' | 'webgl';
@@ -23,6 +24,8 @@ declare global {
         effectIsolation: RendererEffectIsolation;
         wireframe: boolean;
       };
+      getWeatherMode: () => WeatherPostProcessMode;
+      setWeatherMode: (mode: WeatherPostProcessMode) => void;
     };
   }
 }

--- a/src/renderer/ComputeWeatherPostProcessor.ts
+++ b/src/renderer/ComputeWeatherPostProcessor.ts
@@ -1,0 +1,404 @@
+import { WEATHER_PARAMS_FLOAT_COUNT, WeatherParamIndex } from './weatherUniformLayout';
+
+// Must match NOISE_TILE_SIZE in src/wasm/wasmNoiseFeeder.ts and the
+// storage buffer declared in weather-post.wgsl. The compute variant does
+// not yet bind this tile to the shader (see weather-post-compute.wgsl
+// header) — the buffer is kept here only so the public API matches
+// WeatherPostProcessor and callers don't need to branch.
+const NOISE_TILE_SIZE = 64;
+const NOISE_BUFFER_BYTES = NOISE_TILE_SIZE * NOISE_TILE_SIZE * 4;
+
+// image_video_effects-compatible Uniforms struct size:
+// config(vec4) + zoom_config(vec4) + zoom_params(vec4) + ripples(array<vec4,50>)
+const COMPUTE_UNIFORMS_BYTE_SIZE = (4 + 4 + 4 + 50 * 4) * 4;
+
+const WORKGROUP_SIZE = 16;
+
+const BLIT_SHADER = `
+@group(0) @binding(0) var srcTex: texture_2d<f32>;
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertexIndex: u32) -> @builtin(position) vec4<f32> {
+    var pos = vec2<f32>(0.0, 0.0);
+    switch(vertexIndex) {
+        case 0u: { pos = vec2<f32>(-1.0, -1.0); }
+        case 1u: { pos = vec2<f32>( 3.0, -1.0); }
+        case 2u: { pos = vec2<f32>(-1.0,  3.0); }
+        default: {}
+    }
+    return vec4<f32>(pos, 0.0, 1.0);
+}
+
+@fragment
+fn fs_main(@builtin(position) fragCoord: vec4<f32>) -> @location(0) vec4<f32> {
+    let coord = vec2<i32>(fragCoord.xy);
+    return textureLoad(srcTex, coord, 0);
+}
+`;
+
+/**
+ * Compute-shader variant of the weather post-processing pass. Renders the
+ * same rain/snow/fog/color-grading effects as WeatherPostProcessor but via
+ * a compute pipeline writing into a storage texture, then blits that
+ * texture to the canvas. Exposes the same public API as
+ * WeatherPostProcessor so Renderer.ts can use either interchangeably.
+ *
+ * Foundation for WASM noise buffers (#128), volumetric fog, and GPU
+ * particles, all of which want storage-buffer access that a fragment pass
+ * can't offer efficiently. See docs/RENDERER_FALLBACK.md.
+ */
+export class ComputeWeatherPostProcessor {
+    private device: GPUDevice;
+    private context: GPUCanvasContext;
+
+    private computePipeline!: GPUComputePipeline;
+    private computeBindGroup!: GPUBindGroup;
+    private blitPipeline!: GPURenderPipeline;
+    private blitBindGroup!: GPUBindGroup;
+
+    private extraBuffer!: GPUBuffer;
+    private computeUniformsBuffer!: GPUBuffer;
+    private noiseBuffer!: GPUBuffer;
+    private writeTexture!: GPUTexture;
+    private writeWidth: number = 0;
+    private writeHeight: number = 0;
+
+    // Dummy 1x1 resources for image_video_effects bindings this shader
+    // doesn't use yet (depth, data textures, plasma buffer).
+    private filteringSampler!: GPUSampler;
+    private nonFilteringSampler!: GPUSampler;
+    private comparisonSampler!: GPUSampler;
+    private dummyReadDepthTexture!: GPUTexture;
+    private dummyWriteDepthTexture!: GPUTexture;
+    private dummyDataTextureA!: GPUTexture;
+    private dummyDataTextureB!: GPUTexture;
+    private dummyDataTextureC!: GPUTexture;
+    private dummyPlasmaBuffer!: GPUBuffer;
+
+    private weatherParams: Float32Array = new Float32Array(WEATHER_PARAMS_FLOAT_COUNT);
+    private startTime: number = Date.now();
+    private shaderEffectsEnabled: boolean = true;
+
+    constructor(device: GPUDevice, context: GPUCanvasContext, _canvas: HTMLCanvasElement) {
+        this.device = device;
+        this.context = context;
+
+        this.filteringSampler = this.device.createSampler({
+            magFilter: 'linear',
+            minFilter: 'linear',
+            addressModeU: 'clamp-to-edge',
+            addressModeV: 'clamp-to-edge',
+        });
+        this.nonFilteringSampler = this.device.createSampler({
+            magFilter: 'nearest',
+            minFilter: 'nearest',
+        });
+        this.comparisonSampler = this.device.createSampler({
+            compare: 'less',
+        });
+
+        this.extraBuffer = this.device.createBuffer({
+            size: WEATHER_PARAMS_FLOAT_COUNT * 4,
+            usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+        });
+        this.computeUniformsBuffer = this.device.createBuffer({
+            size: COMPUTE_UNIFORMS_BYTE_SIZE,
+            usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+        });
+        this.noiseBuffer = this.device.createBuffer({
+            size: NOISE_BUFFER_BYTES,
+            usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+        });
+        this.dummyPlasmaBuffer = this.device.createBuffer({
+            size: 16,
+            usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+        });
+
+        this.dummyReadDepthTexture = this.device.createTexture({
+            size: [1, 1],
+            format: 'rgba8unorm',
+            usage: GPUTextureUsage.TEXTURE_BINDING,
+        });
+        this.dummyDataTextureC = this.device.createTexture({
+            size: [1, 1],
+            format: 'rgba8unorm',
+            usage: GPUTextureUsage.TEXTURE_BINDING,
+        });
+        this.dummyWriteDepthTexture = this.device.createTexture({
+            size: [1, 1],
+            format: 'r32float',
+            usage: GPUTextureUsage.STORAGE_BINDING,
+        });
+        this.dummyDataTextureA = this.device.createTexture({
+            size: [1, 1],
+            format: 'rgba32float',
+            usage: GPUTextureUsage.STORAGE_BINDING,
+        });
+        this.dummyDataTextureB = this.device.createTexture({
+            size: [1, 1],
+            format: 'rgba32float',
+            usage: GPUTextureUsage.STORAGE_BINDING,
+        });
+
+        this.weatherParams.set([
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 1.0,
+            0.0, 0.0, 0.0, 0.5, 0.5,
+            0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            1.0,
+            0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0
+        ]);
+        this.device.queue.writeBuffer(this.extraBuffer, 0, this.weatherParams);
+    }
+
+    public async init(presentationFormat: GPUTextureFormat): Promise<void> {
+        const shaderUrl = `${process.env.PUBLIC_URL || '/'}/shaders/weather-post-compute.wgsl`;
+        let shaderCode: string;
+        try {
+            const response = await fetch(shaderUrl);
+            if (!response.ok) {
+                throw new Error(`Failed to load weather-post-compute.wgsl: ${response.status} ${response.statusText}`);
+            }
+            shaderCode = await response.text();
+        } catch (error) {
+            console.error(`[Renderer] Failed to load weather-post-compute shader from ${shaderUrl}:`, error);
+            throw error;
+        }
+
+        const computeModule = this.device.createShaderModule({ code: shaderCode });
+
+        const computeBindGroupLayout = this.device.createBindGroupLayout({
+            entries: [
+                { binding: 0, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' } },
+                { binding: 1, visibility: GPUShaderStage.COMPUTE, texture: { sampleType: 'float' } },
+                { binding: 2, visibility: GPUShaderStage.COMPUTE, storageTexture: { access: 'write-only', format: 'rgba32float' } },
+                { binding: 3, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform' } },
+                { binding: 4, visibility: GPUShaderStage.COMPUTE, texture: { sampleType: 'float' } },
+                { binding: 5, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' } },
+                { binding: 6, visibility: GPUShaderStage.COMPUTE, storageTexture: { access: 'write-only', format: 'r32float' } },
+                { binding: 7, visibility: GPUShaderStage.COMPUTE, storageTexture: { access: 'write-only', format: 'rgba32float' } },
+                { binding: 8, visibility: GPUShaderStage.COMPUTE, storageTexture: { access: 'write-only', format: 'rgba32float' } },
+                { binding: 9, visibility: GPUShaderStage.COMPUTE, texture: { sampleType: 'float' } },
+                { binding: 10, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+                { binding: 11, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' } },
+                { binding: 12, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
+            ],
+        });
+
+        this.computePipeline = this.device.createComputePipeline({
+            layout: this.device.createPipelineLayout({ bindGroupLayouts: [computeBindGroupLayout] }),
+            compute: { module: computeModule, entryPoint: 'main' },
+        });
+
+        const blitModule = this.device.createShaderModule({ code: BLIT_SHADER });
+        const blitBindGroupLayout = this.device.createBindGroupLayout({
+            entries: [
+                { binding: 0, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'unfilterable-float' } },
+            ],
+        });
+        this.blitPipeline = this.device.createRenderPipeline({
+            layout: this.device.createPipelineLayout({ bindGroupLayouts: [blitBindGroupLayout] }),
+            vertex: { module: blitModule, entryPoint: 'vs_main' },
+            fragment: { module: blitModule, entryPoint: 'fs_main', targets: [{ format: presentationFormat }] },
+            primitive: { topology: 'triangle-list' },
+        });
+    }
+
+    private ensureWriteTexture(width: number, height: number): void {
+        if (this.writeTexture && this.writeWidth === width && this.writeHeight === height) return;
+        if (this.writeTexture) this.writeTexture.destroy();
+
+        this.writeWidth = width;
+        this.writeHeight = height;
+        this.writeTexture = this.device.createTexture({
+            size: [Math.max(1, width), Math.max(1, height)],
+            format: 'rgba32float',
+            usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+        });
+    }
+
+    public updateWeatherBindGroup(intermediateTextureView: GPUTextureView, width?: number, height?: number): void {
+        if (!this.computePipeline || !intermediateTextureView) return;
+
+        this.ensureWriteTexture(width || 1, height || 1);
+
+        this.computeBindGroup = this.device.createBindGroup({
+            layout: this.computePipeline.getBindGroupLayout(0),
+            entries: [
+                { binding: 0, resource: this.filteringSampler },
+                { binding: 1, resource: intermediateTextureView },
+                { binding: 2, resource: this.writeTexture.createView() },
+                { binding: 3, resource: { buffer: this.computeUniformsBuffer } },
+                { binding: 4, resource: this.dummyReadDepthTexture.createView() },
+                { binding: 5, resource: this.nonFilteringSampler },
+                { binding: 6, resource: this.dummyWriteDepthTexture.createView() },
+                { binding: 7, resource: this.dummyDataTextureA.createView() },
+                { binding: 8, resource: this.dummyDataTextureB.createView() },
+                { binding: 9, resource: this.dummyDataTextureC.createView() },
+                { binding: 10, resource: { buffer: this.extraBuffer } },
+                { binding: 11, resource: this.comparisonSampler },
+                { binding: 12, resource: { buffer: this.dummyPlasmaBuffer } },
+            ],
+        });
+
+        this.blitBindGroup = this.device.createBindGroup({
+            layout: this.blitPipeline.getBindGroupLayout(0),
+            entries: [
+                { binding: 0, resource: this.writeTexture.createView() },
+            ],
+        });
+    }
+
+    public updateNoiseBuffer(tile: Float32Array): void {
+        if (!this.noiseBuffer || !this.device) return;
+        this.device.queue.writeBuffer(this.noiseBuffer, 0, tile);
+    }
+
+    public setShaderEffects(enabled: boolean): void {
+        this.shaderEffectsEnabled = enabled;
+        if (this.extraBuffer && this.device) {
+            this.weatherParams[WeatherParamIndex.shaderEffectsEnabled] = enabled ? 1.0 : 0.0;
+            this.device.queue.writeBuffer(this.extraBuffer, 0, this.weatherParams);
+        }
+    }
+
+    public getCameraParams(): { heading: number; pitch: number } {
+        return {
+            heading: this.weatherParams[WeatherParamIndex.cameraHeading]!,
+            pitch: this.weatherParams[WeatherParamIndex.cameraPitch]!
+        };
+    }
+
+    public getShaderEffectsEnabled(): boolean {
+        return this.shaderEffectsEnabled;
+    }
+
+    public updateWeatherParams(params: Float32Array): void {
+        if (this.extraBuffer && this.device) {
+            this.weatherParams.set(params);
+            this.device.queue.writeBuffer(this.extraBuffer, 0, this.weatherParams);
+        }
+    }
+
+    public updateCameraParams(heading: number, pitch: number): void {
+        if (this.extraBuffer && this.device) {
+            this.weatherParams[WeatherParamIndex.cameraHeading] = heading;
+            this.weatherParams[WeatherParamIndex.cameraPitch] = pitch;
+            this.device.queue.writeBuffer(this.extraBuffer, 0, this.weatherParams);
+        }
+    }
+
+    public updateColorParams(params: Float32Array): void {
+        if (this.extraBuffer && this.device) {
+            this.weatherParams.set(params.slice(0, 6), 0);
+            this.device.queue.writeBuffer(this.extraBuffer, 0, this.weatherParams);
+        }
+    }
+
+    public updateWeatherAnimation(): void {
+        if (!this.device || !this.extraBuffer) return;
+        try {
+            const time = (Date.now() - this.startTime) / 1000;
+            this.weatherParams[WeatherParamIndex.time] = time % 10000.0;
+            this.device.queue.writeBuffer(this.extraBuffer, 0, this.weatherParams);
+        } catch (e) {
+            // Ignore errors during weather-only updates
+        }
+    }
+
+    private dispatch(commandEncoder: GPUCommandEncoder): void {
+        if (!this.computeBindGroup || this.writeWidth <= 0 || this.writeHeight <= 0) return;
+
+        this.device.queue.writeBuffer(
+            this.computeUniformsBuffer,
+            0,
+            new Float32Array([this.weatherParams[WeatherParamIndex.time]!, 0, this.writeWidth, this.writeHeight])
+        );
+
+        const computePass = commandEncoder.beginComputePass();
+        computePass.setPipeline(this.computePipeline);
+        computePass.setBindGroup(0, this.computeBindGroup);
+        computePass.dispatchWorkgroups(
+            Math.ceil(this.writeWidth / WORKGROUP_SIZE),
+            Math.ceil(this.writeHeight / WORKGROUP_SIZE)
+        );
+        computePass.end();
+    }
+
+    private blit(commandEncoder: GPUCommandEncoder): void {
+        if (!this.blitBindGroup) return;
+        const finalTextureView = this.context.getCurrentTexture().createView();
+        const blitPass = commandEncoder.beginRenderPass({
+            colorAttachments: [{
+                view: finalTextureView,
+                clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+                loadOp: 'clear' as GPULoadOp,
+                storeOp: 'store' as GPUStoreOp,
+            }],
+        });
+        blitPass.setPipeline(this.blitPipeline);
+        blitPass.setBindGroup(0, this.blitBindGroup);
+        blitPass.draw(3, 1, 0, 0);
+        blitPass.end();
+    }
+
+    public renderWeatherOnly(intermediateTextureView: GPUTextureView): void {
+        if (!this.device || !this.computePipeline) return;
+
+        try {
+            this.updateWeatherAnimation();
+
+            const commandEncoder = this.device.createCommandEncoder();
+
+            const clearPass = commandEncoder.beginRenderPass({
+                colorAttachments: [{
+                    view: intermediateTextureView,
+                    clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+                    loadOp: 'clear' as GPULoadOp,
+                    storeOp: 'store' as GPUStoreOp,
+                }],
+            });
+            clearPass.end();
+
+            this.dispatch(commandEncoder);
+            this.blit(commandEncoder);
+
+            this.device.queue.submit([commandEncoder.finish()]);
+        } catch (e) {
+            // Suppress errors during weather-only rendering
+        }
+    }
+
+    public renderPass(commandEncoder: GPUCommandEncoder): void {
+        this.dispatch(commandEncoder);
+        this.blit(commandEncoder);
+    }
+
+    public dispose(): void {
+        try {
+            if (this.extraBuffer) this.extraBuffer.destroy();
+            if (this.computeUniformsBuffer) this.computeUniformsBuffer.destroy();
+            if (this.noiseBuffer) this.noiseBuffer.destroy();
+            if (this.dummyPlasmaBuffer) this.dummyPlasmaBuffer.destroy();
+            if (this.writeTexture) this.writeTexture.destroy();
+            if (this.dummyReadDepthTexture) this.dummyReadDepthTexture.destroy();
+            if (this.dummyWriteDepthTexture) this.dummyWriteDepthTexture.destroy();
+            if (this.dummyDataTextureA) this.dummyDataTextureA.destroy();
+            if (this.dummyDataTextureB) this.dummyDataTextureB.destroy();
+            if (this.dummyDataTextureC) this.dummyDataTextureC.destroy();
+        } catch (e) {
+            // ignore cleanup errors
+        }
+        this.extraBuffer = undefined as any;
+        this.computeUniformsBuffer = undefined as any;
+        this.noiseBuffer = undefined as any;
+        this.writeTexture = undefined as any;
+        this.computePipeline = undefined as any;
+        this.computeBindGroup = undefined as any;
+        this.blitPipeline = undefined as any;
+        this.blitBindGroup = undefined as any;
+    }
+}

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -1,9 +1,27 @@
 import { RenderMode } from './types';
 import { TransitionManager } from './TransitionManager';
 import { WeatherPostProcessor } from './WeatherPostProcessor';
+import { ComputeWeatherPostProcessor } from './ComputeWeatherPostProcessor';
 import { getCanvasFingerprint } from '../utils/panoramaStability';
 import { streetViewProbe } from '../utils/streetViewProbe';
-import { RendererDebugOptions, StreetViewRenderer } from './RendererBackend';
+import { RendererDebugOptions, RendererInitOptions, StreetViewRenderer, WeatherPostProcessMode } from './RendererBackend';
+
+/** Common surface shared by WeatherPostProcessor and ComputeWeatherPostProcessor. */
+interface WeatherPostProcessorLike {
+    init(presentationFormat: GPUTextureFormat): Promise<void>;
+    updateWeatherBindGroup(intermediateTextureView: GPUTextureView, width?: number, height?: number): void;
+    updateNoiseBuffer(tile: Float32Array): void;
+    setShaderEffects(enabled: boolean): void;
+    getCameraParams(): { heading: number; pitch: number };
+    getShaderEffectsEnabled(): boolean;
+    updateWeatherParams(params: Float32Array): void;
+    updateCameraParams(heading: number, pitch: number): void;
+    updateColorParams(params: Float32Array): void;
+    updateWeatherAnimation(): void;
+    renderWeatherOnly(intermediateTextureView: GPUTextureView): void;
+    renderPass(commandEncoder: GPUCommandEncoder): void;
+    dispose(): void;
+}
 
 export class Renderer implements StreetViewRenderer {
     public readonly backendType = 'webgpu' as const;
@@ -42,7 +60,8 @@ export class Renderer implements StreetViewRenderer {
 
     // Sub-systems
     private transitionManager!: TransitionManager;
-    private weatherPostProcessor!: WeatherPostProcessor;
+    private weatherPostProcessor!: WeatherPostProcessorLike;
+    private weatherPostProcessMode: WeatherPostProcessMode = 'fragment';
 
     // World-space pan tracking
     private capturePanX: number = 0.5;
@@ -56,8 +75,9 @@ export class Renderer implements StreetViewRenderer {
         this.canvas = canvas;
     }
 
-    public async init(options?: { onLost?: (info: GPUDeviceLostInfo) => void }): Promise<boolean> {
+    public async init(options?: RendererInitOptions): Promise<boolean> {
         this.onLostCallback = options?.onLost;
+        this.weatherPostProcessMode = options?.weatherPostProcessMode || 'fragment';
         if (!navigator.gpu) {
             console.warn('WebGPU not supported. Using StreetView fallback.');
             return false;
@@ -117,7 +137,9 @@ export class Renderer implements StreetViewRenderer {
 
             await this.createPipeline();
 
-            this.weatherPostProcessor = new WeatherPostProcessor(this.device, this.context, this.canvas);
+            this.weatherPostProcessor = this.weatherPostProcessMode === 'compute'
+                ? new ComputeWeatherPostProcessor(this.device, this.context, this.canvas)
+                : new WeatherPostProcessor(this.device, this.context, this.canvas);
             await this.weatherPostProcessor.init(this.presentationFormat);
 
             this.transitionManager = new TransitionManager(this.device, this.sampler);
@@ -155,7 +177,11 @@ export class Renderer implements StreetViewRenderer {
         });
 
         this.intermediateTextureView = this.intermediateTexture.createView();
-        this.weatherPostProcessor.updateWeatherBindGroup(this.intermediateTextureView);
+        this.weatherPostProcessor.updateWeatherBindGroup(this.intermediateTextureView, width, height);
+    }
+
+    public getWeatherPostProcessMode(): WeatherPostProcessMode {
+        return this.weatherPostProcessMode;
     }
 
     private createTexture(width: number, height: number) {

--- a/src/renderer/RendererBackend.ts
+++ b/src/renderer/RendererBackend.ts
@@ -16,8 +16,12 @@ export interface RendererDebugOptions {
     wireframe: boolean;
 }
 
+export type WeatherPostProcessMode = 'fragment' | 'compute';
+
 export interface RendererInitOptions {
     onLost?: (info: GPUDeviceLostInfo) => void;
+    /** WebGPU only — WebGL2 fallback stays fragment-only. See docs/RENDERER_FALLBACK.md. */
+    weatherPostProcessMode?: WeatherPostProcessMode;
 }
 
 export interface StreetViewRenderer {
@@ -67,10 +71,13 @@ export interface StreetViewRenderer {
         zoom?: number
     ): void;
     setDebugOptions?(options: Partial<RendererDebugOptions>): void;
+    /** WebGPU only — returns which weather post-process pipeline is active. */
+    getWeatherPostProcessMode?(): WeatherPostProcessMode;
 }
 
 const VALID_BACKENDS = new Set(['auto', 'webgpu', 'webgl']);
 const VALID_EFFECTS = new Set(['all', 'raw', 'color', 'weather', 'fog', 'night', 'lighting']);
+const VALID_WEATHER_MODES = new Set(['fragment', 'compute']);
 
 function readSearchParams(): URLSearchParams {
     if (typeof window === 'undefined') return new URLSearchParams();
@@ -120,11 +127,38 @@ export function getRendererDebugOptions(): RendererDebugOptions {
     return { effectIsolation, wireframe };
 }
 
+/**
+ * Resolve the weather post-processing pipeline: `?weather=compute` or
+ * `?weather=fragment` in the URL wins, then a persisted `localStorage`
+ * choice, then `fallback` (typically the current visual quality preset's
+ * default — see src/config/visualPresets.ts). WebGPU-only; the WebGL2
+ * fallback renderer always uses its fragment-only SDR approximation.
+ */
+export function getWeatherPostProcessMode(fallback: WeatherPostProcessMode = 'fragment'): WeatherPostProcessMode {
+    const params = readSearchParams();
+    const explicit = params.get('weather')?.toLowerCase();
+    if (explicit && VALID_WEATHER_MODES.has(explicit)) {
+        return explicit as WeatherPostProcessMode;
+    }
+
+    try {
+        const stored = window.localStorage.getItem('streetview.weatherMode');
+        if (stored && VALID_WEATHER_MODES.has(stored)) {
+            return stored as WeatherPostProcessMode;
+        }
+    } catch {
+        // Storage may be unavailable in hardened browsers.
+    }
+
+    return fallback;
+}
+
 export function exposeRendererDebugGlobals(
     backendType: RendererBackendType,
     fallbackReason: string | undefined,
     debugOptions: RendererDebugOptions,
-    applyDebugOptions: (options: Partial<RendererDebugOptions>) => void
+    applyDebugOptions: (options: Partial<RendererDebugOptions>) => void,
+    weatherPostProcessMode?: WeatherPostProcessMode
 ): void {
     if (typeof window === 'undefined') return;
 
@@ -132,6 +166,7 @@ export function exposeRendererDebugGlobals(
     window.usingWebGPU = backendType === 'webgpu';
     window.usingWebGL = backendType === 'webgl';
     window.rendererFallbackReason = fallbackReason || '';
+    window.weatherPostProcessMode = weatherPostProcessMode || 'fragment';
 
     window.streetViewRendererDebug = {
         getBackend: () => ({
@@ -154,5 +189,11 @@ export function exposeRendererDebugGlobals(
             applyDebugOptions({ wireframe: enabled });
         },
         getDebugOptions: () => ({ ...debugOptions }),
+        getWeatherMode: () => window.weatherPostProcessMode || 'fragment',
+        setWeatherMode: (mode: WeatherPostProcessMode) => {
+            if (!VALID_WEATHER_MODES.has(mode)) return;
+            window.localStorage.setItem('streetview.weatherMode', mode);
+            window.location.reload();
+        },
     };
 }

--- a/src/renderer/WeatherPostProcessor.ts
+++ b/src/renderer/WeatherPostProcessor.ts
@@ -1,3 +1,5 @@
+import { WEATHER_PARAMS_FLOAT_COUNT, WeatherParamIndex } from './weatherUniformLayout';
+
 // Must match NOISE_TILE_SIZE in src/wasm/wasmNoiseFeeder.ts and the
 // `array<f32, 4096>` storage buffer declared in weather-post.wgsl.
 const NOISE_TILE_SIZE = 64;
@@ -12,7 +14,7 @@ export class WeatherPostProcessor {
     private weatherParamsBuffer!: GPUBuffer;
     private weatherSampler!: GPUSampler;
     private noiseBuffer!: GPUBuffer;
-    private weatherParams: Float32Array = new Float32Array(40);
+    private weatherParams: Float32Array = new Float32Array(WEATHER_PARAMS_FLOAT_COUNT);
     private startTime: number = Date.now();
     private shaderEffectsEnabled: boolean = true;
 
@@ -112,7 +114,7 @@ export class WeatherPostProcessor {
         });
     }
 
-    public updateWeatherBindGroup(intermediateTextureView: GPUTextureView): void {
+    public updateWeatherBindGroup(intermediateTextureView: GPUTextureView, _width?: number, _height?: number): void {
         if (!this.weatherPipeline || !intermediateTextureView || !this.weatherSampler) return;
 
         this.weatherBindGroup = this.device.createBindGroup({
@@ -138,15 +140,15 @@ export class WeatherPostProcessor {
     public setShaderEffects(enabled: boolean): void {
         this.shaderEffectsEnabled = enabled;
         if (this.weatherParamsBuffer && this.device) {
-            this.weatherParams[32] = enabled ? 1.0 : 0.0;
+            this.weatherParams[WeatherParamIndex.shaderEffectsEnabled] = enabled ? 1.0 : 0.0;
             this.device.queue.writeBuffer(this.weatherParamsBuffer, 0, this.weatherParams);
         }
     }
 
     public getCameraParams(): { heading: number; pitch: number } {
         return {
-            heading: this.weatherParams[33]!,
-            pitch: this.weatherParams[34]!
+            heading: this.weatherParams[WeatherParamIndex.cameraHeading]!,
+            pitch: this.weatherParams[WeatherParamIndex.cameraPitch]!
         };
     }
 
@@ -163,8 +165,8 @@ export class WeatherPostProcessor {
 
     public updateCameraParams(heading: number, pitch: number): void {
         if (this.weatherParamsBuffer && this.device) {
-            this.weatherParams[33] = heading;
-            this.weatherParams[34] = pitch;
+            this.weatherParams[WeatherParamIndex.cameraHeading] = heading;
+            this.weatherParams[WeatherParamIndex.cameraPitch] = pitch;
             this.device.queue.writeBuffer(this.weatherParamsBuffer, 0, this.weatherParams);
         }
     }
@@ -180,7 +182,7 @@ export class WeatherPostProcessor {
         if (!this.device || !this.weatherParamsBuffer) return;
         try {
             const time = (Date.now() - this.startTime) / 1000;
-            this.weatherParams[6] = time % 10000.0;
+            this.weatherParams[WeatherParamIndex.time] = time % 10000.0;
             this.device.queue.writeBuffer(this.weatherParamsBuffer, 0, this.weatherParams);
         } catch (e) {
             // Ignore errors during weather-only updates

--- a/src/renderer/createStreetViewRenderer.ts
+++ b/src/renderer/createStreetViewRenderer.ts
@@ -4,11 +4,13 @@ import {
     exposeRendererDebugGlobals,
     getRendererDebugOptions,
     getRendererPreference,
+    getWeatherPostProcessMode,
     RendererBackendType,
     RendererDebugOptions,
     RendererInitOptions,
     StreetViewRenderer,
 } from './RendererBackend';
+import { getPreset, detectRecommendedQuality } from '../config/visualPresets';
 
 export interface RendererCreateResult {
     renderer: StreetViewRenderer | null;
@@ -30,13 +32,19 @@ export async function createStreetViewRenderer(
             : ['webgpu', 'webgl'];
 
     let fallbackReason: string | undefined;
+    const presetDefaultWeatherMode = getPreset(detectRecommendedQuality()).weatherPostProcessMode;
+    const weatherPostProcessMode = getWeatherPostProcessMode(presetDefaultWeatherMode);
 
     for (const backend of attempts) {
-        const renderer = backend === 'webgpu'
+        const renderer: StreetViewRenderer = backend === 'webgpu'
             ? new Renderer(canvas)
             : new WebGLFallbackRenderer(canvas, debugOptions, fallbackReason || 'WebGPU unavailable or disabled');
 
-        const success = await renderer.init(options);
+        const initOptions: RendererInitOptions = backend === 'webgpu'
+            ? { ...options, weatherPostProcessMode }
+            : options || {};
+
+        const success = await renderer.init(initOptions);
         if (success) {
             exposeRendererDebugGlobals(
                 backend,
@@ -45,7 +53,8 @@ export async function createStreetViewRenderer(
                 (nextDebugOptions) => {
                     Object.assign(debugOptions, nextDebugOptions);
                     renderer.setDebugOptions?.(debugOptions);
-                }
+                },
+                renderer.getWeatherPostProcessMode?.()
             );
             renderer.setDebugOptions?.(debugOptions);
             return {

--- a/src/renderer/weatherUniformLayout.ts
+++ b/src/renderer/weatherUniformLayout.ts
@@ -1,0 +1,70 @@
+/**
+ * Single source of truth for the 40-float (160-byte) weather post-process
+ * uniform layout shared by:
+ *  - src/renderer/WeatherPostProcessor.ts   (fragment pass, uniform buffer)
+ *  - src/renderer/ComputeWeatherPostProcessor.ts (compute pass, storage buffer)
+ *  - public/shaders/weather-post.wgsl        (`struct WeatherParams`)
+ *  - public/shaders/weather-post-compute.wgsl (`extraBuffer` accessors)
+ *  - src/renderer/WebGLFallbackRenderer.ts   (SDR approximation)
+ *
+ * Changing an index here means updating all five in lockstep. See
+ * docs/RENDERER_FALLBACK.md and AGENTS.md ("Shader Uniform Layouts").
+ */
+
+export const WEATHER_PARAMS_FLOAT_COUNT = 40;
+export const WEATHER_PARAMS_BYTE_SIZE = WEATHER_PARAMS_FLOAT_COUNT * 4;
+
+export const WeatherParamIndex = {
+    // 0-5: color grading
+    vibrance: 0,
+    saturation: 1,
+    contrast: 2,
+    exposure: 3,
+    temperature: 4,
+    tint: 5,
+    // 6-10: weather / animation
+    time: 6,
+    rainIntensity: 7,
+    snowIntensity: 8,
+    wind: 9,
+    speed: 10,
+    // 11-15: nighttime + headlights
+    nightIntensity: 11,
+    headlightsOn: 12,
+    highBeam: 13,
+    headlightHeading: 14,
+    headlightPitch: 15,
+    // 16-17: dome light
+    domeLightOn: 16,
+    domeLightIntensity: 17,
+    // 18-21: astronomical sun/moon positions (SunCalc radians)
+    sunAzimuth: 18,
+    sunAltitude: 19,
+    moonAzimuth: 20,
+    moonAltitude: 21,
+    // 22-31: atmospheric effects
+    fogIntensity: 22,
+    fogDensity: 23,
+    fogHeight: 24,
+    fogColorIndex: 25,
+    lightShaftsIntensity: 26,
+    heatShimmerIntensity: 27,
+    lensFlareIntensity: 28,
+    chromaticAberration: 29,
+    dustIntensity: 30,
+    humidityHaze: 31,
+    // 32: shader toggle
+    shaderEffectsEnabled: 32,
+    // 33-35: camera + WASM noise toggle
+    cameraHeading: 33,
+    cameraPitch: 34,
+    wasmNoiseEnabled: 35,
+    // 36-37
+    sunrise: 36,
+    anamorphicStreak: 37,
+    // 38-39: padding to reach 40 floats (160 bytes total)
+    _pad2: 38,
+    _pad3: 39,
+} as const;
+
+export type WeatherParamName = keyof typeof WeatherParamIndex;


### PR DESCRIPTION
## Summary

- Adds `ComputeWeatherPostProcessor` (`src/renderer/ComputeWeatherPostProcessor.ts`) as an opt-in alternative to the existing fragment-pass `WeatherPostProcessor`. It dispatches `weather-post-compute.wgsl` (`@workgroup_size(16, 16, 1)`) into an `rgba32float` storage texture, then blits that texture to the canvas with a cheap `textureLoad` render pass.
- Both pipelines now read/write a **single source of truth** for the 40-float weather uniform layout: `src/renderer/weatherUniformLayout.ts` (`WeatherParamIndex`). Fixed an index-drift bug in `weather-post-compute.wgsl`'s `extraBuffer` comments/accessors where `wasmNoiseEnabled` (index 35) was missing, silently shifting `sunrise`/`anamorphicStreak` down by one relative to the fragment shader's `WeatherParams` struct.
- Feature-flagged via `?weather=compute` / `?weather=fragment` URL params, a persisted `localStorage` choice (`window.streetViewRendererDebug.setWeatherMode(...)`, mirroring the existing `setBackend` pattern), or the active visual quality preset in `src/config/visualPresets.ts` (`weatherPostProcessMode`, defaulting to `'compute'` only for the `ultra` tier). WebGPU-only — the WebGL2 fallback renderer stays fragment-only as before.
- `Renderer.ts` picks the processor at `init()` time behind a shared `WeatherPostProcessorLike` interface, so the render loop, hold-pause transitions, and all weather/camera param setters are unchanged regardless of which pipeline is active.
- `docs/RENDERER_FALLBACK.md` and `AGENTS.md` updated with a new "Weather Post-Process: Fragment vs Compute" section documenting the toggle, defaults, and the known gap (the compute path doesn't yet sample the WASM noise tile used for dust-cloud turbulence — bindings for depth/data textures and a `plasmaBuffer` are wired to 1x1 dummy resources, reserved for #128 and future GPU-particle work).

## Test plan

- [x] `npx tsc --noEmit` — no new type errors (verified against a clean-checkout baseline, which also has pre-existing unrelated `App.test.tsx` jest-type errors).
- [x] `npx eslint` on all changed/new files — clean.
- [x] `npm test` (full suite) — 170/170 passing, including `RendererBackend`/`createStreetViewRenderer` tests.
- [ ] Manual WebGPU visual parity check (rain/snow/fog/color grading, FreeLook + Car Mode) and fragment-vs-compute FPS benchmark on integrated vs discrete GPU — **not run**: this sandbox has no Maps API key configured, so `WebGPUCanvas` never mounts a renderer and there's no way to drive a real WebGPU device here. Recommend running with `?weather=compute` vs default locally, plus `window.streetViewRendererDebug.getWeatherMode()` to confirm the toggle, before merging.
- [ ] Hold-pause probe checklist (`StreetViewProbe` hold/release logs) — same limitation, needs a live Maps key to exercise.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MesmLK5amjrGgnPj1cHinA)_