### PR TITLE
Fix import.meta SyntaxError and PWA meta deprecation

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -148,6 +148,10 @@ def _build_index_problems(build_path: Path) -> list[str]:
         )
     if "static/js/main" not in content:
         problems.append("does not reference static/js/main.*.js (React bundle will never load)")
+    if 'type="module"' not in content:
+        problems.append(
+            'main script is missing type="module" (Vite ESM bundle will throw on import.meta)'
+        )
     return problems
 
 
@@ -271,7 +275,7 @@ def _repair_index_html(index_html: bytes, build_path: Path) -> bytes:
     if main_css and main_css not in text:
         insert += f'<link href="{main_css}" rel="stylesheet">'
     if main_js not in text:
-        insert += f'<script defer="defer" src="{main_js}"></script>'
+        insert += f'<script type="module" crossorigin src="{main_js}"></script>'
 
     if not insert:
         return text.encode("utf-8") if changed else index_html

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#4CAF50" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="manifest" href="./manifest.json" />

--- a/scripts/verify-build.sh
+++ b/scripts/verify-build.sh
@@ -82,11 +82,12 @@ else
     echo "✅ index.html uses bundle-only Maps key delivery (go.1ink.us style)"
   fi
 
-  # Vite emits native ES modules — import.meta is valid (no Cesium IIFE sed patch).
+  # Vite emits native ES modules — import.meta requires type=module on the script tag.
   if grep -q 'type="module"' "$INDEX_HTML"; then
     echo "✅ index.html loads the bundle as type=module (import.meta OK)"
   else
-    echo "⚠️  WARNING: index.html does not mark the main script as type=module"
+    echo "❌ ERROR: index.html does not mark the main script as type=module (import.meta will throw)"
+    ERRORS=$((ERRORS+1))
   fi
 fi
 

--- a/src/app/mapsKeyUtils.ts
+++ b/src/app/mapsKeyUtils.ts
@@ -15,11 +15,9 @@ export function normalizeMapsKey(value: string | undefined): string {
 }
 
 export function getConfiguredMapsKey(): string {
+  // Vite replaces process.env.* at build time (see vite.config.ts define shim).
   const buildTimeKey =
-    (typeof import.meta !== 'undefined' &&
-      (import.meta.env?.VITE_MAPS_API_KEY || import.meta.env?.REACT_APP_MAPS_API_KEY)) ||
-    process.env.VITE_MAPS_API_KEY ||
-    process.env.REACT_APP_MAPS_API_KEY;
+    process.env.VITE_MAPS_API_KEY || process.env.REACT_APP_MAPS_API_KEY;
 
   return getConfiguredMapsKeyFromEnv(
     buildTimeKey,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users see `Uncaught SyntaxError: Cannot use 'import.meta' outside a module` and a deprecation warning for `apple-mobile-web-app-capable`.

**Root cause:** The live deploy at `test.1ink.us/streetview` serves `index.html` with:

```html
<script crossorigin src="./static/js/main.*.js"></script>
```

Vite's production bundle is native ESM and requires `type="module"`. Without it, both `import.meta.url` (chunk loading) and the leftover `typeof import.meta` guard in `mapsKeyUtils` throw at parse time.

## Fix

1. **`mapsKeyUtils.ts`** — Use the existing `process.env.*` Vite define shim instead of `import.meta.env`, eliminating runtime `import.meta` from the maps-key path.
2. **`index.html`** — Add `<meta name="mobile-web-app-capable" content="yes">` (keep the Apple tag for iOS).
3. **`verify-build.sh`** — Fail the build if `type="module"` is missing from `index.html`.
4. **`deploy.py`** — Reject deploys missing `type="module"`; repair fallback script injection now uses `type="module"`.

## After merge

Redeploy with `npm run build && MAPS_API_KEY=... python deploy.py` so production picks up the corrected `index.html` (`type="module"` on the main script tag).

## Testing

- `npm test -- --run src/app/mapsKeyUtils.test.ts` — pass
- `npm run build` — pass; verify-build confirms `type="module"` present
- Built bundle no longer contains `typeof import.meta` from mapsKeyUtils (only Vite's `import.meta.url` for lazy chunks, which is valid with `type="module"`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18f666ce-c0a7-42fc-a375-41810bb2f7f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18f666ce-c0a7-42fc-a375-41810bb2f7f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

