### PR TITLE
Implement Phase 3 offline route-graph prefetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,11 @@ Limited offline exploration is supported in three phases (see `docs/feature_expa
 |---|---|---|
 | **1 — App shell** | ✅ | React bundle, WGSL shaders, WASM loader (`public/service-worker.js`) |
 | **2 — Metadata** | ✅ | Bookmarks, history, tours, snapshot gallery (IndexedDB + localStorage mirror) |
-| **3 — Route prefetch** | 🚧 Scaffold | Pano link graph storage API (`src/offline/routePrefetch.ts`); UI wiring pending #134 |
+| **3 — Route prefetch** | ✅ | Prepare a tour's panorama link graph while online (`src/offline/routePrefetch.ts`); browse/delete it from the Tours and Offline panels |
 
-After one online visit, the app shell loads without network. Open **Offline** in the toolbar to view storage quota, clear cached shell assets, or wipe offline metadata.
+After one online visit, the app shell loads without network. Open **Offline** in the toolbar to view storage quota, clear cached shell assets, wipe offline metadata, or manage prepared route graphs.
+
+Open a saved tour in the **Tours** panel and click **Prepare offline graph** (while online) to walk its waypoints via `StreetViewService`, collect each panorama's link IDs, and persist them to IndexedDB. Cruise mode and tour playback consult this graph (see `src/offline/routeGraphNavigation.ts`) to pre-warm the likely next panorama when the connection is flaky — the graph never substitutes for a live connection, and no imagery is ever cached. Once offline, the app still shows which panos/links are known; it never fabricates a panorama.
 
 ### Google Maps Platform Terms — caching constraints
 

--- a/docs/feature_expansion_plan.md
+++ b/docs/feature_expansion_plan.md
@@ -675,13 +675,14 @@ const estimateStorage = async () => {
 - Thumbnail regeneration on demand
 - Metadata search/filtering
 
-#### 8.3 Downloadable Route Data 🚧
-**Pre-download Workflow:**
-1. User plots a route
-2. System identifies all panoramas within X meters of route
-3. Shows download size estimate
-4. Downloads in background with progress indicator
-5. Stores in IndexedDB with route association (link graph scaffold landed; UI pending #134)
+#### 8.3 Downloadable Route Data ✅
+**Pre-download workflow (implemented via the Tours panel's "Prepare offline graph"):**
+1. User selects a saved tour (its waypoints double as the route)
+2. `prefetchRouteGraph` walks each waypoint via `StreetViewService`, snapping to the nearest panorama
+3. Progress is reported per waypoint (`RoutePrefetchProgress`) and shown in the Tours panel
+4. Pano IDs + link IDs (never imagery) are stored in IndexedDB under `routeGraph`, keyed by `${routeId}:${panoId}`
+5. The Offline storage panel lists prepared graphs by node count and supports deleting them
+6. Cruise mode and tour playback consult the graph (`src/offline/routeGraphNavigation.ts`) to pre-warm the likely next panorama when online but flaky; no fake panoramas are shown when truly offline
 
 #### 8.4 Offline POI Data ⬜
 - Wikipedia articles for landmarks (offline package)

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -5,6 +5,7 @@ import {
   useViewMode,
   useEnvironmentSettings,
   useAdvanceSafe,
+  useRoutePrefetch,
 } from '../hooks';
 import { useOfflineStatus } from '../hooks/useOfflineStatus';
 import { useSharedSession } from '../hooks/useSharedSession';
@@ -54,6 +55,7 @@ export function AppShell() {
     setZoom,
   } = useStreetView();
   const { advanceSafe, teleportSafe, teleportToPanoSafe, panoCache } = useAdvanceSafe();
+  const routePrefetch = useRoutePrefetch();
   const { viewMode, toggleViewMode } = useViewMode();
   const env = useEnvironmentSettings();
   const panels = useAppPanels();
@@ -122,6 +124,8 @@ export function AppShell() {
     setPitch,
     setZoom,
     isPanoramaReady,
+    routePrefetch,
+    panoCacheFetch: panoCache.fetch,
   });
 
   const { isCruiseMode, setIsCruiseMode } = useCruiseMode({
@@ -131,6 +135,7 @@ export function AppShell() {
     heading,
     isTransitioning,
     setNavPending: connection.setNavPending,
+    loadOfflineRouteGraphNodes: routePrefetch.loadAllCachedNodes,
   });
   onAuthFailureRef.current = () => setIsCruiseMode(false);
 
@@ -318,6 +323,11 @@ export function AppShell() {
             rendererBackendInfo: connection.rendererBackendInfo,
             navPending: connection.navPending,
             historicalAfterLabel: historical.historicalAfterLabel,
+          }}
+          offlineRoutes={{
+            summaries: routePrefetch.summaries,
+            onDelete: (routeId) => void routePrefetch.deleteRouteGraph(routeId),
+            onRefresh: () => void routePrefetch.refreshSummaries(),
           }}
         />
       )}

--- a/src/app/shell/ConnectedChrome.tsx
+++ b/src/app/shell/ConnectedChrome.tsx
@@ -12,6 +12,7 @@ import type { UseHistoricalExperienceResult } from '../useHistoricalExperience';
 import type { RendererBackendInfo } from '../../components/RendererBackendIndicator';
 import type { PerformanceMonitorState } from '../../hooks/usePerformanceMonitor';
 import type { MemoryStats } from '../../utils/memoryProfiler';
+import type { RouteGraphSummary } from '../../offline';
 import AppToolbar from '../../components/AppToolbar';
 import {
   BookmarkPanel,
@@ -113,6 +114,12 @@ export interface ConnectedChromeGlobe {
   handleStartJourney: (waypoints: { lat: number; lng: number }[]) => void | Promise<void>;
 }
 
+export interface ConnectedChromeOfflineRoutes {
+  summaries: RouteGraphSummary[];
+  onDelete: (routeId: string) => void;
+  onRefresh: () => void;
+}
+
 export interface ConnectedChromeOverlays {
   showPerformanceStats: boolean;
   setShowPerformanceStats: (show: boolean) => void;
@@ -136,6 +143,7 @@ export interface ConnectedChromeProps {
   tourPanelProps: TourPanelBindings;
   globe: ConnectedChromeGlobe;
   overlays: ConnectedChromeOverlays;
+  offlineRoutes: ConnectedChromeOfflineRoutes;
 }
 
 /** Toolbar + feature panels + globe, shown once the user is connected. */
@@ -152,6 +160,7 @@ export function ConnectedChrome({
   tourPanelProps,
   globe,
   overlays,
+  offlineRoutes,
 }: ConnectedChromeProps) {
   const {
     viewMode,
@@ -413,6 +422,9 @@ export function ConnectedChrome({
           onClose={() => setIsStoragePanelOpen(false)}
           isOnline={snaps.isOnline}
           hasServiceWorker={snaps.hasServiceWorker}
+          routeGraphSummaries={offlineRoutes.summaries}
+          onDeleteRouteGraph={offlineRoutes.onDelete}
+          onRefreshRouteGraphs={offlineRoutes.onRefresh}
         />
       )}
 

--- a/src/app/useTourBindings.ts
+++ b/src/app/useTourBindings.ts
@@ -1,5 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { useTours, type CurrentPOV, type Tour, type TourWaypoint } from '../hooks/useTours';
+import type { UseRoutePrefetchResult } from '../hooks/useRoutePrefetch';
+import type { RouteGraphNode, RouteGraphSummary, RoutePrefetchProgress } from '../offline';
 
 export interface UseTourBindingsParams {
   panorama: google.maps.StreetViewPanorama | null;
@@ -12,6 +14,8 @@ export interface UseTourBindingsParams {
   setPitch: (pitch: number) => void;
   setZoom: (zoom: number) => void;
   isPanoramaReady: boolean;
+  routePrefetch: UseRoutePrefetchResult;
+  panoCacheFetch: (lat: number, lng: number) => Promise<unknown>;
 }
 
 /** Props bag consumed by TourPanel (minus isOpen/onClose owned by panels). */
@@ -42,6 +46,15 @@ export interface TourPanelBindings {
   setPitch: (pitch: number) => void;
   setZoom: (zoom: number) => void;
   isPanoramaReady: boolean;
+  /** Offline route-graph prefetch (Phase 3): one summary per prepared tour. */
+  routeGraphSummaries: RouteGraphSummary[];
+  routeGraphBusyId: string | null;
+  routeGraphProgress: Record<string, RoutePrefetchProgress>;
+  routeGraphError: string | null;
+  onPrepareOfflineGraph: (tour: Tour) => void;
+  onDeleteRouteGraph: (routeId: string) => void;
+  getRouteGraph: (routeId: string) => Promise<RouteGraphNode[]>;
+  panoCacheFetch: (lat: number, lng: number) => Promise<unknown>;
 }
 
 export interface UseTourBindingsResult {
@@ -64,6 +77,8 @@ export function useTourBindings({
   setPitch,
   setZoom,
   isPanoramaReady,
+  routePrefetch,
+  panoCacheFetch,
 }: UseTourBindingsParams): UseTourBindingsResult {
   const toursApi = useTours();
 
@@ -78,6 +93,23 @@ export function useTourBindings({
       pov: { heading, pitch, zoom },
     };
   }, [panorama, heading, pitch, zoom]);
+
+  const onPrepareOfflineGraph = useCallback(
+    (tour: Tour) => {
+      void routePrefetch.prepareOfflineGraph(
+        tour.id,
+        tour.waypoints.map((wp) => ({ lat: wp.position.lat, lng: wp.position.lng, label: wp.annotation })),
+      );
+    },
+    [routePrefetch],
+  );
+
+  const onDeleteRouteGraph = useCallback(
+    (routeId: string) => {
+      void routePrefetch.deleteRouteGraph(routeId);
+    },
+    [routePrefetch],
+  );
 
   const tourPanelProps: TourPanelBindings = useMemo(
     () => ({
@@ -106,6 +138,14 @@ export function useTourBindings({
       setPitch,
       setZoom,
       isPanoramaReady,
+      routeGraphSummaries: routePrefetch.summaries,
+      routeGraphBusyId: routePrefetch.busyRouteId,
+      routeGraphProgress: routePrefetch.progressByRouteId,
+      routeGraphError: routePrefetch.error,
+      onPrepareOfflineGraph,
+      onDeleteRouteGraph,
+      getRouteGraph: routePrefetch.getRouteGraph,
+      panoCacheFetch,
     }),
     [
       toursApi,
@@ -116,6 +156,14 @@ export function useTourBindings({
       setPitch,
       setZoom,
       isPanoramaReady,
+      routePrefetch.summaries,
+      routePrefetch.busyRouteId,
+      routePrefetch.progressByRouteId,
+      routePrefetch.error,
+      routePrefetch.getRouteGraph,
+      onPrepareOfflineGraph,
+      onDeleteRouteGraph,
+      panoCacheFetch,
     ],
   );
 

--- a/src/components/StorageManagementPanel.tsx
+++ b/src/components/StorageManagementPanel.tsx
@@ -6,6 +6,7 @@ import {
   readStorageEstimate,
   requestPersistentStorage,
   type StorageEstimateSummary,
+  type RouteGraphSummary,
 } from '../offline';
 
 interface StorageManagementPanelProps {
@@ -13,6 +14,10 @@ interface StorageManagementPanelProps {
   onClose: () => void;
   isOnline: boolean;
   hasServiceWorker: boolean;
+  /** Offline route-graph prefetch (Phase 3) — optional so panel still works without it wired up. */
+  routeGraphSummaries?: RouteGraphSummary[];
+  onDeleteRouteGraph?: (routeId: string) => void;
+  onRefreshRouteGraphs?: () => void;
 }
 
 const panelStyle: React.CSSProperties = {
@@ -38,6 +43,9 @@ const StorageManagementPanel: React.FC<StorageManagementPanelProps> = ({
   onClose,
   isOnline,
   hasServiceWorker,
+  routeGraphSummaries = [],
+  onDeleteRouteGraph,
+  onRefreshRouteGraphs,
 }) => {
   const panelRef = React.useRef<HTMLDivElement>(null);
   const [estimate, setEstimate] = useState<StorageEstimateSummary | null>(null);
@@ -48,7 +56,8 @@ const StorageManagementPanel: React.FC<StorageManagementPanelProps> = ({
 
   const refresh = useCallback(async () => {
     setEstimate(await readStorageEstimate());
-  }, []);
+    onRefreshRouteGraphs?.();
+  }, [onRefreshRouteGraphs]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -224,6 +233,45 @@ const StorageManagementPanel: React.FC<StorageManagementPanelProps> = ({
             </div>
           </div>
         )}
+
+        <div style={{ marginBottom: 16 }}>
+          <h3 style={{ margin: '0 0 8px', fontSize: 15 }}>Prepared route graphs ({routeGraphSummaries.length})</h3>
+          <p style={{ margin: '0 0 10px', fontSize: 12, color: 'rgba(255,255,255,0.6)', lineHeight: 1.4 }}>
+            Pano IDs and link connections for tours prepared via "Prepare offline graph" in the Tours panel.
+            Imagery still requires a network connection — these store link IDs only, never tile pixels.
+          </p>
+          {routeGraphSummaries.length === 0 ? (
+            <p style={{ margin: 0, fontSize: 13, color: 'rgba(255,255,255,0.5)' }}>None prepared yet.</p>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              {routeGraphSummaries.map((summary) => (
+                <div
+                  key={summary.routeId}
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    background: 'rgba(255,255,255,0.06)',
+                    borderRadius: 8,
+                    padding: '8px 12px',
+                    fontSize: 13,
+                  }}
+                >
+                  <span>{summary.nodeCount} pano{summary.nodeCount === 1 ? '' : 's'} cached</span>
+                  {onDeleteRouteGraph && (
+                    <button
+                      onClick={() => onDeleteRouteGraph(summary.routeId)}
+                      aria-label={`Delete route graph ${summary.routeId}`}
+                      style={{ background: 'none', border: 'none', color: '#ff8a8a', cursor: 'pointer', fontSize: 12 }}
+                    >
+                      Delete
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
           <button

--- a/src/components/TourPanel.tsx
+++ b/src/components/TourPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect, useState } from 'react';
 import { Tour, TourWaypoint, CurrentPOV, TourTransitionType } from '../hooks/useTours';
+import type { RouteGraphNode, RouteGraphSummary, RoutePrefetchProgress } from '../offline';
 import { useFocusTrap } from '../hooks/useKeyboardShortcuts';
 import TourRecorder from './TourRecorder';
 import TourPlayer from './TourPlayer';
@@ -33,6 +34,16 @@ interface TourPanelProps {
     setPitch: (pitch: number) => void;
     setZoom: (zoom: number) => void;
     isPanoramaReady: boolean;
+
+    /** Offline route-graph prefetch (Phase 3) — pano link graph, no imagery. */
+    routeGraphSummaries?: RouteGraphSummary[];
+    routeGraphBusyId?: string | null;
+    routeGraphProgress?: Record<string, RoutePrefetchProgress>;
+    routeGraphError?: string | null;
+    onPrepareOfflineGraph?: (tour: Tour) => void;
+    onDeleteRouteGraph?: (routeId: string) => void;
+    getRouteGraph?: (routeId: string) => Promise<RouteGraphNode[]>;
+    panoCacheFetch?: (lat: number, lng: number) => Promise<unknown>;
 }
 
 type TabKey = 'library' | 'record' | 'play';
@@ -74,6 +85,14 @@ const TourPanel: React.FC<TourPanelProps> = ({
     setPitch,
     setZoom,
     isPanoramaReady,
+    routeGraphSummaries = [],
+    routeGraphBusyId = null,
+    routeGraphProgress = {},
+    routeGraphError = null,
+    onPrepareOfflineGraph,
+    onDeleteRouteGraph,
+    getRouteGraph,
+    panoCacheFetch,
 }) => {
     const panelRef = useRef<HTMLDivElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
@@ -259,9 +278,54 @@ const TourPanel: React.FC<TourPanelProps> = ({
                                                 ×
                                             </button>
                                         </div>
+
+                                        {onPrepareOfflineGraph && (() => {
+                                            const summary = routeGraphSummaries.find(s => s.routeId === tour.id);
+                                            const progress = routeGraphProgress[tour.id];
+                                            const isBusy = routeGraphBusyId === tour.id;
+                                            return (
+                                                <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginTop: '6px', fontSize: '11px', color: '#9ccc65' }}>
+                                                    <button
+                                                        onClick={() => onPrepareOfflineGraph(tour)}
+                                                        disabled={isBusy || tour.waypoints.length === 0}
+                                                        title="Prefetch this tour's panorama link graph (pano IDs only, no imagery) for offline browsing"
+                                                        style={{ padding: '4px 8px', backgroundColor: 'rgba(255,255,255,0.08)', color: '#fff', border: '1px solid rgba(255,255,255,0.25)', borderRadius: '4px', cursor: isBusy ? 'default' : 'pointer', fontSize: '11px' }}
+                                                    >
+                                                        {isBusy
+                                                            ? `Preparing… ${progress ? `${progress.completedSteps}/${progress.totalSteps}` : ''}`
+                                                            : summary
+                                                                ? '↻ Refresh offline graph'
+                                                                : '📡 Prepare offline graph'}
+                                                    </button>
+                                                    {summary && !isBusy && (
+                                                        <>
+                                                            <span>✓ {summary.nodeCount} pano{summary.nodeCount === 1 ? '' : 's'} cached</span>
+                                                            {onDeleteRouteGraph && (
+                                                                <button
+                                                                    onClick={() => onDeleteRouteGraph(tour.id)}
+                                                                    aria-label={`Delete offline graph for ${tour.name}`}
+                                                                    style={{ background: 'none', border: 'none', color: '#ff8a8a', cursor: 'pointer', fontSize: '11px', padding: 0 }}
+                                                                >
+                                                                    remove
+                                                                </button>
+                                                            )}
+                                                        </>
+                                                    )}
+                                                </div>
+                                            );
+                                        })()}
                                     </div>
                                 ))}
                             </div>
+                        )}
+                        {routeGraphError && (
+                            <div style={{ color: '#ff8a8a', fontSize: '12px' }}>⚠️ {routeGraphError}</div>
+                        )}
+                        {(onPrepareOfflineGraph) && (
+                            <p style={{ margin: 0, fontSize: '11px', color: '#777', lineHeight: 1.4 }}>
+                                Offline graphs store panorama IDs and link connections only — imagery still
+                                requires a network connection (Google Maps Platform Terms).
+                            </p>
                         )}
                     </div>
                 )}
@@ -289,6 +353,8 @@ const TourPanel: React.FC<TourPanelProps> = ({
                         setPitch={setPitch}
                         setZoom={setZoom}
                         isPanoramaReady={isPanoramaReady}
+                        getRouteGraph={getRouteGraph}
+                        prewarmPanoCache={panoCacheFetch}
                     />
                 )}
             </div>

--- a/src/components/TourPlayer.tsx
+++ b/src/components/TourPlayer.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { Tour } from '../hooks/useTours';
+import type { RouteGraphNode } from '../offline';
+import { findPathBetweenPanos } from '../offline';
 
 interface TourPlayerProps {
     tour: Tour;
@@ -8,6 +10,10 @@ interface TourPlayerProps {
     setPitch: (pitch: number) => void;
     setZoom: (zoom: number) => void;
     isPanoramaReady: boolean;
+    /** Loads this tour's prefetched pano link graph, if one was prepared (see useRoutePrefetch). */
+    getRouteGraph?: (routeId: string) => Promise<RouteGraphNode[]>;
+    /** Pre-warms the panorama cache for a lat/lng, used to smooth hops the offline graph knows about. */
+    prewarmPanoCache?: (lat: number, lng: number) => Promise<unknown>;
 }
 
 const btnStyle: React.CSSProperties = {
@@ -29,6 +35,8 @@ const TourPlayer: React.FC<TourPlayerProps> = ({
     setPitch,
     setZoom,
     isPanoramaReady,
+    getRouteGraph,
+    prewarmPanoCache,
 }) => {
     const [currentIndex, setCurrentIndex] = useState(0);
     const [isPlaying, setIsPlaying] = useState(false);
@@ -38,6 +46,7 @@ const TourPlayer: React.FC<TourPlayerProps> = ({
     const speedRef = useRef(speed);
     speedRef.current = speed;
     const runTokenRef = useRef(0);
+    const routeGraphNodesRef = useRef<RouteGraphNode[]>([]);
 
     // Reset playback position whenever a different tour is loaded.
     useEffect(() => {
@@ -45,14 +54,44 @@ const TourPlayer: React.FC<TourPlayerProps> = ({
         setIsPlaying(false);
     }, [tour.id]);
 
+    // Load this tour's prefetched link graph (if any) once per tour, so
+    // playback can use known link edges to pre-warm upcoming hops.
+    useEffect(() => {
+        routeGraphNodesRef.current = [];
+        if (!getRouteGraph) return;
+        let cancelled = false;
+        getRouteGraph(tour.id)
+            .then((nodes) => {
+                if (!cancelled) routeGraphNodesRef.current = nodes;
+            })
+            .catch((err) => console.warn('[TourPlayer] Failed to load offline route graph', err));
+        return () => {
+            cancelled = true;
+        };
+    }, [tour.id, getRouteGraph]);
+
     const visitWaypoint = useCallback(async (index: number) => {
         const wp = tour.waypoints[index];
         if (!wp) return;
+
+        // If we know a prefetched link path from the previous waypoint to this
+        // one, pre-warm those intermediate panos — smooths playback online,
+        // never used to alter where we actually teleport.
+        const prevWp = tour.waypoints[index - 1];
+        if (prewarmPanoCache && prevWp && routeGraphNodesRef.current.length > 0) {
+            const path = findPathBetweenPanos(routeGraphNodesRef.current, prevWp.panoId, wp.panoId);
+            if (path) {
+                for (const node of path) {
+                    void prewarmPanoCache(node.lat, node.lng);
+                }
+            }
+        }
+
         await teleportToPano(wp.panoId);
         setHeading(wp.pov.heading);
         setPitch(wp.pov.pitch);
         setZoom(wp.pov.zoom);
-    }, [tour.waypoints, teleportToPano, setHeading, setPitch, setZoom]);
+    }, [tour.waypoints, teleportToPano, setHeading, setPitch, setZoom, prewarmPanoCache]);
 
     // Playback loop: advances through waypoints from currentIndex while isPlaying.
     useEffect(() => {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -46,6 +46,9 @@ export {
 export { usePanoramaCache } from './usePanoramaCache';
 export { useAdvanceSafe } from './useAdvanceSafe';
 
+// Offline route-graph prefetch (Phase 3)
+export { useRoutePrefetch, type UseRoutePrefetchResult } from './useRoutePrefetch';
+
 // Historical Timeline ("time travel") hooks
 export { useHistoricalImagery, type UseHistoricalImageryResult } from './useHistoricalImagery';
 export { useHistoricalTimeline, type UseHistoricalTimelineResult } from './useHistoricalTimeline';

--- a/src/hooks/useCruiseMode.ts
+++ b/src/hooks/useCruiseMode.ts
@@ -1,4 +1,6 @@
 import { useRef, useEffect, useState } from 'react';
+import { findBestOfflineLink } from '../offline';
+import type { RouteGraphNode } from '../offline';
 
 export interface UseCruiseModeOptions {
   panorama: google.maps.StreetViewPanorama | null;
@@ -7,6 +9,15 @@ export interface UseCruiseModeOptions {
   heading: number;
   isTransitioning: boolean;
   setNavPending: (pending: boolean) => void;
+  /**
+   * Optional loader for previously-prefetched route-graph nodes (see
+   * `useRoutePrefetch`). When provided, cruise mode loads them once per
+   * cruise session and uses them to pre-warm the likely next panorama —
+   * useful when the connection is flaky and a live `getLinks()` round trip
+   * is slow. Purely a pre-fetch hint; the live link lookup still decides
+   * the actual hop.
+   */
+  loadOfflineRouteGraphNodes?: () => Promise<RouteGraphNode[]>;
 }
 
 /** Initial bearing (degrees, 0–360) from point A to point B. */
@@ -31,8 +42,10 @@ export function useCruiseMode({
   heading,
   isTransitioning,
   setNavPending,
+  loadOfflineRouteGraphNodes,
 }: UseCruiseModeOptions) {
   const [isCruiseMode, setIsCruiseMode] = useState(false);
+  const offlineNodesRef = useRef<RouteGraphNode[]>([]);
 
   // Live view heading — tracks head-look every render but is NOT the travel
   // direction. Used only to seed the committed heading when cruise starts.
@@ -61,6 +74,16 @@ export function useCruiseMode({
     // Commit the current view heading as the travel direction the moment cruise
     // engages. From here it evolves only from real movement, not head-look.
     cruiseHeadingRef.current = liveHeadingRef.current;
+    // Load any previously-prefetched route graphs once per cruise session so a
+    // flaky connection doesn't pay an IndexedDB round trip on every hop.
+    offlineNodesRef.current = [];
+    if (loadOfflineRouteGraphNodes) {
+      loadOfflineRouteGraphNodes()
+        .then((nodes) => {
+          offlineNodesRef.current = nodes;
+        })
+        .catch((err) => console.warn('[CruiseMode] Failed to load offline route graph nodes', err));
+    }
     const hop = async () => {
       if (useTransitionRef.current) {
         console.log('[CruiseMode] Skipping hop - still transitioning');
@@ -72,9 +95,17 @@ export function useCruiseMode({
       }
       const panoIdBefore = panorama.getPano();
       const posBefore = panorama.getPosition() ?? null;
+      // Prefer a known next pano from a prefetched route graph, if we have
+      // one for the current location — pre-warms the pano cache so the hop
+      // stays smooth even when the live `getLinks()` round trip is slow.
+      let targetHint: { lat: number; lng: number } | undefined;
+      if (panoIdBefore && offlineNodesRef.current.length > 0) {
+        const bestOffline = findBestOfflineLink(offlineNodesRef.current, panoIdBefore, cruiseHeadingRef.current);
+        if (bestOffline) targetHint = { lat: bestOffline.lat, lng: bestOffline.lng };
+      }
       setNavPending(true);
       try {
-        await advanceSafe('forward', undefined, cruiseHeadingRef.current);
+        await advanceSafe('forward', targetHint, cruiseHeadingRef.current);
       } finally {
         setNavPending(false);
       }

--- a/src/hooks/useRoutePrefetch.ts
+++ b/src/hooks/useRoutePrefetch.ts
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  createStreetViewLinkCollector,
+  prefetchRouteGraph,
+  offlineGetAllRouteGraphNodes,
+  offlineGetRouteGraph,
+  offlineListRouteGraphs,
+  offlineDeleteRouteGraph,
+  type RoutePrefetchProgress,
+  type RoutePrefetchWaypoint,
+  type RouteGraphNode,
+  type RouteGraphSummary,
+} from '../offline';
+
+export interface UseRoutePrefetchResult {
+  /** One summary row per prepared route graph (routeId, node count, last-cached time). */
+  summaries: RouteGraphSummary[];
+  /** routeId currently being prepared, if any. */
+  busyRouteId: string | null;
+  /** Latest progress event per routeId that has been prepared this session. */
+  progressByRouteId: Record<string, RoutePrefetchProgress>;
+  /** Human-readable error from the most recent prepare/delete attempt, if any. */
+  error: string | null;
+  /** Prefetch a live pano link graph for the given waypoints and persist it under routeId. */
+  prepareOfflineGraph: (routeId: string, waypoints: RoutePrefetchWaypoint[]) => Promise<void>;
+  /** Remove a previously prepared route graph. */
+  deleteRouteGraph: (routeId: string) => Promise<void>;
+  /** Re-read summaries from IndexedDB (e.g. after external changes). */
+  refreshSummaries: () => Promise<void>;
+  /** Nodes for one route graph, for consumers that need the raw link data (e.g. tour playback). */
+  getRouteGraph: (routeId: string) => Promise<RouteGraphNode[]>;
+  /** All prefetched nodes across every route, for consumers with no single "current route" (e.g. cruise mode). */
+  loadAllCachedNodes: () => Promise<RouteGraphNode[]>;
+}
+
+/**
+ * Orchestrates Phase 3 route-graph prefetching: runs a live `StreetViewService`
+ * walk over a set of waypoints, persists pano IDs + link IDs (never imagery) to
+ * IndexedDB, and exposes progress/summary state for UI (Tour panel, Storage panel).
+ */
+export function useRoutePrefetch(): UseRoutePrefetchResult {
+  const [summaries, setSummaries] = useState<RouteGraphSummary[]>([]);
+  const [busyRouteId, setBusyRouteId] = useState<string | null>(null);
+  const [progressByRouteId, setProgressByRouteId] = useState<Record<string, RoutePrefetchProgress>>({});
+  const [error, setError] = useState<string | null>(null);
+
+  const refreshSummaries = useCallback(async () => {
+    try {
+      setSummaries(await offlineListRouteGraphs());
+    } catch (err) {
+      console.warn('[useRoutePrefetch] Failed to list route graphs', err);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshSummaries();
+  }, [refreshSummaries]);
+
+  const prepareOfflineGraph = useCallback(
+    async (routeId: string, waypoints: RoutePrefetchWaypoint[]) => {
+      if (!navigator.onLine) {
+        setError('Cannot prepare an offline route graph while offline — connect to the internet first.');
+        return;
+      }
+      if (typeof google === 'undefined' || !google.maps?.StreetViewService) {
+        setError('Street View is not ready yet — try again once the map has loaded.');
+        return;
+      }
+      if (waypoints.length === 0) {
+        setError('This route has no waypoints to prefetch.');
+        return;
+      }
+
+      setError(null);
+      setBusyRouteId(routeId);
+      try {
+        const collectLinksAt = createStreetViewLinkCollector(new google.maps.StreetViewService());
+        await prefetchRouteGraph({ routeId, waypoints }, collectLinksAt, (progress) => {
+          setProgressByRouteId((prev) => ({ ...prev, [routeId]: progress }));
+        });
+        await refreshSummaries();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to prepare offline route graph.');
+      } finally {
+        setBusyRouteId(null);
+      }
+    },
+    [refreshSummaries],
+  );
+
+  const deleteRouteGraph = useCallback(
+    async (routeId: string) => {
+      try {
+        await offlineDeleteRouteGraph(routeId);
+        setProgressByRouteId((prev) => {
+          if (!(routeId in prev)) return prev;
+          const next = { ...prev };
+          delete next[routeId];
+          return next;
+        });
+        await refreshSummaries();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to delete offline route graph.');
+      }
+    },
+    [refreshSummaries],
+  );
+
+  const getRouteGraph = useCallback((routeId: string) => offlineGetRouteGraph(routeId), []);
+  const loadAllCachedNodes = useCallback(() => offlineGetAllRouteGraphNodes(), []);
+
+  return {
+    summaries,
+    busyRouteId,
+    progressByRouteId,
+    error,
+    prepareOfflineGraph,
+    deleteRouteGraph,
+    refreshSummaries,
+    getRouteGraph,
+    loadAllCachedNodes,
+  };
+}

--- a/src/offline/index.ts
+++ b/src/offline/index.ts
@@ -19,10 +19,15 @@ export {
   offlineUpsertPanoMetadata,
   offlineGetRouteGraph,
   offlineSaveRouteGraph,
+  offlineGetAllRouteGraphNodes,
+  offlineListRouteGraphs,
+  offlineDeleteRouteGraph,
   type PanoMetadata,
   type RouteGraphNode,
+  type RouteGraphSummary,
   type OfflineStoreName,
 } from './offlineStore';
+export { findBestOfflineLink, findPathBetweenPanos } from './routeGraphNavigation';
 export {
   migrateLocalStorageToIndexedDB,
   loadMirroredJson,
@@ -42,7 +47,11 @@ export {
   buildRouteGraphNodes,
   savePrefetchedRoute,
   prefetchRouteGraph,
+  createStreetViewLinkCollector,
   type RoutePrefetchPlan,
+  type RoutePrefetchWaypoint,
+  type RoutePrefetchProgress,
   type PanoLinkSnapshot,
+  type StreetViewServiceLike,
 } from './routePrefetch';
 export { registerServiceWorker, unregisterServiceWorker } from './serviceWorkerRegistration';

--- a/src/offline/offlineStore.ts
+++ b/src/offline/offlineStore.ts
@@ -180,3 +180,44 @@ export async function offlineSaveRouteGraph(routeId: string, nodes: Omit<RouteGr
     ),
   );
 }
+
+/** All prefetched route-graph nodes across every route, deduplicated by their storage key. */
+export async function offlineGetAllRouteGraphNodes(): Promise<RouteGraphNode[]> {
+  const allKeys = await offlineListKeys('routeGraph');
+  const nodes: RouteGraphNode[] = [];
+  for (const key of allKeys) {
+    const node = await offlineGet<RouteGraphNode>('routeGraph', key);
+    if (node) nodes.push(node);
+  }
+  return nodes;
+}
+
+export interface RouteGraphSummary {
+  routeId: string;
+  nodeCount: number;
+  cachedAt: string;
+}
+
+/** One summary row per prepared route graph, for storage-management UI. */
+export async function offlineListRouteGraphs(): Promise<RouteGraphSummary[]> {
+  const nodes = await offlineGetAllRouteGraphNodes();
+  const summaries = new Map<string, RouteGraphSummary>();
+  for (const node of nodes) {
+    const existing = summaries.get(node.routeId);
+    if (existing) {
+      existing.nodeCount += 1;
+      if (node.cachedAt > existing.cachedAt) existing.cachedAt = node.cachedAt;
+    } else {
+      summaries.set(node.routeId, { routeId: node.routeId, nodeCount: 1, cachedAt: node.cachedAt });
+    }
+  }
+  return Array.from(summaries.values());
+}
+
+/** Delete every node belonging to one prepared route graph. */
+export async function offlineDeleteRouteGraph(routeId: string): Promise<void> {
+  const allKeys = await offlineListKeys('routeGraph');
+  const prefix = `${routeId}:`;
+  const keysToDelete = allKeys.filter((key) => key.startsWith(prefix));
+  await Promise.all(keysToDelete.map((key) => offlineDelete('routeGraph', key)));
+}

--- a/src/offline/routeGraphNavigation.test.ts
+++ b/src/offline/routeGraphNavigation.test.ts
@@ -1,0 +1,103 @@
+import { findBestOfflineLink, findPathBetweenPanos } from './routeGraphNavigation';
+import type { RouteGraphNode } from './offlineStore';
+
+function node(partial: Partial<RouteGraphNode> & { panoId: string }): RouteGraphNode {
+  return {
+    lat: 0,
+    lng: 0,
+    linkPanoIds: [],
+    routeId: 'route-1',
+    cachedAt: '2026-01-01T00:00:00.000Z',
+    ...partial,
+  };
+}
+
+describe('findBestOfflineLink', () => {
+  it('returns the neighbor whose bearing is closest to the target heading', () => {
+    const nodes: RouteGraphNode[] = [
+      node({ panoId: 'start', lat: 0, lng: 0, linkPanoIds: ['north', 'east'] }),
+      node({ panoId: 'north', lat: 1, lng: 0 }),
+      node({ panoId: 'east', lat: 0, lng: 1 }),
+    ];
+
+    const best = findBestOfflineLink(nodes, 'start', 0);
+    expect(best?.panoId).toBe('north');
+
+    const bestEast = findBestOfflineLink(nodes, 'start', 90);
+    expect(bestEast?.panoId).toBe('east');
+  });
+
+  it('returns null when the current pano is not in the graph', () => {
+    const nodes: RouteGraphNode[] = [node({ panoId: 'other' })];
+    expect(findBestOfflineLink(nodes, 'missing', 0)).toBeNull();
+  });
+
+  it('returns null when no neighbor is within the heading tolerance', () => {
+    const nodes: RouteGraphNode[] = [
+      node({ panoId: 'start', lat: 0, lng: 0, linkPanoIds: ['south'] }),
+      node({ panoId: 'south', lat: -1, lng: 0 }),
+    ];
+    // south is ~180 degrees away from a target heading of due north (0).
+    expect(findBestOfflineLink(nodes, 'start', 0)).toBeNull();
+  });
+
+  it('ignores linked panoIds that have no corresponding node', () => {
+    const nodes: RouteGraphNode[] = [
+      node({ panoId: 'start', lat: 0, lng: 0, linkPanoIds: ['ghost', 'north'] }),
+      node({ panoId: 'north', lat: 1, lng: 0 }),
+    ];
+    expect(findBestOfflineLink(nodes, 'start', 0)?.panoId).toBe('north');
+  });
+});
+
+describe('findPathBetweenPanos', () => {
+  it('returns an empty path when start equals destination', () => {
+    expect(findPathBetweenPanos([node({ panoId: 'a' })], 'a', 'a')).toEqual([]);
+  });
+
+  it('finds a direct single-hop path', () => {
+    const nodes: RouteGraphNode[] = [
+      node({ panoId: 'a', linkPanoIds: ['b'] }),
+      node({ panoId: 'b', linkPanoIds: ['a'] }),
+    ];
+    const path = findPathBetweenPanos(nodes, 'a', 'b');
+    expect(path?.map((n) => n.panoId)).toEqual(['b']);
+  });
+
+  it('finds a multi-hop path through intermediate nodes', () => {
+    const nodes: RouteGraphNode[] = [
+      node({ panoId: 'a', linkPanoIds: ['b'] }),
+      node({ panoId: 'b', linkPanoIds: ['a', 'c'] }),
+      node({ panoId: 'c', linkPanoIds: ['b', 'd'] }),
+      node({ panoId: 'd', linkPanoIds: ['c'] }),
+    ];
+    const path = findPathBetweenPanos(nodes, 'a', 'd');
+    expect(path?.map((n) => n.panoId)).toEqual(['b', 'c', 'd']);
+  });
+
+  it('returns null when the destination is unreachable', () => {
+    const nodes: RouteGraphNode[] = [
+      node({ panoId: 'a', linkPanoIds: ['b'] }),
+      node({ panoId: 'b', linkPanoIds: ['a'] }),
+      node({ panoId: 'isolated', linkPanoIds: [] }),
+    ];
+    expect(findPathBetweenPanos(nodes, 'a', 'isolated')).toBeNull();
+  });
+
+  it('returns null when either endpoint is missing from the graph', () => {
+    const nodes: RouteGraphNode[] = [node({ panoId: 'a', linkPanoIds: ['b'] })];
+    expect(findPathBetweenPanos(nodes, 'a', 'missing')).toBeNull();
+    expect(findPathBetweenPanos(nodes, 'missing', 'a')).toBeNull();
+  });
+
+  it('respects maxHops and gives up beyond it', () => {
+    const nodes: RouteGraphNode[] = [
+      node({ panoId: 'a', linkPanoIds: ['b'] }),
+      node({ panoId: 'b', linkPanoIds: ['c'] }),
+      node({ panoId: 'c', linkPanoIds: ['d'] }),
+      node({ panoId: 'd', linkPanoIds: [] }),
+    ];
+    expect(findPathBetweenPanos(nodes, 'a', 'd', 2)).toBeNull();
+    expect(findPathBetweenPanos(nodes, 'a', 'd', 3)?.map((n) => n.panoId)).toEqual(['b', 'c', 'd']);
+  });
+});

--- a/src/offline/routeGraphNavigation.ts
+++ b/src/offline/routeGraphNavigation.ts
@@ -1,0 +1,85 @@
+/**
+ * Pure, offline-friendly navigation helpers over a prefetched `RouteGraphNode[]`
+ * graph (see `routePrefetch.ts` / `offlineStore.ts`). No network access here —
+ * these only ever consult data already persisted by a prior prefetch.
+ */
+
+import { absoluteAngleDiff, initialBearing } from '../utils/navigation';
+import type { RouteGraphNode } from './offlineStore';
+
+const MAX_HEADING_DIFF_DEG = 45;
+
+/**
+ * Pick the neighbor of `currentPanoId` (via its stored `linkPanoIds`) whose
+ * bearing is closest to `targetHeading`, mirroring the live `findBestLink`
+ * heuristic in `utils/navigation.ts` but using cached graph data instead of
+ * a live `getLinks()` call. Returns null if the current pano isn't in the
+ * graph or no neighbor is within `MAX_HEADING_DIFF_DEG`.
+ */
+export function findBestOfflineLink(
+  nodes: RouteGraphNode[],
+  currentPanoId: string,
+  targetHeading: number,
+): RouteGraphNode | null {
+  const byId = new Map(nodes.map((node) => [node.panoId, node]));
+  const current = byId.get(currentPanoId);
+  if (!current) return null;
+
+  let best: RouteGraphNode | null = null;
+  let smallestDiff = MAX_HEADING_DIFF_DEG;
+
+  for (const linkedId of current.linkPanoIds) {
+    const linked = byId.get(linkedId);
+    if (!linked) continue;
+    const bearing = initialBearing(current.lat, current.lng, linked.lat, linked.lng);
+    const diff = absoluteAngleDiff(targetHeading, bearing);
+    if (diff < smallestDiff) {
+      smallestDiff = diff;
+      best = linked;
+    }
+  }
+
+  return best;
+}
+
+/**
+ * Breadth-first search over the prefetched link graph from `fromPanoId` to
+ * `toPanoId`. Returns the ordered list of intermediate + destination nodes
+ * (excluding the start), or null if no path is found within `maxHops`.
+ * Used to pre-warm the panorama cache for hops a recorded tour "knows about"
+ * via its offline graph, without changing where playback actually teleports.
+ */
+export function findPathBetweenPanos(
+  nodes: RouteGraphNode[],
+  fromPanoId: string,
+  toPanoId: string,
+  maxHops = 8,
+): RouteGraphNode[] | null {
+  if (fromPanoId === toPanoId) return [];
+
+  const byId = new Map(nodes.map((node) => [node.panoId, node]));
+  if (!byId.has(fromPanoId) || !byId.has(toPanoId)) return null;
+
+  const visited = new Set<string>([fromPanoId]);
+  const queue: { panoId: string; path: RouteGraphNode[] }[] = [{ panoId: fromPanoId, path: [] }];
+
+  while (queue.length > 0) {
+    const { panoId, path } = queue.shift()!;
+    if (path.length >= maxHops) continue;
+    const node = byId.get(panoId);
+    if (!node) continue;
+
+    for (const nextId of node.linkPanoIds) {
+      if (visited.has(nextId)) continue;
+      visited.add(nextId);
+      const nextNode = byId.get(nextId);
+      if (!nextNode) continue;
+
+      const nextPath = [...path, nextNode];
+      if (nextId === toPanoId) return nextPath;
+      queue.push({ panoId: nextId, path: nextPath });
+    }
+  }
+
+  return null;
+}

--- a/src/offline/routePrefetch.test.ts
+++ b/src/offline/routePrefetch.test.ts
@@ -1,6 +1,23 @@
-import { buildRouteGraphNodes } from './routePrefetch';
+import { vi } from 'vitest';
+import {
+  buildRouteGraphNodes,
+  prefetchRouteGraph,
+  createStreetViewLinkCollector,
+  type PanoLinkSnapshot,
+  type RoutePrefetchProgress,
+  type StreetViewServiceLike,
+} from './routePrefetch';
+
+const { offlineSaveRouteGraph } = vi.hoisted(() => ({
+  offlineSaveRouteGraph: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('./offlineStore', () => ({ offlineSaveRouteGraph }));
 
 describe('routePrefetch', () => {
+  beforeEach(() => {
+    offlineSaveRouteGraph.mockClear();
+  });
+
   it('builds route graph nodes from pano link snapshots', () => {
     const nodes = buildRouteGraphNodes('route-1', [
       {
@@ -23,5 +40,150 @@ describe('routePrefetch', () => {
     expect(first.panoId).toBe('pano-a');
     expect(first.linkPanoIds).toEqual(['pano-b', 'pano-c']);
     expect(second.lat).toBe(37.2);
+  });
+
+  describe('prefetchRouteGraph', () => {
+    it('collects links at every waypoint and persists a non-empty graph', async () => {
+      const snapshotsByWaypoint: Record<string, PanoLinkSnapshot> = {
+        '37.1,-122.1': { panoId: 'pano-a', lat: 37.1, lng: -122.1, linkPanoIds: ['pano-b'] },
+        '37.2,-122.2': { panoId: 'pano-b', lat: 37.2, lng: -122.2, linkPanoIds: ['pano-a', 'pano-c'] },
+      };
+      const collectLinksAt = vi.fn(async (waypoint: { lat: number; lng: number }) => {
+        return snapshotsByWaypoint[`${waypoint.lat},${waypoint.lng}`] ?? null;
+      });
+
+      const progressEvents: RoutePrefetchProgress[] = [];
+      const count = await prefetchRouteGraph(
+        {
+          routeId: 'route-1',
+          waypoints: [
+            { lat: 37.1, lng: -122.1 },
+            { lat: 37.2, lng: -122.2 },
+          ],
+        },
+        collectLinksAt,
+        (progress) => progressEvents.push(progress),
+      );
+
+      expect(collectLinksAt).toHaveBeenCalledTimes(2);
+      expect(count).toBe(2);
+      expect(offlineSaveRouteGraph).toHaveBeenCalledTimes(1);
+      const [routeId, savedNodes] = offlineSaveRouteGraph.mock.calls[0]!;
+      expect(routeId).toBe('route-1');
+      expect(savedNodes).toHaveLength(2);
+      expect(savedNodes.map((n: PanoLinkSnapshot) => n.panoId).sort()).toEqual(['pano-a', 'pano-b']);
+
+      expect(progressEvents).toHaveLength(2);
+      expect(progressEvents[0]).toEqual({
+        routeId: 'route-1',
+        totalSteps: 2,
+        completedSteps: 1,
+        currentPanoId: 'pano-a',
+      });
+      expect(progressEvents[1]).toEqual({
+        routeId: 'route-1',
+        totalSteps: 2,
+        completedSteps: 2,
+        currentPanoId: 'pano-b',
+      });
+    });
+
+    it('dedupes snapshots that resolve to the same panoId', async () => {
+      const collectLinksAt = vi.fn(async () => ({
+        panoId: 'pano-shared',
+        lat: 1,
+        lng: 2,
+        linkPanoIds: [] as string[],
+      }));
+
+      const count = await prefetchRouteGraph(
+        { routeId: 'route-dupe', waypoints: [{ lat: 1, lng: 2 }, { lat: 1.0001, lng: 2.0001 }] },
+        collectLinksAt,
+      );
+
+      expect(count).toBe(1);
+      const [, savedNodes] = offlineSaveRouteGraph.mock.calls[0]!;
+      expect(savedNodes).toHaveLength(1);
+    });
+
+    it('skips a waypoint whose collector throws or returns null without aborting the run', async () => {
+      const collectLinksAt = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('network down'))
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ panoId: 'pano-ok', lat: 3, lng: 4, linkPanoIds: [] });
+
+      const progressEvents: RoutePrefetchProgress[] = [];
+      const count = await prefetchRouteGraph(
+        {
+          routeId: 'route-flaky',
+          waypoints: [{ lat: 0, lng: 0 }, { lat: 1, lng: 1 }, { lat: 2, lng: 2 }],
+        },
+        collectLinksAt,
+        (progress) => progressEvents.push(progress),
+      );
+
+      expect(count).toBe(1);
+      expect(progressEvents).toHaveLength(3);
+      expect(progressEvents[2]).toEqual({
+        routeId: 'route-flaky',
+        totalSteps: 3,
+        completedSteps: 3,
+        currentPanoId: 'pano-ok',
+      });
+    });
+
+    it('still saves (an empty) graph when every waypoint fails to resolve', async () => {
+      const collectLinksAt = vi.fn().mockResolvedValue(null);
+      const count = await prefetchRouteGraph(
+        { routeId: 'route-empty', waypoints: [{ lat: 0, lng: 0 }] },
+        collectLinksAt,
+      );
+      expect(count).toBe(0);
+      expect(offlineSaveRouteGraph).toHaveBeenCalledWith('route-empty', []);
+    });
+  });
+
+  describe('createStreetViewLinkCollector', () => {
+    it('resolves a snapshot from a StreetViewService-shaped getPanorama call', async () => {
+      const service: StreetViewServiceLike = {
+        getPanorama: (_request, callback) => {
+          callback(
+            {
+              location: { pano: 'pano-a', latLng: { lat: () => 37.1, lng: () => -122.1 } },
+              links: [{ pano: 'pano-b' }, { pano: null }, null],
+            },
+            'OK',
+          );
+        },
+      };
+      const collect = createStreetViewLinkCollector(service);
+      const snapshot = await collect({ lat: 37.1, lng: -122.1 });
+      expect(snapshot).toEqual({
+        panoId: 'pano-a',
+        lat: 37.1,
+        lng: -122.1,
+        linkPanoIds: ['pano-b'],
+      });
+    });
+
+    it('resolves null when the service reports a non-OK status', async () => {
+      const service: StreetViewServiceLike = {
+        getPanorama: (_request, callback) => callback(null, 'ZERO_RESULTS'),
+      };
+      const collect = createStreetViewLinkCollector(service);
+      const snapshot = await collect({ lat: 0, lng: 0 });
+      expect(snapshot).toBeNull();
+    });
+
+    it('passes the configured search radius through to the service', async () => {
+      const getPanorama = vi.fn((_request, callback) => callback(null, 'ZERO_RESULTS'));
+      const collect = createStreetViewLinkCollector({ getPanorama }, { radiusMeters: 200 });
+      await collect({ lat: 1, lng: 2 });
+      expect(getPanorama).toHaveBeenCalledWith(
+        expect.objectContaining({ location: { lat: 1, lng: 2 }, radius: 200 }),
+        expect.any(Function),
+      );
+    });
   });
 });

--- a/src/offline/routePrefetch.ts
+++ b/src/offline/routePrefetch.ts
@@ -1,5 +1,5 @@
 /**
- * Phase 3 — route pre-download scaffolding.
+ * Phase 3 — route pre-download.
  * Enumerates panorama link graphs along a planned route for offline link-walking.
  * Does NOT download Google tile imagery (Maps ToS).
  */
@@ -57,25 +57,103 @@ export async function savePrefetchedRoute(
   return nodes.length;
 }
 
-/** Placeholder for future background prefetch worker integration (#134 tours). */
+/**
+ * Walk a planned route, collecting panorama link data at each waypoint and
+ * persisting the resulting graph. `collectLinksAt` is supplied by the caller
+ * (see `createStreetViewLinkCollector`) so this module has no direct
+ * `google.maps` runtime dependency and stays unit-testable with a mock.
+ * A waypoint that fails to resolve (offline, no imagery nearby) is skipped
+ * rather than aborting the whole prefetch.
+ */
 export async function prefetchRouteGraph(
   plan: RoutePrefetchPlan,
-  _collectLinksAt: (waypoint: RoutePrefetchWaypoint) => Promise<PanoLinkSnapshot | null>,
+  collectLinksAt: (waypoint: RoutePrefetchWaypoint) => Promise<PanoLinkSnapshot | null>,
   onProgress?: (progress: RoutePrefetchProgress) => void,
 ): Promise<number> {
-  const snapshots: PanoLinkSnapshot[] = [];
+  const snapshots = new Map<string, PanoLinkSnapshot>();
   const totalSteps = plan.waypoints.length;
 
   for (let i = 0; i < plan.waypoints.length; i++) {
-    const waypoint = plan.waypoints[i];
+    const waypoint = plan.waypoints[i]!;
+    let snapshot: PanoLinkSnapshot | null = null;
+    try {
+      snapshot = await collectLinksAt(waypoint);
+    } catch (err) {
+      console.warn(`[routePrefetch] Failed to collect links for waypoint ${i}`, err);
+    }
+    if (snapshot) {
+      snapshots.set(snapshot.panoId, snapshot);
+    }
     onProgress?.({
       routeId: plan.routeId,
       totalSteps,
-      completedSteps: i,
+      completedSteps: i + 1,
+      currentPanoId: snapshot?.panoId,
     });
-    // Phase 3: wire to Street View link enumeration when route UI lands.
-    void waypoint;
   }
 
-  return savePrefetchedRoute(plan.routeId, snapshots);
+  return savePrefetchedRoute(plan.routeId, Array.from(snapshots.values()));
+}
+
+/**
+ * Minimal duck-typed shape of `google.maps.StreetViewService` — kept
+ * decoupled from the real Maps typings so tests can inject a plain mock
+ * without loading the Maps JS API.
+ */
+export interface StreetViewServiceLike {
+  getPanorama(
+    request: {
+      location: { lat: number; lng: number };
+      radius?: number;
+      source?: 'default' | 'outdoor' | 'google' | null;
+    },
+    callback: (
+      data: {
+        location?: { pano?: string | null; latLng?: { lat(): number; lng(): number } | null } | null;
+        links?: Array<{ pano?: string | null } | null> | null;
+      } | null,
+      status: string,
+    ) => void,
+  ): void;
+}
+
+export interface CreateStreetViewLinkCollectorOptions {
+  /** Search radius in meters used to snap a waypoint to the nearest panorama. */
+  radiusMeters?: number;
+}
+
+const DEFAULT_SEARCH_RADIUS_METERS = 50;
+
+/**
+ * Build a `collectLinksAt` function backed by a live `StreetViewService`.
+ * Snaps each waypoint to the nearest panorama and reads its link graph —
+ * never touches tile imagery, only pano IDs / coordinates / link IDs.
+ */
+export function createStreetViewLinkCollector(
+  service: StreetViewServiceLike,
+  options: CreateStreetViewLinkCollectorOptions = {},
+): (waypoint: RoutePrefetchWaypoint) => Promise<PanoLinkSnapshot | null> {
+  const radius = options.radiusMeters ?? DEFAULT_SEARCH_RADIUS_METERS;
+
+  return (waypoint) =>
+    new Promise((resolve) => {
+      service.getPanorama(
+        { location: { lat: waypoint.lat, lng: waypoint.lng }, radius, source: 'outdoor' },
+        (data, status) => {
+          if (status !== 'OK' || !data?.location?.pano || !data.location.latLng) {
+            resolve(null);
+            return;
+          }
+          const linkPanoIds = (data.links ?? [])
+            .map((link) => link?.pano)
+            .filter((pano): pano is string => typeof pano === 'string');
+          resolve({
+            panoId: data.location.pano,
+            lat: data.location.latLng.lat(),
+            lng: data.location.latLng.lng(),
+            linkPanoIds,
+          });
+        },
+      );
+    });
 }


### PR DESCRIPTION
## Summary

Phase 3 of offline mode ("Route prefetch") was scaffolded but never wired up — `prefetchRouteGraph` looped over waypoints without ever calling the link-collection callback, so it always persisted an empty graph, and there was no UI to trigger it. This closes that gap end-to-end while keeping the Maps ToS constraint intact: **only pano IDs + link IDs + coordinates are ever stored, never tile imagery.**

- `src/offline/routePrefetch.ts` — `prefetchRouteGraph` now actually calls `collectLinksAt` per waypoint, dedupes results by `panoId`, skips (rather than aborts on) a waypoint that fails to resolve, and reports per-step `RoutePrefetchProgress` (with a final `completedSteps === totalSteps` event). Added `createStreetViewLinkCollector`, which builds that collector from a live `StreetViewService`, snapping each waypoint to its nearest panorama and reading `links`/`location` — kept behind a small duck-typed `StreetViewServiceLike` interface so the module has no runtime `google.maps` dependency and stays unit-testable.
- `src/offline/routeGraphNavigation.ts` (new) — pure helpers over a prefetched graph: `findBestOfflineLink` (pick the neighbor closest to a target heading, mirroring the live `findBestLink` heuristic) and `findPathBetweenPanos` (BFS between two panos).
- `src/offline/offlineStore.ts` — added `offlineGetAllRouteGraphNodes`, `offlineListRouteGraphs` (per-route summaries with node counts), and `offlineDeleteRouteGraph`.
- `src/hooks/useRoutePrefetch.ts` (new) — orchestrates preparing a graph (progress state, busy/error state), listing summaries, and deleting a graph.
- **UI**: the Tours panel gets a "📡 Prepare offline graph" button per tour (progress while running, node count + delete once prepared, copy clarifying imagery still needs network); the Offline storage panel gets a "Prepared route graphs" section listing/deleting graphs.
- **Runtime use of the graph**: cruise mode loads any prefetched nodes once per cruise session and uses `findBestOfflineLink` to pre-warm the likely next panorama (a hint only — the live `getLinks()` call still decides the actual hop), useful when the connection is flaky. Tour playback loads its own tour's graph and uses `findPathBetweenPanos` to pre-warm intermediate hops between recorded waypoints.
- Updated `README.md` and `docs/feature_expansion_plan.md` to mark Phase 3 done and describe the new flow.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 269/269 tests pass across 30 files, including new `routePrefetch.test.ts` coverage (waypoint→snapshot wiring, progress events, dedupe, per-waypoint failure resilience, the `StreetViewService`-shaped collector) and new `routeGraphNavigation.test.ts` (heading-based link selection, BFS pathfinding)
- [x] Confirmed `swPolicy.test.ts` still passes unchanged — Google hosts are still never cached
- [ ] Manual UI smoke test (record/prepare/play a tour with offline graph) — not run in this environment (no Maps API key / browser available); would appreciate a manual pass before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Us7HEdwjJYDouToh7pQxLf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prepare offline route graphs for saved tours, with waypoint progress tracking.
  * Browse, refresh, and delete prepared route graphs from storage management.
  * Cruise and tour playback can pre-warm upcoming panoramas when connectivity is unreliable.
  * Offline navigation uses known panorama links only and does not cache imagery or invent content.
* **Documentation**
  * Updated offline mode and downloadable route data documentation to reflect the enabled workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->