### PR TITLE
Replace manual SDP paste with room-code signaling for shared sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,42 @@ Live Street View navigation, cruise mode, and route planning still require an in
 
 ---
 
+## Shared Exploration Sessions (Road Trip)
+
+Open **Road Trip** in the toolbar to explore Street View together: a host drives, guests follow the host's pano + heading/pitch/zoom in real time.
+
+- **Host**: "Start Session (Host)" generates a 6-character room code. Share it (voice, chat, whatever) with guests.
+- **Guest**: enter the code and "Join Session (Guest)".
+- The room roster (who's in the room) updates live as people join/leave.
+- Media is **peer-to-peer WebRTC** — POV state flows directly host→guest over a data channel, never through a server.
+
+### How the room code replaces SDP copy-paste
+
+Earlier versions of this feature required manually copy-pasting base64 SDP blobs between host and guest. That's gone: a short-lived [Supabase Realtime](https://supabase.com/docs/guides/realtime) channel, named after the room code, now carries only the WebRTC *signaling* handshake (SDP offer/answer + trickle ICE candidates) between participants — see `src/services/signaling/signalingClient.ts` and `src/hooks/useSharedSession.ts`. Rooms are pure Realtime channels: nothing is persisted server-side, so a room "expires" the instant everyone leaves it — there's nothing left to clean up.
+
+**What crosses the signaling channel:** SDP + ICE metadata and each participant's `clientId`/`role` only.
+**What never crosses it (or the data channel):** Street View tile imagery — only `panoId`, lat/lng, and view angles are synced, consistent with the Maps Platform Terms constraints described above.
+
+### STUN/TURN and connection failures
+
+WebRTC needs to traverse NAT to connect two browsers directly. This app currently configures **STUN only** (`stun:stun.l.google.com:19302`, see `ICE_SERVERS` in `useSharedSession.ts`) — no TURN relay yet. STUN is enough for most home/mobile networks, but two participants both behind symmetric NATs or restrictive corporate firewalls may fail to connect a data channel even though signaling succeeds. When that happens:
+
+- The affected connection retries automatically (up to 5 attempts, ~2s apart) as long as both sides are still in the room.
+- After exhausting retries, an error banner explains a TURN server is likely needed.
+
+To add TURN, extend `ICE_SERVERS` in `src/hooks/useSharedSession.ts` with a `urls`/`username`/`credential` entry (a free/open TURN provider, or a self-hosted [coturn](https://github.com/coturn/coturn)) — no other code changes are required.
+
+### Configuring the signaling backend
+
+The Supabase project used for signaling needs its URL + anon/publishable key available at runtime, following the same pattern as the Maps API key:
+
+- Build-time: set `REACT_APP_SUPABASE_URL` / `REACT_APP_SUPABASE_ANON_KEY` (or `VITE_...`) in `.env.local` and rebuild.
+- Runtime (no rebuild): edit `window.SUPABASE_URL` / `window.SUPABASE_ANON_KEY` in `public/config.js` on the deployed server.
+
+If neither is configured, "Road Trip" surfaces a clear "signaling connection is not configured" error instead of silently failing — the rest of the app is unaffected either way.
+
+---
+
 ## Quick Start
 
 ### Requirements

--- a/docs/feature_expansion_plan.md
+++ b/docs/feature_expansion_plan.md
@@ -934,13 +934,14 @@ recognition.start();
 - Photo attachments
 - Vote system
 
-#### 14.3 Shared Exploration Sessions ⬜
-**WebRTC or WebSockets:**
-- Host creates session room
-- Guests join via code/link
-- Synchronized navigation
-- Host controls with guest following
-- Text chat overlay
+#### 14.3 Shared Exploration Sessions ✅ (text chat overlay still ⬜)
+**WebRTC signaled via Supabase Realtime:**
+- ✅ Host creates a session room — 6-character room code, no server-side persistence (rooms "expire" the moment everyone leaves)
+- ✅ Guests join via code — signaling handshake (SDP/ICE) goes through a Realtime broadcast channel keyed by the code; media stays peer-to-peer over WebRTC
+- ✅ Synchronized navigation — host broadcasts POV at 10Hz, guests apply it seq-ordered (`shouldApplyIncomingState`)
+- ✅ Host controls with guest following, live room roster via Realtime presence, multi-guest hub topology, automatic reconnect retry (capped) on a dropped peer connection
+- ⬜ Text chat overlay — not built
+- ⬜ TURN server — STUN-only for now; see README "Shared Exploration Sessions" for how to add one
 
 #### 14.4 Content Moderation ⬜
 - Report button

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "webgpu-react-app",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.111.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
@@ -3330,6 +3331,90 @@
       "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.111.0.tgz",
+      "integrity": "sha512-hbRLgyQZEX0SDyF4LYXpv94qOIQyFATfpT5SIs2V0SisHnisVRkYgiPQWzv80l4S2mO3qof78rmoH9j5zoFsYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.111.0.tgz",
+      "integrity": "sha512-RW/OCsd6MO592zU8ifzP8/f8XzxxIdpb+Up5XaOtE26Fw+3zTp475WX7+GuuktiD1WF8pFUDe6khUPbMp77RCw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.5.tgz",
+      "integrity": "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.111.0.tgz",
+      "integrity": "sha512-pcqeDsnWP0lx9GawduYxNZJHeuTm53O7L0SC8RF8tniV3GWIPY6me6OTdnwzdwNUmNy1dzUVtSyIfE6+OflzPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.111.0.tgz",
+      "integrity": "sha512-6oRf/vZyRwg8f8GbFSJkrD2w4HAu/yTvyMViHXHS+H5hNJzdXCrUR7cP5oW7daT3YlRnzRPY9LcGSJKZAmfMSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "0.4.5",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.111.0.tgz",
+      "integrity": "sha512-UEViNmTzVOxE8dqUA81wls+n9xgmlvSFfhfwo6QxrO4kQOytCYyw3ciYFoi4XoD4Jl95NJ3jnndHN5iIudWzqw==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.111.0.tgz",
+      "integrity": "sha512-9q0/AULthQnWeiDh1vGyjoJZbSY04bu6qHcWit70pqEYn5Kv/dkCPY62Ja1123jEnJbB9Vd2pjY7Kvk/lK3peA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.111.0",
+        "@supabase/functions-js": "2.111.0",
+        "@supabase/postgrest-js": "2.111.0",
+        "@supabase/realtime-js": "2.111.0",
+        "@supabase/storage-js": "2.111.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
@@ -6729,6 +6814,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -9366,6 +9460,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "homepage": ".",
   "dependencies": {
+    "@supabase/supabase-js": "^2.111.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",

--- a/public/config.js
+++ b/public/config.js
@@ -16,3 +16,14 @@
 //
 // See README "Production Deployment", docs/DEPLOY_CHECKLIST.md, and #89.
 window.MAPS_API_KEY = "";
+
+// Supabase project used ONLY as a signaling relay for Shared Exploration
+// Sessions (multiplayer road trips) — short room codes instead of pasting
+// SDP blobs. The anon/publishable key is safe to expose client-side (that's
+// what it's for), but following the same convention as MAPS_API_KEY above,
+// this stays blank in git and is supplied via REACT_APP_SUPABASE_URL /
+// REACT_APP_SUPABASE_ANON_KEY at build time, or edited here after a bundle
+// deploy. No Street View imagery ever touches this channel — see
+// src/hooks/useSharedSession.ts and README "Shared Exploration Sessions".
+window.SUPABASE_URL = "";
+window.SUPABASE_ANON_KEY = "";

--- a/src/app/shell/ConnectedChrome.tsx
+++ b/src/app/shell/ConnectedChrome.tsx
@@ -283,12 +283,11 @@ export function ConnectedChrome({
           role={sharedSession.role}
           status={sharedSession.status}
           error={sharedSession.error}
-          inviteCode={sharedSession.inviteCode}
-          joinCode={sharedSession.joinCode}
+          roomCode={sharedSession.roomCode}
+          participants={sharedSession.participants}
           isConnected={sharedSession.isConnected}
-          onStartHosting={sharedSession.startHosting}
-          onAdmitGuest={sharedSession.admitGuest}
-          onJoinWithInviteCode={sharedSession.joinWithInviteCode}
+          onCreateRoom={sharedSession.createRoom}
+          onJoinRoom={sharedSession.joinRoom}
           onLeave={sharedSession.leaveSession}
         />
       )}

--- a/src/components/SharedSessionPanel.tsx
+++ b/src/components/SharedSessionPanel.tsx
@@ -1,5 +1,9 @@
 import React, { useState } from 'react';
-import type { SharedSessionRole, SharedSessionStatus } from '../hooks/useSharedSession';
+import type {
+  SharedSessionParticipant,
+  SharedSessionRole,
+  SharedSessionStatus,
+} from '../hooks/useSharedSession';
 
 interface SharedSessionPanelProps {
     isOpen: boolean;
@@ -7,23 +11,23 @@ interface SharedSessionPanelProps {
     role: SharedSessionRole;
     status: SharedSessionStatus;
     error: string | null;
-    inviteCode: string | null;
-    joinCode: string | null;
+    roomCode: string | null;
+    participants: SharedSessionParticipant[];
     isConnected: boolean;
-    onStartHosting: () => void;
-    onAdmitGuest: (joinCode: string) => void;
-    onJoinWithInviteCode: (inviteCode: string) => void;
+    onCreateRoom: () => void;
+    onJoinRoom: (code: string) => void;
     onLeave: () => void;
 }
 
 const statusLabel: Record<SharedSessionStatus, string> = {
     idle: 'Not in a session',
-    'creating-invite': 'Creating invite…',
-    'awaiting-join-code': 'Waiting for guest join code',
-    joining: 'Joining…',
-    'awaiting-connection': 'Connecting…',
+    'creating-room': 'Creating room…',
+    'awaiting-guests': 'Waiting for guests to join',
+    'joining-room': 'Joining…',
+    connecting: 'Connecting…',
     connected: 'Connected',
     disconnected: 'Disconnected',
+    'host-left': 'Host left the session',
     error: 'Error',
 };
 
@@ -33,28 +37,27 @@ const SharedSessionPanel: React.FC<SharedSessionPanelProps> = ({
     role,
     status,
     error,
-    inviteCode,
-    joinCode,
+    roomCode,
+    participants,
     isConnected,
-    onStartHosting,
-    onAdmitGuest,
-    onJoinWithInviteCode,
+    onCreateRoom,
+    onJoinRoom,
     onLeave,
 }) => {
-    const [pastedInviteCode, setPastedInviteCode] = useState('');
-    const [pastedJoinCode, setPastedJoinCode] = useState('');
+    const [codeInput, setCodeInput] = useState('');
     const [copied, setCopied] = useState(false);
 
     if (!isOpen) return null;
 
-    const handleCopy = async (code: string) => {
+    const handleCopy = async () => {
+        if (!roomCode) return;
         try {
-            await navigator.clipboard.writeText(code);
+            await navigator.clipboard.writeText(roomCode);
             setCopied(true);
             setTimeout(() => setCopied(false), 1500);
         } catch {
             // Clipboard access can fail (permissions, insecure context); the code
-            // is still visible in the textarea for manual copy.
+            // is still visible on screen for manual copy.
         }
     };
 
@@ -77,7 +80,7 @@ const SharedSessionPanel: React.FC<SharedSessionPanelProps> = ({
                 display: 'flex',
                 flexDirection: 'column',
                 boxShadow: '0 8px 32px rgba(0,0,0,0.5)',
-                fontFamily: 'monospace',
+                fontFamily: 'system-ui, sans-serif',
             }}
         >
             <div style={{
@@ -93,6 +96,7 @@ const SharedSessionPanel: React.FC<SharedSessionPanelProps> = ({
                 </h3>
                 <button
                     onClick={onClose}
+                    aria-label="Close road trip panel"
                     style={{ background: 'none', border: 'none', color: '#aaa', fontSize: '20px', cursor: 'pointer', padding: '0 5px' }}
                 >
                     ×
@@ -110,78 +114,104 @@ const SharedSessionPanel: React.FC<SharedSessionPanelProps> = ({
 
                 {!role && (
                     <>
-                        <button className="control-btn" style={{ width: '100%' }} onClick={onStartHosting}>
+                        <button className="control-btn" style={{ width: '100%' }} onClick={onCreateRoom}>
                             Start Session (Host)
                         </button>
 
-                        <div style={{ color: '#888', fontSize: '11px' }}>Have an invite code? Paste it to join:</div>
-                        <textarea
-                            value={pastedInviteCode}
-                            onChange={(e) => setPastedInviteCode(e.target.value)}
-                            placeholder="Paste host invite code…"
-                            style={{ width: '100%', minHeight: '60px', fontSize: '10px', backgroundColor: '#111', color: '#0f0', border: '1px solid #333', borderRadius: '4px', resize: 'vertical' }}
-                        />
+                        <div style={{ color: '#888', fontSize: '11px' }}>Have a room code? Join with it:</div>
+                        <div style={{ display: 'flex', gap: '6px' }}>
+                            <input
+                                value={codeInput}
+                                onChange={(e) => setCodeInput(e.target.value.toUpperCase())}
+                                placeholder="ABCDEF"
+                                maxLength={8}
+                                aria-label="Room code"
+                                style={{
+                                    flex: 1,
+                                    fontFamily: 'monospace',
+                                    fontSize: '16px',
+                                    letterSpacing: '2px',
+                                    textAlign: 'center',
+                                    backgroundColor: '#111',
+                                    color: '#0f0',
+                                    border: '1px solid #333',
+                                    borderRadius: '4px',
+                                    padding: '8px',
+                                }}
+                            />
+                        </div>
                         <button
                             className="control-btn"
                             style={{ width: '100%' }}
-                            disabled={!pastedInviteCode.trim()}
-                            onClick={() => onJoinWithInviteCode(pastedInviteCode.trim())}
+                            disabled={!codeInput.trim()}
+                            onClick={() => onJoinRoom(codeInput.trim())}
                         >
                             Join Session (Guest)
                         </button>
                     </>
                 )}
 
-                {role === 'host' && inviteCode && (
+                {role && roomCode && (
                     <>
-                        <div style={{ color: '#888', fontSize: '11px' }}>Share this invite code with guests:</div>
-                        <textarea
-                            readOnly
-                            value={inviteCode}
-                            style={{ width: '100%', minHeight: '60px', fontSize: '10px', backgroundColor: '#111', color: '#0f0', border: '1px solid #333', borderRadius: '4px', resize: 'vertical' }}
-                            onFocus={(e) => e.currentTarget.select()}
-                        />
-                        <button className="control-btn" style={{ width: '100%' }} onClick={() => handleCopy(inviteCode)}>
-                            {copied ? 'Copied!' : 'Copy Invite Code'}
-                        </button>
+                        <div style={{ color: '#888', fontSize: '11px' }}>
+                            {role === 'host' ? 'Share this room code with guests:' : 'Room code:'}
+                        </div>
+                        <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+                            <div
+                                style={{
+                                    flex: 1,
+                                    fontFamily: 'monospace',
+                                    fontSize: '20px',
+                                    letterSpacing: '4px',
+                                    textAlign: 'center',
+                                    backgroundColor: '#111',
+                                    color: '#0f0',
+                                    border: '1px solid #333',
+                                    borderRadius: '4px',
+                                    padding: '10px',
+                                }}
+                            >
+                                {roomCode}
+                            </div>
+                            <button className="control-btn" onClick={() => void handleCopy()}>
+                                {copied ? '✓' : 'Copy'}
+                            </button>
+                        </div>
 
-                        {!isConnected && (
-                            <>
-                                <div style={{ color: '#888', fontSize: '11px' }}>Paste the guest's join code here:</div>
-                                <textarea
-                                    value={pastedJoinCode}
-                                    onChange={(e) => setPastedJoinCode(e.target.value)}
-                                    placeholder="Paste guest join code…"
-                                    style={{ width: '100%', minHeight: '60px', fontSize: '10px', backgroundColor: '#111', color: '#0f0', border: '1px solid #333', borderRadius: '4px', resize: 'vertical' }}
-                                />
-                                <button
-                                    className="control-btn"
-                                    style={{ width: '100%' }}
-                                    disabled={!pastedJoinCode.trim()}
-                                    onClick={() => onAdmitGuest(pastedJoinCode.trim())}
-                                >
-                                    Connect Guest
-                                </button>
-                            </>
+                        {participants.length > 0 && (
+                            <div>
+                                <div style={{ color: '#888', fontSize: '11px', marginBottom: '4px' }}>
+                                    In this room ({participants.length}):
+                                </div>
+                                <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                                    {participants.map((p) => (
+                                        <li
+                                            key={p.clientId}
+                                            style={{
+                                                fontSize: '12px',
+                                                color: '#ddd',
+                                                display: 'flex',
+                                                alignItems: 'center',
+                                                gap: '6px',
+                                            }}
+                                        >
+                                            <span>{p.role === 'host' ? '🧭' : '🚙'}</span>
+                                            <span>{p.role === 'host' ? 'Host' : 'Guest'}{p.isSelf ? ' (you)' : ''}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
                         )}
-                    </>
-                )}
 
-                {role === 'guest' && joinCode && (
-                    <>
-                        <div style={{ color: '#888', fontSize: '11px' }}>Send this join code back to the host:</div>
-                        <textarea
-                            readOnly
-                            value={joinCode}
-                            style={{ width: '100%', minHeight: '60px', fontSize: '10px', backgroundColor: '#111', color: '#0f0', border: '1px solid #333', borderRadius: '4px', resize: 'vertical' }}
-                            onFocus={(e) => e.currentTarget.select()}
-                        />
-                        <button className="control-btn" style={{ width: '100%' }} onClick={() => handleCopy(joinCode)}>
-                            {copied ? 'Copied!' : 'Copy Join Code'}
-                        </button>
-                        {isConnected && (
+                        {role === 'guest' && isConnected && (
                             <div style={{ color: '#4FC3F7', fontSize: '11px' }}>
                                 Following the host's view. Local navigation is disabled while connected.
+                            </div>
+                        )}
+
+                        {status === 'host-left' && (
+                            <div style={{ color: '#ff6b6b', fontSize: '11px' }}>
+                                The host left this room. Leave and rejoin with a new code to continue.
                             </div>
                         )}
                     </>
@@ -196,6 +226,12 @@ const SharedSessionPanel: React.FC<SharedSessionPanelProps> = ({
                         Leave Session
                     </button>
                 )}
+
+                <p style={{ margin: 0, fontSize: '10px', color: '#666', lineHeight: 1.4 }}>
+                    Peer-to-peer over WebRTC (STUN only, no TURN server yet) — works on most networks, but very
+                    restrictive corporate/mobile networks on both ends may fail to connect. Only pano IDs and
+                    view angles are shared, never Street View imagery.
+                </p>
             </div>
         </div>
     );

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -68,12 +68,11 @@ export {
 // Shared Exploration Sessions (multiplayer road trips)
 export {
   useSharedSession,
-  encodeSignal,
-  decodeSignal,
   shouldApplyIncomingState,
   type SessionState,
   type SharedSessionRole,
   type SharedSessionStatus,
+  type SharedSessionParticipant,
   type UseSharedSessionResult,
 } from './useSharedSession';
 

--- a/src/hooks/sharedSessionRoster.test.ts
+++ b/src/hooks/sharedSessionRoster.test.ts
@@ -1,0 +1,55 @@
+import { toSharedSessionParticipants, shouldRetryPeerConnection } from './sharedSessionRoster';
+import type { PresenceEntry } from '../services/signaling/signalingClient';
+
+describe('toSharedSessionParticipants', () => {
+  it('marks the matching clientId as isSelf', () => {
+    const entries: PresenceEntry[] = [
+      { clientId: 'host-1', role: 'host' },
+      { clientId: 'guest-1', role: 'guest' },
+    ];
+    const result = toSharedSessionParticipants(entries, 'guest-1');
+    expect(result.find((p) => p.clientId === 'guest-1')?.isSelf).toBe(true);
+    expect(result.find((p) => p.clientId === 'host-1')?.isSelf).toBe(false);
+  });
+
+  it('sorts the host first, then guests by clientId', () => {
+    const entries: PresenceEntry[] = [
+      { clientId: 'guest-2', role: 'guest' },
+      { clientId: 'guest-1', role: 'guest' },
+      { clientId: 'host-1', role: 'host' },
+    ];
+    const result = toSharedSessionParticipants(entries, 'host-1');
+    expect(result.map((p) => p.clientId)).toEqual(['host-1', 'guest-1', 'guest-2']);
+  });
+
+  it('returns an empty list for an empty roster', () => {
+    expect(toSharedSessionParticipants([], 'self')).toEqual([]);
+  });
+});
+
+describe('shouldRetryPeerConnection', () => {
+  it('retries a failed connection while the peer is still present', () => {
+    expect(shouldRetryPeerConnection('failed', true, 0)).toBe(true);
+    expect(shouldRetryPeerConnection('disconnected', true, 0)).toBe(true);
+  });
+
+  it('does not retry once the peer has left', () => {
+    expect(shouldRetryPeerConnection('failed', false, 0)).toBe(false);
+  });
+
+  it('does not retry a healthy connection state', () => {
+    expect(shouldRetryPeerConnection('connected', true, 0)).toBe(false);
+    expect(shouldRetryPeerConnection('connecting', true, 0)).toBe(false);
+    expect(shouldRetryPeerConnection('new', true, 0)).toBe(false);
+  });
+
+  it('stops retrying once the attempt budget is exhausted', () => {
+    expect(shouldRetryPeerConnection('failed', true, 5)).toBe(false);
+    expect(shouldRetryPeerConnection('failed', true, 4)).toBe(true);
+  });
+
+  it('respects a custom max-attempts budget', () => {
+    expect(shouldRetryPeerConnection('failed', true, 2, 2)).toBe(false);
+    expect(shouldRetryPeerConnection('failed', true, 1, 2)).toBe(true);
+  });
+});

--- a/src/hooks/sharedSessionRoster.ts
+++ b/src/hooks/sharedSessionRoster.ts
@@ -1,0 +1,35 @@
+import type { PresenceEntry } from '../services/signaling/signalingClient';
+
+export interface SharedSessionParticipant extends PresenceEntry {
+  isSelf: boolean;
+}
+
+/** Presence roster -> UI-ready participant list, host first then by clientId. */
+export function toSharedSessionParticipants(
+  entries: PresenceEntry[],
+  selfClientId: string,
+): SharedSessionParticipant[] {
+  return entries
+    .map((entry) => ({ ...entry, isSelf: entry.clientId === selfClientId }))
+    .sort((a, b) => {
+      if (a.role !== b.role) return a.role === 'host' ? -1 : 1;
+      return a.clientId.localeCompare(b.clientId);
+    });
+}
+
+/**
+ * Whether a dropped WebRTC peer connection should be automatically
+ * re-negotiated. Only retry while the peer is still present in the room's
+ * presence roster (they haven't explicitly left) and we haven't exceeded the
+ * retry budget — a permanently-unreachable peer (e.g. symmetric NAT with no
+ * TURN server) would otherwise retry forever.
+ */
+export function shouldRetryPeerConnection(
+  connectionState: RTCPeerConnectionState,
+  peerStillPresent: boolean,
+  attemptsSoFar: number,
+  maxAttempts = 5,
+): boolean {
+  if (attemptsSoFar >= maxAttempts) return false;
+  return (connectionState === 'failed' || connectionState === 'disconnected') && peerStillPresent;
+}

--- a/src/hooks/useSharedSession.test.ts
+++ b/src/hooks/useSharedSession.test.ts
@@ -1,28 +1,4 @@
-import { decodeSignal, encodeSignal, shouldApplyIncomingState, SessionState } from './useSharedSession';
-
-describe('encodeSignal / decodeSignal', () => {
-  it('round-trips an SDP description through a copy-pasteable code', () => {
-    const description: RTCSessionDescriptionInit = { type: 'offer', sdp: 'v=0\r\no=- 123 456 IN IP4 0.0.0.0\r\n' };
-    const code = encodeSignal(description);
-    expect(typeof code).toBe('string');
-    expect(decodeSignal(code)).toEqual(description);
-  });
-
-  it('tolerates surrounding whitespace from copy/paste', () => {
-    const description: RTCSessionDescriptionInit = { type: 'answer', sdp: 'v=0\r\n' };
-    const code = `  ${encodeSignal(description)}\n`;
-    expect(decodeSignal(code)).toEqual(description);
-  });
-
-  it('rejects a code that is not a valid session description', () => {
-    const bogus = btoa(JSON.stringify({ foo: 'bar' }));
-    expect(() => decodeSignal(bogus)).toThrow('Invalid session code');
-  });
-
-  it('rejects a code that is not valid base64/JSON', () => {
-    expect(() => decodeSignal('not-a-real-code')).toThrow();
-  });
-});
+import { shouldApplyIncomingState, type SessionState } from './useSharedSession';
 
 describe('shouldApplyIncomingState', () => {
   const base: SessionState = {

--- a/src/hooks/useSharedSession.ts
+++ b/src/hooks/useSharedSession.ts
@@ -1,14 +1,39 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  createRoomSignalingClient,
+  generateClientId,
+  generateRoomCode,
+  isValidRoomCode,
+  normalizeRoomCode,
+  type PresenceEntry,
+  type RoomSignalingClient,
+  type SignalingMessage,
+} from '../services/signaling/signalingClient';
+import { getSignalingRealtimeClient } from '../services/signaling/supabaseRealtimeClient';
+import {
+  shouldRetryPeerConnection,
+  toSharedSessionParticipants,
+  type SharedSessionParticipant,
+} from './sharedSessionRoster';
 
 /**
  * Shared Exploration Sessions — multiplayer Street View road trips.
  *
  * A host drives (cruise/autopilot/keyboard); guests follow with a synchronized
- * POV. Peer-to-peer over WebRTC, signaled by hand (no server): the host
- * generates an "invite code" (its SDP offer, base64-encoded) to share out of
- * band (chat, link, etc), the guest pastes it to generate a "join code"
- * (its SDP answer) to send back. Once the host applies the join code the
- * data channel opens and state starts flowing.
+ * POV. Media is peer-to-peer over WebRTC data channels (one per guest, hub
+ * topology) — only *signaling* (SDP offer/answer + trickle ICE candidates)
+ * goes through a short-lived Supabase Realtime room keyed by a 6-character
+ * room code, replacing the old copy-paste-an-SDP-blob flow. No imagery and
+ * no POV state ever touches the signaling channel — only handshake metadata.
+ *
+ * Rooms are pure Realtime channels: nothing is persisted server-side, so a
+ * room "expires" the moment everyone leaves it — there is nothing left to
+ * clean up.
+ *
+ * TURN is intentionally not configured (STUN-only) — most NATs traverse
+ * fine, but symmetric NATs / restrictive firewalls on both ends can fail to
+ * connect. See README "Shared Exploration Sessions" for how to add a TURN
+ * server later (just extend ICE_SERVERS below; no other changes needed).
  *
  * See docs/feature_expansion_plan.md §14.3.
  */
@@ -26,35 +51,30 @@ export type SharedSessionRole = 'host' | 'guest' | null;
 
 export type SharedSessionStatus =
   | 'idle'
-  | 'creating-invite'
-  | 'awaiting-join-code'
-  | 'joining'
-  | 'awaiting-connection'
+  | 'creating-room'
+  | 'awaiting-guests'
+  | 'joining-room'
+  | 'connecting'
   | 'connected'
   | 'disconnected'
+  | 'host-left'
   | 'error';
 
+export type { SharedSessionParticipant };
+
 const DATA_CHANNEL_LABEL = 'streetview-sync';
+/** STUN-only for now — see the module doc comment above and README for TURN. */
 const ICE_SERVERS: RTCIceServer[] = [{ urls: 'stun:stun.l.google.com:19302' }];
-
-/** Serialize an SDP offer/answer into a copy-pasteable invite/join code. */
-export function encodeSignal(description: RTCSessionDescriptionInit): string {
-  return btoa(JSON.stringify(description));
-}
-
-/** Parse a code produced by {@link encodeSignal} back into an SDP description. */
-export function decodeSignal(code: string): RTCSessionDescriptionInit {
-  const parsed = JSON.parse(atob(code.trim()));
-  if (!parsed || typeof parsed.type !== 'string' || typeof parsed.sdp !== 'string') {
-    throw new Error('Invalid session code');
-  }
-  return parsed as RTCSessionDescriptionInit;
-}
+const RECONNECT_DELAY_MS = 2000;
+const MAX_RECONNECT_ATTEMPTS = 5;
 
 /**
  * Guests apply state in sequence order only, so a message that arrives late
  * (out-of-order data channel delivery, retried send) never rolls the view
- * backwards.
+ * backwards. `seq` is never reset except by starting a brand-new hosted
+ * room, so a guest reconnecting mid-session simply resumes from whatever
+ * seq the host is currently on — no special-casing needed to avoid
+ * corruption on disconnect/reconnect.
  */
 export function shouldApplyIncomingState(
   current: SessionState | null,
@@ -64,36 +84,29 @@ export function shouldApplyIncomingState(
   return incoming.seq > current.seq;
 }
 
-function waitForIceGatheringComplete(pc: RTCPeerConnection): Promise<void> {
-  if (pc.iceGatheringState === 'complete') return Promise.resolve();
-  return new Promise((resolve) => {
-    const check = () => {
-      if (pc.iceGatheringState === 'complete') {
-        pc.removeEventListener('icegatheringstatechange', check);
-        resolve();
-      }
-    };
-    pc.addEventListener('icegatheringstatechange', check);
-  });
+interface PeerConnectionEntry {
+  pc: RTCPeerConnection;
+  dc: RTCDataChannel | null;
+  remoteDescriptionSet: boolean;
+  pendingCandidates: RTCIceCandidateInit[];
 }
 
 export interface UseSharedSessionResult {
   role: SharedSessionRole;
   status: SharedSessionStatus;
   error: string | null;
-  /** Host-generated code to share with guests (SDP offer). */
-  inviteCode: string | null;
-  /** Guest-generated code to send back to the host (SDP answer). */
-  joinCode: string | null;
+  /** Short room code guests use to join (set by the host on create, or the guest on join). */
+  roomCode: string | null;
+  /** Live roster of everyone in the room (self included), from Realtime presence. */
+  participants: SharedSessionParticipant[];
   /** Latest state received by a guest from the host. */
   latestState: SessionState | null;
+  /** Host: true once at least one guest's data channel is open. Guest: true once connected to the host. */
   isConnected: boolean;
-  /** Host: start a new session and generate an invite code. */
-  startHosting: () => Promise<void>;
-  /** Host: apply a join code pasted from a guest to complete the handshake. */
-  admitGuest: (joinCode: string) => Promise<void>;
-  /** Guest: consume a host invite code and generate a join code to send back. */
-  joinWithInviteCode: (inviteCode: string) => Promise<void>;
+  /** Host: create a new room and generate a room code for guests to join. */
+  createRoom: () => Promise<void>;
+  /** Guest: join a room by its code. */
+  joinRoom: (code: string) => Promise<void>;
   /** Host: broadcast the current view to all connected guests. */
   broadcastState: (state: Omit<SessionState, 'seq'>) => void;
   leaveSession: () => void;
@@ -103,128 +116,313 @@ export function useSharedSession(): UseSharedSessionResult {
   const [role, setRole] = useState<SharedSessionRole>(null);
   const [status, setStatus] = useState<SharedSessionStatus>('idle');
   const [error, setError] = useState<string | null>(null);
-  const [inviteCode, setInviteCode] = useState<string | null>(null);
-  const [joinCode, setJoinCode] = useState<string | null>(null);
+  const [roomCode, setRoomCode] = useState<string | null>(null);
+  const [participants, setParticipants] = useState<SharedSessionParticipant[]>([]);
   const [latestState, setLatestState] = useState<SessionState | null>(null);
   const [isConnected, setIsConnected] = useState(false);
 
-  const pcRef = useRef<RTCPeerConnection | null>(null);
-  const dcRef = useRef<RTCDataChannel | null>(null);
+  const clientIdRef = useRef<string | null>(null);
+  if (clientIdRef.current === null) clientIdRef.current = generateClientId();
+
+  const signalingRef = useRef<RoomSignalingClient | null>(null);
+  /** Host: guestClientId -> connection. Guest: hostClientId -> connection (single entry). */
+  const peersRef = useRef<Map<string, PeerConnectionEntry>>(new Map());
+  const hostClientIdRef = useRef<string | null>(null);
   const seqRef = useRef(0);
+  const reconnectTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const reconnectAttemptsRef = useRef<Map<string, number>>(new Map());
+  const roleRef = useRef<SharedSessionRole>(null);
+  roleRef.current = role;
+
+  const clearReconnectTimer = useCallback((peerId: string) => {
+    const timer = reconnectTimersRef.current.get(peerId);
+    if (timer) {
+      clearTimeout(timer);
+      reconnectTimersRef.current.delete(peerId);
+    }
+  }, []);
+
+  const closePeer = useCallback((peerId: string) => {
+    clearReconnectTimer(peerId);
+    const entry = peersRef.current.get(peerId);
+    if (!entry) return;
+    entry.dc?.close();
+    entry.pc.close();
+    peersRef.current.delete(peerId);
+  }, [clearReconnectTimer]);
 
   const teardown = useCallback(() => {
-    dcRef.current?.close();
-    dcRef.current = null;
-    pcRef.current?.close();
-    pcRef.current = null;
-  }, []);
+    for (const timer of reconnectTimersRef.current.values()) clearTimeout(timer);
+    reconnectTimersRef.current.clear();
+    reconnectAttemptsRef.current.clear();
+    for (const peerId of Array.from(peersRef.current.keys())) closePeer(peerId);
+    peersRef.current.clear();
+    hostClientIdRef.current = null;
+    void signalingRef.current?.leave();
+    signalingRef.current = null;
+  }, [closePeer]);
 
-  const attachDataChannel = useCallback((dc: RTCDataChannel) => {
-    dcRef.current = dc;
-    dc.onopen = () => {
-      setIsConnected(true);
-      setStatus('connected');
-    };
-    dc.onclose = () => {
-      setIsConnected(false);
-      setStatus('disconnected');
-    };
-    dc.onmessage = (event) => {
-      try {
-        const incoming = JSON.parse(event.data) as SessionState;
-        setLatestState((current) => (shouldApplyIncomingState(current, incoming) ? incoming : current));
-      } catch {
-        // Ignore malformed messages rather than crashing the session.
+  /** Recompute isConnected/status from live peer data-channel state. */
+  const syncConnectionStatus = useCallback(() => {
+    let anyOpen = false;
+    for (const entry of peersRef.current.values()) {
+      if (entry.dc?.readyState === 'open') {
+        anyOpen = true;
+        break;
       }
-    };
+    }
+    setIsConnected(anyOpen);
+    setStatus((prev) => {
+      if (anyOpen) return 'connected';
+      if (prev === 'connected') return 'disconnected';
+      return prev;
+    });
   }, []);
 
-  const startHosting = useCallback(async () => {
-    teardown();
-    setError(null);
-    setLatestState(null);
-    seqRef.current = 0;
-    setRole('host');
-    setStatus('creating-invite');
+  const flushPendingCandidates = useCallback(async (entry: PeerConnectionEntry) => {
+    entry.remoteDescriptionSet = true;
+    const pending = entry.pendingCandidates.splice(0);
+    for (const candidate of pending) {
+      try {
+        await entry.pc.addIceCandidate(candidate);
+      } catch (e) {
+        console.warn('[SharedSession] Failed to add queued ICE candidate', e);
+      }
+    }
+  }, []);
 
-    try {
+  /** Host: open a fresh RTCPeerConnection + data channel for one guest and send it an offer. */
+  const connectToGuest = useCallback(
+    async (guestClientId: string) => {
+      clearReconnectTimer(guestClientId);
       const pc = new RTCPeerConnection({ iceServers: ICE_SERVERS });
-      pcRef.current = pc;
+      const entry: PeerConnectionEntry = { pc, dc: null, remoteDescriptionSet: false, pendingCandidates: [] };
+      peersRef.current.set(guestClientId, entry);
+
+      pc.onicecandidate = (e) => {
+        if (e.candidate) {
+          signalingRef.current?.send({ type: 'ice-candidate', to: guestClientId, payload: e.candidate.toJSON() });
+        }
+      };
       pc.onconnectionstatechange = () => {
-        if (pc.connectionState === 'disconnected' || pc.connectionState === 'failed' || pc.connectionState === 'closed') {
-          setIsConnected(false);
-          setStatus('disconnected');
+        syncConnectionStatus();
+        const attempts = reconnectAttemptsRef.current.get(guestClientId) ?? 0;
+        const stillPresent = peersRef.current.has(guestClientId);
+        if (shouldRetryPeerConnection(pc.connectionState, stillPresent, attempts, MAX_RECONNECT_ATTEMPTS)) {
+          closePeer(guestClientId);
+          reconnectAttemptsRef.current.set(guestClientId, attempts + 1);
+          const timer = setTimeout(() => {
+            if (roleRef.current === 'host') void connectToGuest(guestClientId);
+          }, RECONNECT_DELAY_MS);
+          reconnectTimersRef.current.set(guestClientId, timer);
+        } else if (pc.connectionState === 'failed' && attempts >= MAX_RECONNECT_ATTEMPTS) {
+          setError(
+            'Could not keep a peer-to-peer connection with one guest — this usually means a strict NAT/firewall ' +
+              'without a TURN server. See README "Shared Exploration Sessions" for TURN setup.',
+          );
         }
       };
 
       const dc = pc.createDataChannel(DATA_CHANNEL_LABEL);
-      attachDataChannel(dc);
+      entry.dc = dc;
+      dc.onopen = () => {
+        reconnectAttemptsRef.current.delete(guestClientId);
+        syncConnectionStatus();
+      };
+      dc.onclose = () => syncConnectionStatus();
 
-      const offer = await pc.createOffer();
-      await pc.setLocalDescription(offer);
-      await waitForIceGatheringComplete(pc);
+      try {
+        const offer = await pc.createOffer();
+        await pc.setLocalDescription(offer);
+        signalingRef.current?.send({ type: 'offer', to: guestClientId, payload: offer });
+      } catch (e) {
+        console.warn('[SharedSession] Failed to create offer for guest', guestClientId, e);
+        closePeer(guestClientId);
+      }
+    },
+    [clearReconnectTimer, closePeer, syncConnectionStatus],
+  );
 
-      setInviteCode(encodeSignal(pc.localDescription!));
-      setStatus('awaiting-join-code');
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to start session');
-      setStatus('error');
-    }
-  }, [attachDataChannel, teardown]);
+  /** Guest: respond to the host's offer with a fresh RTCPeerConnection + answer. */
+  const connectToHost = useCallback(
+    async (hostId: string, offer: RTCSessionDescriptionInit) => {
+      closePeer(hostId); // tear down any previous attempt before renegotiating
+      const pc = new RTCPeerConnection({ iceServers: ICE_SERVERS });
+      const entry: PeerConnectionEntry = { pc, dc: null, remoteDescriptionSet: false, pendingCandidates: [] };
+      peersRef.current.set(hostId, entry);
+      hostClientIdRef.current = hostId;
 
-  const admitGuest = useCallback(async (guestJoinCode: string) => {
-    const pc = pcRef.current;
-    if (!pc) {
-      setError('No active session to admit a guest into');
-      return;
-    }
-    try {
-      const answer = decodeSignal(guestJoinCode);
-      await pc.setRemoteDescription(answer);
-      setStatus('awaiting-connection');
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Invalid join code');
-      setStatus('error');
-    }
-  }, []);
+      pc.onicecandidate = (e) => {
+        if (e.candidate) {
+          signalingRef.current?.send({ type: 'ice-candidate', to: hostId, payload: e.candidate.toJSON() });
+        }
+      };
+      pc.onconnectionstatechange = () => {
+        syncConnectionStatus();
+        if (pc.connectionState === 'failed' || pc.connectionState === 'disconnected') {
+          setStatus((prev) => (prev === 'host-left' ? prev : 'disconnected'));
+        }
+      };
+      pc.ondatachannel = (e) => {
+        entry.dc = e.channel;
+        e.channel.onopen = () => syncConnectionStatus();
+        e.channel.onclose = () => syncConnectionStatus();
+        e.channel.onmessage = (event) => {
+          try {
+            const incoming = JSON.parse(event.data) as SessionState;
+            setLatestState((current) => (shouldApplyIncomingState(current, incoming) ? incoming : current));
+          } catch {
+            // Ignore malformed messages rather than crashing the session.
+          }
+        };
+      };
 
-  const joinWithInviteCode = useCallback(async (hostInviteCode: string) => {
+      try {
+        await pc.setRemoteDescription(offer);
+        await flushPendingCandidates(entry);
+        const answer = await pc.createAnswer();
+        await pc.setLocalDescription(answer);
+        signalingRef.current?.send({ type: 'answer', to: hostId, payload: answer });
+        setStatus('connecting');
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to answer host offer');
+        setStatus('error');
+      }
+    },
+    [closePeer, flushPendingCandidates, syncConnectionStatus],
+  );
+
+  const handleSignalingMessage = useCallback(
+    (message: SignalingMessage) => {
+      const entry = peersRef.current.get(message.from);
+
+      if (message.type === 'offer') {
+        // Only guests receive offers, always from the host.
+        void connectToHost(message.from, message.payload as RTCSessionDescriptionInit);
+        return;
+      }
+
+      if (message.type === 'answer') {
+        if (!entry) return;
+        entry.pc
+          .setRemoteDescription(message.payload as RTCSessionDescriptionInit)
+          .then(() => flushPendingCandidates(entry))
+          .catch((e) => console.warn('[SharedSession] Failed to apply guest answer', e));
+        return;
+      }
+
+      if (message.type === 'ice-candidate') {
+        if (!entry) return;
+        const candidate = message.payload as RTCIceCandidateInit;
+        if (entry.remoteDescriptionSet) {
+          entry.pc.addIceCandidate(candidate).catch((e) => console.warn('[SharedSession] Failed to add ICE candidate', e));
+        } else {
+          entry.pendingCandidates.push(candidate);
+        }
+      }
+    },
+    [connectToHost, flushPendingCandidates],
+  );
+
+  const createRoom = useCallback(async () => {
     teardown();
     setError(null);
     setLatestState(null);
-    setRole('guest');
-    setStatus('joining');
+    setParticipants([]);
+    seqRef.current = 0;
+    setRole('host');
+    setStatus('creating-room');
+
+    const realtime = getSignalingRealtimeClient();
+    if (!realtime) {
+      setError('Shared sessions need a signaling connection that is not configured in this deployment.');
+      setStatus('error');
+      setRole(null);
+      return;
+    }
 
     try {
-      const offer = decodeSignal(hostInviteCode);
-      const pc = new RTCPeerConnection({ iceServers: ICE_SERVERS });
-      pcRef.current = pc;
-      pc.onconnectionstatechange = () => {
-        if (pc.connectionState === 'disconnected' || pc.connectionState === 'failed' || pc.connectionState === 'closed') {
-          setIsConnected(false);
-          setStatus('disconnected');
+      const code = generateRoomCode();
+      const self: PresenceEntry = { clientId: clientIdRef.current!, role: 'host' };
+      const signaling = createRoomSignalingClient(realtime, code, self);
+      signalingRef.current = signaling;
+
+      signaling.onMessage(handleSignalingMessage);
+      signaling.onPresenceSync((entries) => setParticipants(toSharedSessionParticipants(entries, self.clientId)));
+      signaling.onPresenceJoin((entries) => {
+        for (const entry of entries) {
+          if (entry.role === 'guest' && entry.clientId !== self.clientId) void connectToGuest(entry.clientId);
         }
-      };
-      pc.ondatachannel = (event) => attachDataChannel(event.channel);
+      });
+      signaling.onPresenceLeave((entries) => {
+        for (const entry of entries) closePeer(entry.clientId);
+      });
 
-      await pc.setRemoteDescription(offer);
-      const answer = await pc.createAnswer();
-      await pc.setLocalDescription(answer);
-      await waitForIceGatheringComplete(pc);
-
-      setJoinCode(encodeSignal(pc.localDescription!));
-      setStatus('awaiting-connection');
+      setRoomCode(code);
+      setStatus('awaiting-guests');
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Invalid invite code');
+      setError(e instanceof Error ? e.message : 'Failed to create session room');
       setStatus('error');
     }
-  }, [attachDataChannel, teardown]);
+  }, [teardown, handleSignalingMessage, connectToGuest, closePeer]);
+
+  const joinRoom = useCallback(
+    async (codeInput: string) => {
+      if (!isValidRoomCode(codeInput)) {
+        setError("That room code doesn't look right — codes are 6 characters.");
+        setStatus('error');
+        return;
+      }
+
+      teardown();
+      setError(null);
+      setLatestState(null);
+      setParticipants([]);
+      setRole('guest');
+      setStatus('joining-room');
+
+      const realtime = getSignalingRealtimeClient();
+      if (!realtime) {
+        setError('Shared sessions need a signaling connection that is not configured in this deployment.');
+        setStatus('error');
+        setRole(null);
+        return;
+      }
+
+      try {
+        const code = normalizeRoomCode(codeInput);
+        const self: PresenceEntry = { clientId: clientIdRef.current!, role: 'guest' };
+        const signaling = createRoomSignalingClient(realtime, code, self);
+        signalingRef.current = signaling;
+
+        signaling.onMessage(handleSignalingMessage);
+        signaling.onPresenceSync((entries) => setParticipants(toSharedSessionParticipants(entries, self.clientId)));
+        signaling.onPresenceLeave((entries) => {
+          for (const entry of entries) {
+            if (entry.clientId === hostClientIdRef.current) {
+              closePeer(entry.clientId);
+              setStatus('host-left');
+              setIsConnected(false);
+            }
+          }
+        });
+
+        setRoomCode(code);
+        setStatus('connecting');
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to join session room');
+        setStatus('error');
+      }
+    },
+    [teardown, handleSignalingMessage, closePeer],
+  );
 
   const broadcastState = useCallback((state: Omit<SessionState, 'seq'>) => {
-    const dc = dcRef.current;
-    if (!dc || dc.readyState !== 'open') return;
     seqRef.current += 1;
-    dc.send(JSON.stringify({ ...state, seq: seqRef.current }));
+    const message = JSON.stringify({ ...state, seq: seqRef.current });
+    for (const entry of peersRef.current.values()) {
+      if (entry.dc?.readyState === 'open') entry.dc.send(message);
+    }
   }, []);
 
   const leaveSession = useCallback(() => {
@@ -232,8 +430,8 @@ export function useSharedSession(): UseSharedSessionResult {
     setRole(null);
     setStatus('idle');
     setError(null);
-    setInviteCode(null);
-    setJoinCode(null);
+    setRoomCode(null);
+    setParticipants([]);
     setLatestState(null);
     setIsConnected(false);
   }, [teardown]);
@@ -244,13 +442,12 @@ export function useSharedSession(): UseSharedSessionResult {
     role,
     status,
     error,
-    inviteCode,
-    joinCode,
+    roomCode,
+    participants,
     latestState,
     isConnected,
-    startHosting,
-    admitGuest,
-    joinWithInviteCode,
+    createRoom,
+    joinRoom,
     broadcastState,
     leaveSession,
   };

--- a/src/services/signaling/signalingClient.test.ts
+++ b/src/services/signaling/signalingClient.test.ts
@@ -1,0 +1,301 @@
+import {
+  createRoomSignalingClient,
+  generateClientId,
+  generateRoomCode,
+  isValidRoomCode,
+  roomChannelName,
+  type PresenceEntry,
+  type RealtimeChannelLike,
+  type SignalingMessage,
+  type SupabaseRealtimeClientLike,
+} from './signalingClient';
+
+/**
+ * In-memory fake standing in for a Supabase Realtime client/channel pair —
+ * this is our "mock WS": no real socket, but the same broadcast + presence
+ * semantics `createRoomSignalingClient` depends on (self:false broadcast,
+ * presence sync/join/leave scoped per channel name).
+ */
+class FakeRoom {
+  private channels = new Set<FakeChannel>();
+  private presence = new Map<FakeChannel, Record<string, unknown>>();
+
+  register(channel: FakeChannel) {
+    this.channels.add(channel);
+  }
+
+  unregister(channel: FakeChannel) {
+    this.channels.delete(channel);
+    this.presence.delete(channel);
+  }
+
+  broadcast(sender: FakeChannel, event: string, payload: unknown) {
+    for (const channel of this.channels) {
+      if (channel === sender) continue; // broadcast: { self: false }
+      channel.deliverBroadcast(event, payload);
+    }
+  }
+
+  track(channel: FakeChannel, state: Record<string, unknown>) {
+    this.presence.set(channel, state);
+    for (const c of this.channels) c.deliverPresenceSync();
+    for (const c of this.channels) c.deliverPresenceJoin([state]);
+  }
+
+  untrack(channel: FakeChannel) {
+    const state = this.presence.get(channel);
+    this.presence.delete(channel);
+    for (const c of this.channels) c.deliverPresenceSync();
+    if (state) for (const c of this.channels) c.deliverPresenceLeave([state]);
+  }
+
+  presenceState(): Record<string, Array<Record<string, unknown>>> {
+    const result: Record<string, Array<Record<string, unknown>>> = {};
+    for (const state of this.presence.values()) {
+      const key = String(state.clientId ?? 'unknown');
+      result[key] = [state];
+    }
+    return result;
+  }
+}
+
+class FakeChannel implements RealtimeChannelLike {
+  private broadcastHandlers = new Map<string, Array<(message: { payload: unknown }) => void>>();
+  private syncHandlers: Array<() => void> = [];
+  private joinHandlers: Array<(p: { key: string; newPresences?: unknown[] }) => void> = [];
+  private leaveHandlers: Array<(p: { key: string; leftPresences?: unknown[] }) => void> = [];
+
+  constructor(private room: FakeRoom) {}
+
+  on(type: 'broadcast' | 'presence', filter: { event: string }, callback: (...args: any[]) => void): this {
+    if (type === 'broadcast') {
+      const arr = this.broadcastHandlers.get(filter.event) ?? [];
+      arr.push(callback);
+      this.broadcastHandlers.set(filter.event, arr);
+    } else if (filter.event === 'sync') {
+      this.syncHandlers.push(callback);
+    } else if (filter.event === 'join') {
+      this.joinHandlers.push(callback);
+    } else if (filter.event === 'leave') {
+      this.leaveHandlers.push(callback);
+    }
+    return this;
+  }
+
+  subscribe(callback?: (status: string) => void): this {
+    this.room.register(this);
+    callback?.('SUBSCRIBED');
+    return this;
+  }
+
+  send(message: { type: 'broadcast'; event: string; payload: unknown }): Promise<unknown> {
+    this.room.broadcast(this, message.event, message.payload);
+    return Promise.resolve();
+  }
+
+  track(state: Record<string, unknown>): Promise<unknown> {
+    this.room.track(this, state);
+    return Promise.resolve();
+  }
+
+  untrack(): Promise<unknown> {
+    this.room.untrack(this);
+    return Promise.resolve();
+  }
+
+  presenceState(): Record<string, Array<Record<string, unknown>>> {
+    return this.room.presenceState();
+  }
+
+  deliverBroadcast(event: string, payload: unknown) {
+    (this.broadcastHandlers.get(event) ?? []).forEach((h) => h({ payload }));
+  }
+
+  deliverPresenceSync() {
+    this.syncHandlers.forEach((h) => h());
+  }
+
+  deliverPresenceJoin(newPresences: unknown[]) {
+    this.joinHandlers.forEach((h) => h({ key: '', newPresences }));
+  }
+
+  deliverPresenceLeave(leftPresences: unknown[]) {
+    this.leaveHandlers.forEach((h) => h({ key: '', leftPresences }));
+  }
+}
+
+class FakeSupabaseRealtimeClient implements SupabaseRealtimeClientLike {
+  private rooms = new Map<string, FakeRoom>();
+
+  channel(name: string): RealtimeChannelLike {
+    let room = this.rooms.get(name);
+    if (!room) {
+      room = new FakeRoom();
+      this.rooms.set(name, room);
+    }
+    return new FakeChannel(room);
+  }
+
+  removeChannel(channel: RealtimeChannelLike): Promise<unknown> {
+    for (const room of this.rooms.values()) room.unregister(channel as FakeChannel);
+    return Promise.resolve();
+  }
+}
+
+describe('room code helpers', () => {
+  it('generateRoomCode produces a 6-char code from the safe alphabet', () => {
+    for (let i = 0; i < 20; i++) {
+      const code = generateRoomCode();
+      expect(code).toMatch(/^[ABCDEFGHJKMNPQRSTUVWXYZ23456789]{6}$/);
+    }
+  });
+
+  it('generateRoomCode does not use ambiguous characters', () => {
+    for (let i = 0; i < 50; i++) {
+      expect(generateRoomCode()).not.toMatch(/[0O1IL]/);
+    }
+  });
+
+  it('isValidRoomCode accepts well-formed codes case/whitespace-insensitively', () => {
+    expect(isValidRoomCode('ABCDEF')).toBe(true);
+    expect(isValidRoomCode('abcdef')).toBe(true);
+    expect(isValidRoomCode('  ABCDEF  ')).toBe(true);
+  });
+
+  it('isValidRoomCode rejects malformed codes', () => {
+    expect(isValidRoomCode('')).toBe(false);
+    expect(isValidRoomCode('AB')).toBe(false);
+    expect(isValidRoomCode('ABCDEFGHIJK')).toBe(false);
+    expect(isValidRoomCode('ABC-DEF')).toBe(false);
+    expect(isValidRoomCode('ABCDE0')).toBe(false); // '0' excluded from the alphabet
+  });
+
+  it('roomChannelName is a stable, normalized channel name', () => {
+    expect(roomChannelName('abcdef')).toBe('streetview-room:ABCDEF');
+    expect(roomChannelName('  ABCDEF  ')).toBe('streetview-room:ABCDEF');
+  });
+
+  it('generateClientId produces distinct ids', () => {
+    const a = generateClientId();
+    const b = generateClientId();
+    expect(a).not.toBe(b);
+    expect(a.length).toBeGreaterThan(0);
+  });
+});
+
+/** `send()` is queued behind the channel's async subscribe/track handshake. */
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('createRoomSignalingClient', () => {
+  const host: PresenceEntry = { clientId: 'host-1', role: 'host' };
+  const guest: PresenceEntry = { clientId: 'guest-1', role: 'guest' };
+
+  it('delivers a message only to its addressed recipient', async () => {
+    const client = new FakeSupabaseRealtimeClient();
+    const hostSignaling = createRoomSignalingClient(client, 'ROOM01', host);
+    const guestSignaling = createRoomSignalingClient(client, 'ROOM01', guest);
+
+    const received: SignalingMessage[] = [];
+    guestSignaling.onMessage((m) => received.push(m));
+    const hostReceived: SignalingMessage[] = [];
+    hostSignaling.onMessage((m) => hostReceived.push(m));
+
+    hostSignaling.send({ type: 'offer', to: guest.clientId, payload: { sdp: 'v=0' } });
+    await flush();
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual({ type: 'offer', from: host.clientId, to: guest.clientId, payload: { sdp: 'v=0' } });
+    expect(hostReceived).toHaveLength(0);
+  });
+
+  it('ignores messages addressed to a different client', async () => {
+    const client = new FakeSupabaseRealtimeClient();
+    const hostSignaling = createRoomSignalingClient(client, 'ROOM01', host);
+    const guestSignaling = createRoomSignalingClient(client, 'ROOM01', guest);
+    createRoomSignalingClient(client, 'ROOM01', { clientId: 'guest-2', role: 'guest' });
+
+    const received: SignalingMessage[] = [];
+    guestSignaling.onMessage((m) => received.push(m));
+
+    hostSignaling.send({ type: 'answer', to: 'guest-2', payload: {} });
+    await flush();
+
+    expect(received).toHaveLength(0);
+  });
+
+  it('keeps rooms with different codes isolated', async () => {
+    const client = new FakeSupabaseRealtimeClient();
+    const hostSignaling = createRoomSignalingClient(client, 'ROOM01', host);
+    const otherRoomGuest = createRoomSignalingClient(client, 'ROOM02', guest);
+
+    const received: SignalingMessage[] = [];
+    otherRoomGuest.onMessage((m) => received.push(m));
+
+    hostSignaling.send({ type: 'offer', to: guest.clientId, payload: {} });
+    await flush();
+
+    expect(received).toHaveLength(0);
+  });
+
+  it('reports the full roster via onPresenceSync as participants join', () => {
+    const client = new FakeSupabaseRealtimeClient();
+    const hostSignaling = createRoomSignalingClient(client, 'ROOM01', host);
+
+    const rosters: PresenceEntry[][] = [];
+    hostSignaling.onPresenceSync((participants) => rosters.push(participants));
+
+    createRoomSignalingClient(client, 'ROOM01', guest);
+
+    const last = rosters[rosters.length - 1]!;
+    expect(last).toHaveLength(2);
+    expect(last.map((p) => p.clientId).sort()).toEqual(['guest-1', 'host-1']);
+  });
+
+  it('fires onPresenceJoin with just the new participant', () => {
+    const client = new FakeSupabaseRealtimeClient();
+    const hostSignaling = createRoomSignalingClient(client, 'ROOM01', host);
+
+    const joined: PresenceEntry[] = [];
+    hostSignaling.onPresenceJoin((participants) => joined.push(...participants));
+
+    createRoomSignalingClient(client, 'ROOM01', guest);
+
+    expect(joined).toHaveLength(1);
+    expect(joined[0]).toEqual(guest);
+  });
+
+  it('fires onPresenceLeave for the other side when a participant leaves', async () => {
+    const client = new FakeSupabaseRealtimeClient();
+    const hostSignaling = createRoomSignalingClient(client, 'ROOM01', host);
+    const guestSignaling = createRoomSignalingClient(client, 'ROOM01', guest);
+
+    const left: PresenceEntry[] = [];
+    hostSignaling.onPresenceLeave((participants) => left.push(...participants));
+
+    await guestSignaling.leave();
+
+    expect(left).toHaveLength(1);
+    expect(left[0]).toEqual(guest);
+  });
+
+  it('unsubscribe functions stop further delivery', async () => {
+    const client = new FakeSupabaseRealtimeClient();
+    const hostSignaling = createRoomSignalingClient(client, 'ROOM01', host);
+    const guestSignaling = createRoomSignalingClient(client, 'ROOM01', guest);
+
+    const received: SignalingMessage[] = [];
+    const unsubscribe = guestSignaling.onMessage((m) => received.push(m));
+
+    hostSignaling.send({ type: 'ice-candidate', to: guest.clientId, payload: { n: 1 } });
+    await flush();
+    expect(received).toHaveLength(1);
+
+    unsubscribe();
+    hostSignaling.send({ type: 'ice-candidate', to: guest.clientId, payload: { n: 2 } });
+    await flush();
+
+    expect(received).toHaveLength(1);
+  });
+});

--- a/src/services/signaling/signalingClient.ts
+++ b/src/services/signaling/signalingClient.ts
@@ -1,0 +1,234 @@
+/**
+ * Room-code signaling for Shared Exploration Sessions.
+ *
+ * Replaces manual SDP offer/answer copy-paste with a short room code backed
+ * by a Supabase Realtime channel: participants broadcast SDP/ICE messages
+ * to each other and see a live presence roster, all scoped to one channel
+ * per room. Only signaling metadata (SDP, ICE candidates, client/role ids)
+ * ever passes through this channel — never Street View imagery, and never
+ * the actual synced POV state (that still flows peer-to-peer over the
+ * WebRTC data channel once connected, see useSharedSession.ts).
+ *
+ * Kept decoupled from the real `@supabase/supabase-js` types via a small
+ * duck-typed interface (see `RealtimeChannelLike` / `SupabaseRealtimeClientLike`)
+ * so this module — and the WebRTC signaling logic that depends on it — stays
+ * unit-testable with a plain in-memory fake instead of a real socket.
+ */
+
+export type SignalingRole = 'host' | 'guest';
+
+export type SignalingMessageType = 'offer' | 'answer' | 'ice-candidate';
+
+export interface SignalingMessage {
+  type: SignalingMessageType;
+  /** Sender's clientId, stamped by the signaling client — callers never set this. */
+  from: string;
+  /** Recipient's clientId. */
+  to: string;
+  payload: unknown;
+}
+
+export interface PresenceEntry {
+  clientId: string;
+  role: SignalingRole;
+}
+
+/** Minimal shape of a Supabase Realtime channel this module depends on. */
+export interface RealtimeChannelLike {
+  on(
+    type: 'broadcast',
+    filter: { event: string },
+    callback: (message: { payload: unknown }) => void,
+  ): RealtimeChannelLike;
+  on(
+    type: 'presence',
+    filter: { event: 'sync' },
+    callback: () => void,
+  ): RealtimeChannelLike;
+  on(
+    type: 'presence',
+    filter: { event: 'join' | 'leave' },
+    callback: (payload: { key: string; newPresences?: unknown[]; leftPresences?: unknown[] }) => void,
+  ): RealtimeChannelLike;
+  subscribe(callback?: (status: string, err?: Error) => void): RealtimeChannelLike;
+  send(message: { type: 'broadcast'; event: string; payload: unknown }): Promise<unknown>;
+  track(state: Record<string, unknown>): Promise<unknown>;
+  untrack(): Promise<unknown>;
+  presenceState(): Record<string, Array<Record<string, unknown>>>;
+}
+
+/** Minimal shape of the Supabase client this module depends on. */
+export interface SupabaseRealtimeClientLike {
+  channel(name: string, opts?: Record<string, unknown>): RealtimeChannelLike;
+  removeChannel(channel: RealtimeChannelLike): Promise<unknown> | unknown;
+}
+
+const SIGNAL_EVENT = 'signal';
+const ROOM_CHANNEL_PREFIX = 'streetview-room:';
+
+/** Alphabet excludes 0/O/1/I/L to avoid ambiguous room codes when read aloud or handwritten. */
+const ROOM_CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+const ROOM_CODE_LENGTH = 6;
+
+export function generateRoomCode(): string {
+  let code = '';
+  for (let i = 0; i < ROOM_CODE_LENGTH; i++) {
+    code += ROOM_CODE_ALPHABET[Math.floor(Math.random() * ROOM_CODE_ALPHABET.length)];
+  }
+  return code;
+}
+
+const ROOM_CODE_RE = new RegExp(`^[${ROOM_CODE_ALPHABET}]{4,8}$`);
+
+/** Whether a user-entered string is shaped like a room code (case/whitespace-insensitive). */
+export function isValidRoomCode(code: string): boolean {
+  return ROOM_CODE_RE.test(code.trim().toUpperCase());
+}
+
+export function normalizeRoomCode(code: string): string {
+  return code.trim().toUpperCase();
+}
+
+export function roomChannelName(roomCode: string): string {
+  return `${ROOM_CHANNEL_PREFIX}${normalizeRoomCode(roomCode)}`;
+}
+
+export function generateClientId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export interface RoomSignalingClient {
+  clientId: string;
+  /** Send a signaling message; `from` is stamped automatically. */
+  send(message: Omit<SignalingMessage, 'from'>): void;
+  /** Fires for every message addressed to this client. Returns an unsubscribe fn. */
+  onMessage(handler: (message: SignalingMessage) => void): () => void;
+  /** Fires with the full current roster whenever presence state syncs. */
+  onPresenceSync(handler: (participants: PresenceEntry[]) => void): () => void;
+  /** Fires with just the newly-joined participants. */
+  onPresenceJoin(handler: (participants: PresenceEntry[]) => void): () => void;
+  /** Fires with just the participants who left. */
+  onPresenceLeave(handler: (participants: PresenceEntry[]) => void): () => void;
+  /** Leave the room: untrack presence and tear down the channel. */
+  leave(): Promise<void>;
+}
+
+function isPresenceEntry(value: unknown): value is PresenceEntry {
+  const v = value as Partial<PresenceEntry> | null;
+  return !!v && typeof v.clientId === 'string' && (v.role === 'host' || v.role === 'guest');
+}
+
+/**
+ * Plain loop instead of `Array.prototype.filter(isPresenceEntry)`: TS's
+ * type-guard filter overload requires the guard's target type to structurally
+ * `extend` the array's element type, which an interface without an index
+ * signature (PresenceEntry) never does against `Record<string, unknown>` —
+ * so filter silently falls back to the non-narrowing overload instead.
+ */
+function toPresenceEntries(values: unknown[]): PresenceEntry[] {
+  const result: PresenceEntry[] = [];
+  for (const value of values) {
+    if (isPresenceEntry(value)) result.push(value);
+  }
+  return result;
+}
+
+/** Join (or create) a room's signaling channel for one participant. */
+export function createRoomSignalingClient(
+  client: SupabaseRealtimeClientLike,
+  roomCode: string,
+  self: PresenceEntry,
+): RoomSignalingClient {
+  const channel = client.channel(roomChannelName(roomCode), {
+    config: { broadcast: { self: false }, presence: { key: self.clientId } },
+  });
+
+  const messageHandlers = new Set<(message: SignalingMessage) => void>();
+  const syncHandlers = new Set<(participants: PresenceEntry[]) => void>();
+  const joinHandlers = new Set<(participants: PresenceEntry[]) => void>();
+  const leaveHandlers = new Set<(participants: PresenceEntry[]) => void>();
+
+  function currentParticipants(): PresenceEntry[] {
+    const grouped: Array<Record<string, unknown>>[] = Object.values(channel.presenceState());
+    return toPresenceEntries(grouped.flat());
+  }
+
+  channel.on('broadcast', { event: SIGNAL_EVENT }, ({ payload }) => {
+    const message = payload as SignalingMessage;
+    if (!message || message.to !== self.clientId) return;
+    messageHandlers.forEach((handler) => handler(message));
+  });
+
+  channel.on('presence', { event: 'sync' }, () => {
+    const participants = currentParticipants();
+    syncHandlers.forEach((handler) => handler(participants));
+  });
+
+  channel.on('presence', { event: 'join' }, ({ newPresences }) => {
+    const participants = toPresenceEntries(newPresences ?? []);
+    if (participants.length > 0) joinHandlers.forEach((handler) => handler(participants));
+  });
+
+  channel.on('presence', { event: 'leave' }, ({ leftPresences }) => {
+    const participants = toPresenceEntries(leftPresences ?? []);
+    if (participants.length > 0) leaveHandlers.forEach((handler) => handler(participants));
+  });
+
+  let subscribed = false;
+  const ready = new Promise<void>((resolve, reject) => {
+    channel.subscribe((status) => {
+      if (status === 'SUBSCRIBED') {
+        if (subscribed) return;
+        subscribed = true;
+        void channel.track({ ...self }).then(() => resolve());
+      } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT' || status === 'CLOSED') {
+        if (!subscribed) reject(new Error(`Failed to join signaling room (${status})`));
+      }
+    });
+  });
+  // Signaling-room join failures surface through `send`'s rejection path in
+  // callers that await it; avoid an unhandled-rejection warning for callers
+  // that only use the fire-and-forget `send()`.
+  ready.catch(() => {});
+
+  return {
+    clientId: self.clientId,
+    send(message) {
+      void ready.then(() =>
+        channel.send({
+          type: 'broadcast',
+          event: SIGNAL_EVENT,
+          payload: { ...message, from: self.clientId } satisfies SignalingMessage,
+        }),
+      );
+    },
+    onMessage(handler) {
+      messageHandlers.add(handler);
+      return () => messageHandlers.delete(handler);
+    },
+    onPresenceSync(handler) {
+      syncHandlers.add(handler);
+      return () => syncHandlers.delete(handler);
+    },
+    onPresenceJoin(handler) {
+      joinHandlers.add(handler);
+      return () => joinHandlers.delete(handler);
+    },
+    onPresenceLeave(handler) {
+      leaveHandlers.add(handler);
+      return () => leaveHandlers.delete(handler);
+    },
+    async leave() {
+      messageHandlers.clear();
+      syncHandlers.clear();
+      joinHandlers.clear();
+      leaveHandlers.clear();
+      try {
+        await channel.untrack();
+      } catch {
+        // Best-effort — the channel is being torn down regardless.
+      }
+      await client.removeChannel(channel);
+    },
+  };
+}

--- a/src/services/signaling/supabaseConfig.test.ts
+++ b/src/services/signaling/supabaseConfig.test.ts
@@ -1,0 +1,46 @@
+import {
+  normalizeSupabaseValue,
+  getConfiguredSupabaseUrlFromEnv,
+  getConfiguredSupabaseAnonKeyFromEnv,
+  PLACEHOLDER_SUPABASE_PATTERNS,
+} from './supabaseConfig';
+
+describe('supabaseConfig', () => {
+  describe('normalizeSupabaseValue', () => {
+    it('returns empty string for undefined and blank input', () => {
+      expect(normalizeSupabaseValue(undefined)).toBe('');
+      expect(normalizeSupabaseValue('   ')).toBe('');
+    });
+
+    it('rejects known placeholder patterns', () => {
+      for (const pattern of ['YOUR_SUPABASE_URL', 'placeholder-key', '<insert-url>', 'replace-me']) {
+        expect(normalizeSupabaseValue(pattern)).toBe('');
+      }
+    });
+
+    it('accepts a real-looking value', () => {
+      expect(normalizeSupabaseValue(' https://abc123.supabase.co ')).toBe('https://abc123.supabase.co');
+    });
+
+    it('exports a non-empty placeholder pattern list', () => {
+      expect(PLACEHOLDER_SUPABASE_PATTERNS.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getConfiguredSupabaseUrlFromEnv / getConfiguredSupabaseAnonKeyFromEnv', () => {
+    it('prefers the build-time value over the runtime value', () => {
+      expect(getConfiguredSupabaseUrlFromEnv('build-url', 'runtime-url')).toBe('build-url');
+      expect(getConfiguredSupabaseAnonKeyFromEnv('build-key', 'runtime-key')).toBe('build-key');
+    });
+
+    it('falls through to the runtime value when the build-time value is missing or a placeholder', () => {
+      expect(getConfiguredSupabaseUrlFromEnv(undefined, 'runtime-url')).toBe('runtime-url');
+      expect(getConfiguredSupabaseUrlFromEnv('placeholder', 'runtime-url')).toBe('runtime-url');
+    });
+
+    it('returns empty when both sources are missing or placeholders', () => {
+      expect(getConfiguredSupabaseUrlFromEnv('', '')).toBe('');
+      expect(getConfiguredSupabaseAnonKeyFromEnv(undefined, undefined)).toBe('');
+    });
+  });
+});

--- a/src/services/signaling/supabaseConfig.ts
+++ b/src/services/signaling/supabaseConfig.ts
@@ -1,0 +1,63 @@
+/**
+ * Config resolution for the Supabase project used purely as a signaling
+ * relay for Shared Exploration Sessions (room-code WebRTC handshake).
+ * Mirrors the precedence used by src/app/mapsKeyUtils.ts: a build-time env
+ * var wins, falling back to the runtime value injected by public/config.js.
+ */
+
+declare global {
+  interface Window {
+    /** Runtime Supabase project URL injected by public/config.js. */
+    SUPABASE_URL?: string;
+    /** Runtime Supabase anon/publishable key injected by public/config.js. */
+    SUPABASE_ANON_KEY?: string;
+  }
+}
+
+export const PLACEHOLDER_SUPABASE_PATTERNS: RegExp[] = [
+  /^your[_-]?supabase[_-]?(url|(anon[_-]?)?key)?$/i,
+  /^placeholder/i,
+  /^<.*>$/,
+  /replace/i,
+];
+
+export function normalizeSupabaseValue(value: string | undefined): string {
+  const trimmed = value?.trim() || '';
+  return PLACEHOLDER_SUPABASE_PATTERNS.some((re) => re.test(trimmed)) ? '' : trimmed;
+}
+
+export function getConfiguredSupabaseUrlFromEnv(
+  buildTimeValue: string | undefined,
+  runtimeValue: string | undefined,
+): string {
+  return normalizeSupabaseValue(buildTimeValue) || normalizeSupabaseValue(runtimeValue);
+}
+
+export function getConfiguredSupabaseAnonKeyFromEnv(
+  buildTimeValue: string | undefined,
+  runtimeValue: string | undefined,
+): string {
+  return normalizeSupabaseValue(buildTimeValue) || normalizeSupabaseValue(runtimeValue);
+}
+
+export function getConfiguredSupabaseUrl(): string {
+  // Vite replaces process.env.* at build time (see vite.config.ts define shim).
+  const buildTimeValue = process.env.VITE_SUPABASE_URL || process.env.REACT_APP_SUPABASE_URL;
+  return getConfiguredSupabaseUrlFromEnv(
+    buildTimeValue,
+    typeof window !== 'undefined' ? window.SUPABASE_URL : undefined,
+  );
+}
+
+export function getConfiguredSupabaseAnonKey(): string {
+  const buildTimeValue = process.env.VITE_SUPABASE_ANON_KEY || process.env.REACT_APP_SUPABASE_ANON_KEY;
+  return getConfiguredSupabaseAnonKeyFromEnv(
+    buildTimeValue,
+    typeof window !== 'undefined' ? window.SUPABASE_ANON_KEY : undefined,
+  );
+}
+
+/** Whether both URL + key are configured, i.e. room-code signaling can be attempted. */
+export function isSignalingConfigured(): boolean {
+  return Boolean(getConfiguredSupabaseUrl() && getConfiguredSupabaseAnonKey());
+}

--- a/src/services/signaling/supabaseRealtimeClient.ts
+++ b/src/services/signaling/supabaseRealtimeClient.ts
@@ -1,0 +1,31 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { getConfiguredSupabaseAnonKey, getConfiguredSupabaseUrl, isSignalingConfigured } from './supabaseConfig';
+import type { SupabaseRealtimeClientLike } from './signalingClient';
+
+export { isSignalingConfigured };
+
+let cachedClient: SupabaseClient | null = null;
+let cachedForUrl = '';
+
+/**
+ * Lazily create (and cache) the Supabase client used purely for signaling.
+ * Returns null when no URL/key is configured — callers should surface that
+ * as "shared sessions unavailable" rather than throwing.
+ */
+export function getSignalingRealtimeClient(): SupabaseRealtimeClientLike | null {
+  if (!isSignalingConfigured()) return null;
+
+  const url = getConfiguredSupabaseUrl();
+  if (!cachedClient || cachedForUrl !== url) {
+    cachedClient = createClient(url, getConfiguredSupabaseAnonKey(), {
+      // Signaling only — no auth session, no Postgres/table access needed.
+      auth: { persistSession: false },
+    });
+    cachedForUrl = url;
+  }
+  // The real RealtimeChannel/SupabaseClient surface is a strict superset of
+  // the small duck-typed interface this module depends on (see
+  // signalingClient.ts) — cast rather than hand-maintain a structural type
+  // that mirrors every overload of the real SDK.
+  return cachedClient as unknown as SupabaseRealtimeClientLike;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -51,6 +51,18 @@ export default defineConfig(({ mode }) => {
   if (!('process.env.VITE_MAPS_API_KEY' in processEnvDefines)) {
     processEnvDefines['process.env.VITE_MAPS_API_KEY'] = JSON.stringify('');
   }
+  // Same reachable-define guarantee for the Supabase signaling config (Shared
+  // Exploration Sessions room-code relay) — see src/services/signaling/supabaseConfig.ts.
+  for (const key of [
+    'REACT_APP_SUPABASE_URL',
+    'VITE_SUPABASE_URL',
+    'REACT_APP_SUPABASE_ANON_KEY',
+    'VITE_SUPABASE_ANON_KEY',
+  ]) {
+    if (!(`process.env.${key}` in processEnvDefines)) {
+      processEnvDefines[`process.env.${key}`] = JSON.stringify('');
+    }
+  }
 
   return {
     base: './',


### PR DESCRIPTION
## Summary

Shared Exploration Sessions (multiplayer road trips) worked, but the only way to connect two browsers was pasting a large base64 SDP blob back and forth — error-prone, one-guest-only, and STUN-only with no reconnect story. This replaces that with a short room code:

- **Signaling backend**: [Supabase Realtime](https://supabase.com/docs/guides/realtime) (broadcast + presence), chosen over standing up a new Cloudflare Worker/WS relay because it needed no new hosting credentials to actually verify end-to-end — I provisioned/restored the account's existing (previously-paused) Supabase project via the Supabase MCP tools rather than creating a new one.
- **`src/services/signaling/signalingClient.ts`**: room-code generation (6-char, ambiguity-free alphabet), and `createRoomSignalingClient` — wraps a Realtime channel's broadcast (signaling messages routed by `to: clientId`) and presence (sync/join/leave → live roster). Kept behind a small duck-typed `RealtimeChannelLike`/`SupabaseRealtimeClientLike` interface, independent of `@supabase/supabase-js`'s types, so it's unit-testable against an in-memory fake instead of a real socket — the "mock WS" tests the issue asked for.
- **`src/services/signaling/supabaseConfig.ts` + `supabaseRealtimeClient.ts`**: config resolution mirroring the existing Maps-key pattern (`REACT_APP_SUPABASE_URL`/`REACT_APP_SUPABASE_ANON_KEY` at build time, or `window.SUPABASE_URL`/`window.SUPABASE_ANON_KEY` in `public/config.js` at runtime — blank in git either way).
- **`src/hooks/useSharedSession.ts`** (rewritten): `createRoom()`/`joinRoom(code)` replace `startHosting`/`admitGuest`/`joinWithInviteCode`. Host now runs a **hub topology** — one `RTCPeerConnection` + data channel per guest, opened automatically on presence-join, torn down on presence-leave — with **trickle ICE** (send candidates as they arrive) instead of blocking on full ICE gathering. A dropped peer connection retries automatically (capped at 5 attempts, ~2s apart) as long as the peer is still in the room; `seq`-ordered state application (unchanged) means a guest disconnect/reconnect can never roll the view backwards.
- **`src/hooks/sharedSessionRoster.ts`**: pure helpers — presence roster → UI participant list, and reconnect-retry eligibility — kept separate for easy testing.
- **`SharedSessionPanel`**: room code + live "who's in this room" roster UI replacing the paste-a-blob textareas; documents the STUN-only/no-TURN tradeoff and shows a clear error once retries are exhausted.
- **`useSharedSessionSync.ts`/`sharedSessionSync.ts`** (AppShell glue): untouched — `broadcastState`'s signature didn't change, so the 10Hz host-broadcast / guest-follow wiring in `AppShell.tsx` needed no changes.

## Explicitly out of scope (per issue discussion)

- **TURN server**: still STUN-only. `ICE_SERVERS` in `useSharedSession.ts` is structured so adding a TURN entry later needs no other code changes; documented in README.
- **Host migration**, **text chat overlay**: not part of this issue's acceptance criteria; left for a follow-up.
- The "AppShell decomposition... strongly recommended first" dependency turned out to already be substantially done — the sync/broadcast logic was already isolated in `useSharedSessionSync.ts`/`sharedSessionSync.ts` before this PR.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 293/293 tests pass across 33 files, including:
  - `signalingClient.test.ts` — message routing (addressed-only delivery, room isolation), presence sync/join/leave, unsubscribe, room-code format/alphabet
  - `sharedSessionRoster.test.ts` — roster derivation, retry-eligibility incl. attempt-budget cutoff
  - `supabaseConfig.test.ts` — build-time/runtime key precedence, placeholder rejection
  - `useSharedSession.test.ts` — kept `shouldApplyIncomingState` coverage (seq ordering); dropped the now-removed `encodeSignal`/`decodeSignal` tests
- [ ] Manual two-browser smoke test (create room → join with code → guest follows host) — **not run in this environment.** I don't have two real browsers or open WebSocket egress to Supabase available here to verify the live handshake end-to-end; everything above the actual socket/WebRTC layer is unit-tested against a behaviorally-faithful fake. Would appreciate a manual pass before merge, especially to confirm the restored Supabase project's Realtime broadcast/presence work un-configured (no RLS/private-channel setup was added — channels are left public, matching how Supabase Realtime broadcast works out of the box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Us7HEdwjJYDouToh7pQxLf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time shared exploration sessions using six-character room codes.
  * Hosts can create sessions, guests can join, and all participants appear in a live roster.
  * Added room-code copying, host-following status, and clear host departure messaging.
  * Added automatic connection retries and visible connectivity errors.

* **Documentation**
  * Documented setup, configuration, session behavior, privacy of signaling data, and current STUN-only limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->