### PR TITLE
Sync globe history POIs reactively while globe is active

### DIFF
--- a/src/app/shell/ConnectedChrome.tsx
+++ b/src/app/shell/ConnectedChrome.tsx
@@ -478,7 +478,7 @@ export function ConnectedChrome({
             currentLat={panorama?.getPosition()?.lat() ?? 39.2575}
             currentLng={panorama?.getPosition()?.lng() ?? -121.0218}
             currentHeading={heading}
-            pois={hist.history.slice(0, 30).map((h) => ({
+            pois={hist.history.map((h) => ({
               lat: h.lat,
               lng: h.lng,
               label: h.locationName || `${h.lat.toFixed(2)}, ${h.lng.toFixed(2)}`,

--- a/src/components/GlobeView.tsx
+++ b/src/components/GlobeView.tsx
@@ -324,32 +324,6 @@ const GlobeView: React.FC<GlobeViewProps> = ({
             },
         });
 
-        // POI beacons (location history)
-        const poiImage = makePoiCanvas();
-        poiEntitiesRef.current = pois.slice(0, MAX_VISIBLE_POIS).map(poi =>
-            viewer.entities.add({
-                position: Cesium.Cartesian3.fromDegrees(poi.lng, poi.lat, 60),
-                billboard: {
-                    image: poiImage,
-                    scale: 0.85,
-                    disableDepthTestDistance: Number.POSITIVE_INFINITY,
-                },
-                label: {
-                    text: poi.label,
-                    font: '12px sans-serif',
-                    fillColor: Cesium.Color.fromCssColorString('#FFB400'),
-                    outlineColor: Cesium.Color.BLACK,
-                    outlineWidth: 1,
-                    style: Cesium.LabelStyle.FILL_AND_OUTLINE,
-                    pixelOffset: new Cesium.Cartesian2(0, -42),
-                    showBackground: true,
-                    backgroundColor: Cesium.Color.fromCssColorString('rgba(0,0,0,0.65)'),
-                    backgroundPadding: new Cesium.Cartesian2(6, 3),
-                    disableDepthTestDistance: Number.POSITIVE_INFINITY,
-                },
-            })
-        );
-
         // --- Event handlers ---
 
         const handler = new Cesium.ScreenSpaceEventHandler(viewer.scene.canvas);
@@ -460,6 +434,46 @@ const GlobeView: React.FC<GlobeViewProps> = ({
             cleanupViewer();
         };
     }, []);
+
+    // ---- Reactive POI entities (location history from ConnectedChrome) ----
+    useEffect(() => {
+        const viewer = viewerRef.current;
+        if (!viewer || viewer.isDestroyed() || typeof Cesium === 'undefined') return;
+
+        poiEntitiesRef.current.forEach(e => {
+            try { viewer.entities.remove(e); } catch { /* noop */ }
+        });
+
+        if (pois.length === 0) {
+            poiEntitiesRef.current = [];
+            return;
+        }
+
+        const poiImage = makePoiCanvas();
+        poiEntitiesRef.current = pois.slice(0, MAX_VISIBLE_POIS).map(poi =>
+            viewer.entities.add({
+                position: Cesium.Cartesian3.fromDegrees(poi.lng, poi.lat, 60),
+                billboard: {
+                    image: poiImage,
+                    scale: 0.85,
+                    disableDepthTestDistance: Number.POSITIVE_INFINITY,
+                },
+                label: {
+                    text: poi.label,
+                    font: '12px sans-serif',
+                    fillColor: Cesium.Color.fromCssColorString('#FFB400'),
+                    outlineColor: Cesium.Color.BLACK,
+                    outlineWidth: 1,
+                    style: Cesium.LabelStyle.FILL_AND_OUTLINE,
+                    pixelOffset: new Cesium.Cartesian2(0, -42),
+                    showBackground: true,
+                    backgroundColor: Cesium.Color.fromCssColorString('rgba(0,0,0,0.65)'),
+                    backgroundPadding: new Cesium.Cartesian2(6, 3),
+                    disableDepthTestDistance: Number.POSITIVE_INFINITY,
+                },
+            })
+        );
+    }, [pois]);
 
     // ---- Reactive bookmark entities (from ConnectedChrome bookmarks prop) ----
     useEffect(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Location-history POIs on the Cesium globe were only created once during the `transition === 'entering'` init effect. New history entries added while globe mode stayed open never appeared.

This change mirrors the existing reactive `bookmarks` effect: POI entities are rebuilt whenever the `pois` prop changes.

## Changes
- **`GlobeView.tsx`**: Removed one-shot POI creation from the Cesium init effect; added a `useEffect` keyed on `pois` that removes stale entities and re-adds up to `MAX_VISIBLE_POIS` (30) orange history beacons.
- **`ConnectedChrome.tsx`**: Pass the full `hist.history` array (cap enforced in `GlobeView`, consistent with bookmarks).

## Testing
- `npm run typecheck` — pass
- `npm test` — 299/305 pass; 6 failures in `App.test.tsx` appear pre-existing and unrelated

## Notes
- Cesium entity clustering for very large histories is left as a future enhancement (optional goal).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-279b73aa-fde4-47ad-b787-b98230cdc25c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-279b73aa-fde4-47ad-b787-b98230cdc25c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The globe can now display location history beyond the previous 30-item limit.
  * Globe location markers update automatically when history changes.
  * Visible markers remain capped to help maintain smooth performance.

* **Bug Fixes**
  * Corrected stale location markers that did not refresh after history updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->