### PR TITLE
Fix reactive globe history POI sync after async Cesium init

### DIFF
--- a/src/app/shell/ConnectedChrome.tsx
+++ b/src/app/shell/ConnectedChrome.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, useMemo } from 'react';
 import type { TimeOfDay } from '../../hooks';
 import type { AccessibilitySettings } from '../../hooks/useKeyboardShortcuts';
 import type { Bookmark } from '../../hooks/useBookmarks';
@@ -182,6 +182,29 @@ export function ConnectedChrome({
     teleportToPanoSafe,
   } = session;
   const { globeMode, effectiveMapsKey, handleGlobeTeleport, handleStartJourney } = globe;
+
+  const globePois = useMemo(
+    () =>
+      hist.history.map((h) => ({
+        lat: h.lat,
+        lng: h.lng,
+        label: h.locationName || `${h.lat.toFixed(2)}, ${h.lng.toFixed(2)}`,
+      })),
+    [hist.history],
+  );
+
+  const globeBookmarks = useMemo(
+    () =>
+      bm.bookmarks.map((b) => ({
+        id: b.id,
+        name: b.name,
+        lat: b.lat,
+        lng: b.lng,
+        heading: b.heading,
+        pitch: b.pitch,
+      })),
+    [bm.bookmarks],
+  );
 
   const {
     isBookmarkPanelOpen,
@@ -478,19 +501,8 @@ export function ConnectedChrome({
             currentLat={panorama?.getPosition()?.lat() ?? 39.2575}
             currentLng={panorama?.getPosition()?.lng() ?? -121.0218}
             currentHeading={heading}
-            pois={hist.history.map((h) => ({
-              lat: h.lat,
-              lng: h.lng,
-              label: h.locationName || `${h.lat.toFixed(2)}, ${h.lng.toFixed(2)}`,
-            }))}
-            bookmarks={bm.bookmarks.map((b) => ({
-              id: b.id,
-              name: b.name,
-              lat: b.lat,
-              lng: b.lng,
-              heading: b.heading,
-              pitch: b.pitch,
-            }))}
+            pois={globePois}
+            bookmarks={globeBookmarks}
             mapsApiKey={effectiveMapsKey}
             onTeleportRequest={handleGlobeTeleport}
             onEnterComplete={globeMode.onEnterComplete}

--- a/src/components/GlobeView.tsx
+++ b/src/components/GlobeView.tsx
@@ -159,6 +159,9 @@ const GlobeView: React.FC<GlobeViewProps> = ({
     // WebGL context failure state
     const [contextFailed, setContextFailed] = useState(false);
 
+    // Set once the async Cesium Viewer is created so POI/bookmark effects can sync.
+    const [viewerReady, setViewerReady] = useState(false);
+
     // Transient toast for "No Street View here"
     const [toast, setToast] = useState<string | null>(null);
     const showToast = useCallback((msg: string) => {
@@ -277,6 +280,7 @@ const GlobeView: React.FC<GlobeViewProps> = ({
         }
 
         viewerRef.current = viewer;
+        setViewerReady(true);
 
         // Note: The mts1.googleapis.com/vt Street View coverage overlay has been
         // removed — it is an undocumented endpoint that can 403 silently, causing
@@ -489,7 +493,7 @@ const GlobeView: React.FC<GlobeViewProps> = ({
                 },
             })
         );
-    }, [pois]);
+    }, [pois, viewerReady]);
 
     // ---- Reactive bookmark entities (from ConnectedChrome bookmarks prop) ----
     useEffect(() => {
@@ -537,7 +541,7 @@ const GlobeView: React.FC<GlobeViewProps> = ({
                 },
             })
         );
-    }, [bookmarks]);
+    }, [bookmarks, viewerReady]);
 
     // ---- Update waypoint visuals on globe ----
     useEffect(() => {
@@ -594,7 +598,7 @@ const GlobeView: React.FC<GlobeViewProps> = ({
                 },
             });
         }
-    }, [waypoints]);
+    }, [waypoints, viewerReady]);
 
     // ---- update beacon when street view position changes ---------------------
     useEffect(() => {
@@ -641,6 +645,7 @@ const GlobeView: React.FC<GlobeViewProps> = ({
         const v = viewerRef.current;
         if (v && !v.isDestroyed()) v.destroy();
         viewerRef.current = null;
+        setViewerReady(false);
         setContextFailed(false);
         setScoutTarget(null);
         setWaypoints([]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Location-history POIs on the globe were moved to a reactive `useEffect` keyed on `pois` in #177, but the effect could run before the async Cesium `Viewer` finished initializing. When that happened, POI entities were skipped and never re-synced until `pois` changed again.

This PR completes the reactive history POI behavior by re-running entity sync once the viewer is ready, and by stabilizing globe prop references in `ConnectedChrome`.

## Changes
- **`GlobeView.tsx`**: Add `viewerReady` state, set when the async Cesium viewer is created and cleared on teardown. Include it in POI, bookmark, and waypoint effect dependencies so entity layers sync after init.
- **`ConnectedChrome.tsx`**: Memoize `globePois` and `globeBookmarks` from `hist.history` / `bm.bookmarks` so unrelated chrome re-renders (e.g. heading updates) do not recreate all globe entities.

## Behavior
- Orange history POIs still respect `MAX_VISIBLE_POIS` (30).
- Bookmarks continue to update reactively via the same pattern.
- No clustering added (optional follow-up if history caps are lifted).

## Testing
- `npm run typecheck` — pass
- `npm test` — 300/306 pass; 6 failures in `src/App.test.tsx` also fail on `main` (pre-existing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51ae3bcf-8eff-49c5-b6d8-eea75d87eaf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51ae3bcf-8eff-49c5-b6d8-eea75d87eaf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

