### PR TITLE
Deduplicate car mode gauges: 3D cluster canonical, compact DOM chip

### DIFF
--- a/src/car/DashboardUI.module.css
+++ b/src/car/DashboardUI.module.css
@@ -17,13 +17,12 @@
 }
 
 /* --------------------------------------------------------------------------
-   Gauge row (left zone inner layout)
+   Telemetry chip zone (left zone inner layout)
    -------------------------------------------------------------------------- */
 .gaugeRow {
   display: flex;
   align-items: center;
-  gap: 4px;
-  justify-content: center;
+  justify-content: flex-start;
   height: 100%;
 }
 

--- a/src/car/DashboardUI.tsx
+++ b/src/car/DashboardUI.tsx
@@ -7,7 +7,7 @@
  * only dashboard-specific composition, logic, and event handling.
  */
 
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import styles from './DashboardUI.module.css';
 import { darkTheme, applyTheme } from './theme';
 
@@ -24,7 +24,7 @@ import {
 } from './DashboardLayout';
 
 // Gauge components
-import { SpeedGauge, RpmGauge, GearIndicator } from './Gauges';
+import { TelemetryChip } from './Gauges';
 
 // Icons + audio visualizer
 import {
@@ -236,39 +236,10 @@ export const DashboardUI: React.FC<DashboardUIProps> = ({
   rpm,
   gear,
 }) => {
-  // Demo gauge simulation — used only when no live telemetry props arrive.
   const hasTelemetry = speedKmh !== undefined;
-  const [simulatedSpeed, setSimulatedSpeed] = useState(45);
-  const [simulatedRpm, setSimulatedRpm] = useState(2500);
-  const [simulatedGear, setSimulatedGear] = useState('D');
-
-  useEffect(() => {
-    if (hasTelemetry) return;
-    const interval = setInterval(() => {
-      const targetSpeed = Math.floor(Math.random() * 40) + 25;
-      setSimulatedSpeed((prev) => {
-        const diff = targetSpeed - prev;
-        return prev + diff * 0.3;
-      });
-
-      const targetRpm = 1500 + (targetSpeed / 65) * 2500;
-      setSimulatedRpm((prev) => {
-        const diff = targetRpm - prev;
-        return prev + diff * 0.3;
-      });
-
-      if (Math.random() > 0.9) {
-        setSimulatedGear((prev) => (prev === 'D' ? (Math.random() > 0.5 ? '3' : 'D') : 'D'));
-      }
-    }, 2500);
-
-    return () => clearInterval(interval);
-  }, [hasTelemetry]);
-
-  // SpeedGauge displays MPH; live telemetry arrives in km/h.
-  const displaySpeedMph = hasTelemetry ? speedKmh! * 0.621371 : simulatedSpeed;
-  const displayRpm = hasTelemetry ? rpm ?? 0 : simulatedRpm;
-  const displayGear = hasTelemetry ? gear ?? 'D' : simulatedGear;
+  const displaySpeedKmh = hasTelemetry ? speedKmh! : 0;
+  const displayRpm = hasTelemetry ? rpm ?? 0 : 0;
+  const displayGear = hasTelemetry ? gear ?? 'D' : 'P';
 
   // Event handlers – prevent propagation to underlying canvas
   const stopProp = useCallback((e: React.SyntheticEvent) => {
@@ -312,20 +283,12 @@ export const DashboardUI: React.FC<DashboardUIProps> = ({
             ZONE LEFT – Driving HUD
         ===================================================================== */}
         <ZoneLeft>
-          <div className={styles.gaugeRow}>
-            <SpeedGauge
-              value={Math.round(displaySpeedMph)}
-              size={72}
-              unit="MPH"
-              nightGlow={nightIntensity}
-            />
-            <GearIndicator gear={displayGear} size={28} />
-            <RpmGauge
-              value={Math.round(displayRpm)}
-              size={72}
-              nightGlow={nightIntensity}
-            />
-          </div>
+          <TelemetryChip
+            speedKmh={displaySpeedKmh}
+            rpm={displayRpm}
+            gear={displayGear}
+            nightGlow={nightIntensity}
+          />
         </ZoneLeft>
 
         {/* =====================================================================

--- a/src/car/Gauges.module.css
+++ b/src/car/Gauges.module.css
@@ -90,6 +90,79 @@
 }
 
 /* --------------------------------------------------------------------------
+   Telemetry chip (compact HUD — no duplicate circular dials)
+   -------------------------------------------------------------------------- */
+.telemetryChip {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 8px 12px;
+  min-width: 88px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+  user-select: none;
+}
+
+.telemetryPrimary {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.telemetrySpeed {
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas,
+    'Courier New', monospace;
+  font-size: 28px;
+  font-weight: 700;
+  color: #ffffff;
+  letter-spacing: 0.02em;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.telemetryUnit {
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas,
+    'Courier New', monospace;
+  font-size: 10px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.55);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.telemetrySecondary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.telemetryGear {
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas,
+    'Courier New', monospace;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.telemetryDivider {
+  width: 1px;
+  height: 12px;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.telemetryRpm {
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas,
+    'Courier New', monospace;
+  font-size: 11px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.65);
+  letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+}
+
+/* --------------------------------------------------------------------------
    Gauge dashboard (combined view)
    -------------------------------------------------------------------------- */
 .gaugeDashboard {

--- a/src/car/Gauges.tsx
+++ b/src/car/Gauges.tsx
@@ -53,6 +53,14 @@ export interface GaugeDashboardProps {
   unit?: 'MPH' | 'KPH';
 }
 
+/** Compact digital readout — pairs with the 3D instrument cluster (no duplicate dials). */
+export interface TelemetryChipProps {
+  speedKmh: number;
+  rpm: number;
+  gear: string;
+  nightGlow?: number;
+}
+
 // ============================================================================
 // Utility Functions
 // ============================================================================
@@ -498,6 +506,76 @@ export const GearIndicator: React.FC<GearIndicatorProps> = ({
 };
 
 // ============================================================================
+// TelemetryChip — compact HUD readout (3D cluster is canonical)
+// ============================================================================
+
+const formatRpm = (rpm: number): string => {
+  if (rpm >= 1000) {
+    const k = rpm / 1000;
+    return k >= 10 ? `${Math.round(k)}k` : `${k.toFixed(1)}k`;
+  }
+  return String(Math.round(rpm));
+};
+
+const getGearColor = (gear: string): string => {
+  switch (gear.toUpperCase()) {
+    case 'P':
+      return '#4CAF50';
+    case 'R':
+      return '#FF3864';
+    case 'N':
+      return '#FFC107';
+    case 'D':
+      return '#00D4FF';
+    default:
+      return '#00D4FF';
+  }
+};
+
+export const TelemetryChip: React.FC<TelemetryChipProps> = ({
+  speedKmh,
+  rpm,
+  gear,
+  nightGlow = 0,
+}) => {
+  const displayGear = gear.toUpperCase();
+  const gearColor = getGearColor(displayGear);
+  const speedRounded = Math.round(speedKmh);
+  const rpmLabel = formatRpm(rpm);
+  const glow =
+    nightGlow > 0.3
+      ? `0 0 ${8 + nightGlow * 12}px rgba(0, 212, 255, ${Math.min(0.25 + nightGlow * 0.45, 0.85)})`
+      : '0 0 6px rgba(0, 212, 255, 0.25)';
+
+  return (
+    <div
+      className={styles.telemetryChip}
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      aria-label={`Speed ${speedRounded} kilometres per hour, gear ${displayGear}, engine ${Math.round(rpm)} RPM`}
+    >
+      <div className={styles.telemetryPrimary}>
+        <span className={styles.telemetrySpeed} style={{ textShadow: glow }}>
+          {speedRounded}
+        </span>
+        <span className={styles.telemetryUnit}>km/h</span>
+      </div>
+      <div className={styles.telemetrySecondary}>
+        <span
+          className={styles.telemetryGear}
+          style={{ color: gearColor, textShadow: `0 0 8px ${gearColor}66` }}
+        >
+          {displayGear}
+        </span>
+        <span className={styles.telemetryDivider} aria-hidden="true" />
+        <span className={styles.telemetryRpm}>{rpmLabel} RPM</span>
+      </div>
+    </div>
+  );
+};
+
+// ============================================================================
 // Combined Dashboard Component
 // ============================================================================
 
@@ -537,6 +615,7 @@ const gauges = {
   SpeedGauge,
   RpmGauge,
   GearIndicator,
+  TelemetryChip,
   GaugeDashboard,
 };
 

--- a/src/car/index.ts
+++ b/src/car/index.ts
@@ -80,7 +80,8 @@ export {
 export { 
     SpeedGauge, 
     RpmGauge, 
-    GearIndicator 
+    GearIndicator,
+    TelemetryChip,
 } from './Gauges';
 export { 
     IconButton, 

--- a/src/views/CarModeView.tsx
+++ b/src/views/CarModeView.tsx
@@ -293,12 +293,12 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
       // Update steering wheel
       setCarSteering(steeringInputRef.current);
       
-      // Vehicle dynamics → 3D cluster needles + React dashboard gauges
+      // Vehicle dynamics → 3D cluster needles + compact DOM telemetry chip
       const telem = dynamicsRef.current!.update(deltaTime);
       carSpeedRef.current = telem.speedKmh;
       carRPMRef.current = telem.rpm;
       updateCarGauges(telem.speedKmh, telem.rpm);
-      // Throttle React state pushes; the HUD gauges spring-animate between them.
+      // Throttle React state pushes for the compact HUD telemetry chip.
       if (now - lastTelemetryPushRef.current > 150) {
         lastTelemetryPushRef.current = now;
         setTelemetry(telem);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Car mode showed **duplicate** instrumentation:
1. React DOM circular gauges in `DashboardUI` (bottom HUD bar)
2. Three.js analog dials in `CarInteriorGauges` (windshield instrument cluster)

Both were driven by the same telemetry. Pressing **U** / "Hide HUD" only hid the DOM layer — users still saw two speedometers when the HUD was visible.

## Solution (Option A)
- **3D instrument cluster** remains the canonical analog presentation
- **DOM HUD** now shows a compact `TelemetryChip` (speed km/h + gear + RPM text) instead of circular `SpeedGauge` / `RpmGauge` dials
- **U / Hide HUD** clears the lower DOM bar for immersive driving; 3D cluster stays in the windshield FOV

## Changes
- `src/car/Gauges.tsx` — new `TelemetryChip` with `aria-live` numeric readout
- `src/car/DashboardUI.tsx` — replace gauge row with chip; remove unused demo simulation
- `src/car/Gauges.module.css` — chip styles
- `src/car/index.ts` — export `TelemetryChip`
- `src/views/CarModeView.tsx` — comment updates

## Acceptance
- [x] Only one speed/RPM **dial** presentation dominates the view (3D cluster)
- [x] **U** clears the lower FOV (DOM HUD hidden)
- [x] Accessibility: numeric readout available when HUD is shown (`role="status"`, `aria-live="polite"`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0576b00-7bca-4446-a06a-8713cc4e5ecf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0576b00-7bca-4446-a06a-8713cc4e5ecf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a compact telemetry display showing speed, gear, and RPM.
  * Added night-glow styling and accessible status announcements for telemetry updates.
  * Replaced the legacy driving HUD gauges with the new telemetry display.
* **Style**
  * Updated telemetry layout for a more compact, left-aligned presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->