### PR TITLE
Per-vehicle camera FOV and gauge cluster layout overrides

### DIFF
--- a/docs/CAR_MODE_VEHICLE_QA.md
+++ b/docs/CAR_MODE_VEHICLE_QA.md
@@ -1,0 +1,56 @@
+# Car Mode — Per-Vehicle Visual QA Checklist
+
+Manual checks after changing `VehicleManager`, gauge layout, camera FOV, or steering wheel placement. Run in **car mode** on a WebGPU-capable browser with a valid Maps key.
+
+## Global (all vehicles)
+
+1. **Hide HUD (U)** — lower DOM bar clears; 3D cluster remains readable without a second DOM dial layer.
+2. **Seat slider** — default posture sits slightly back from the dash; increasing seat distance reveals more road without losing gauge legibility.
+3. **Zoom (scroll)** — windshield frame stays roughly aligned with the Street View panorama at zoom ≈ 1.
+4. **Head look** — mouse drag pans view; steering wheel and cluster do not spin with head yaw.
+5. **Night drive** — gauge backlight and needle glow remain visible at high `nightIntensity`.
+
+## Sedan (`standard` layout)
+
+| Check | Pass criteria |
+|-------|----------------|
+| Lower FOV | Speed/tacho rings sit below centre-line; ≥60% of lower screen shows road/pano |
+| Steering wheel | Rim visible at bottom edge but does not cover cluster or horizon |
+| Cluster readout | Needles and numerals readable at default seat offset (0.28 m) |
+| Cruise hop | Hold-pause transition; cluster needles animate smoothly |
+
+## Convertible (`minimal` layout)
+
+| Check | Pass criteria |
+|-------|----------------|
+| Sport wheel | Smaller rim (0.14 m); less obstruction when roof open |
+| Cluster | Slightly lower/smaller dials than sedan; still readable |
+| Roof toggle | Open roof does not clip repositioned gauges |
+| Wind deflector | Visible behind seats; does not overlap cluster |
+
+## Science Lab (`lab` layout)
+
+| Check | Pass criteria |
+|-------|----------------|
+| No analog cluster | `hasGauges: false` — monitors only, no duplicate dials |
+| Steering | Compact wheel; lab monitors visible on dash |
+| Camera height | Slightly elevated eye (y ≈ 1.28); equipment not in central FOV |
+
+## Limousine (`luxury` layout)
+
+| Check | Pass criteria |
+|-------|----------------|
+| Driver posture | Further back (default seat 0.32 m); partition/bar not in windshield |
+| Wider cluster | Gauges spaced for long dash; needles track speed/RPM |
+| FOV | Narrower base FOV (56°) keeps cabin geometry from dominating road view |
+
+## Regression triggers
+
+Re-run this checklist when editing:
+
+- `src/car/VehicleManager.ts`
+- `src/car/vehicleLayout.ts`
+- `src/car/interior/CarInteriorGauges.ts`
+- `src/car/interior/CarInteriorDashboardBuilder.ts`
+- `src/car/interior/CarInteriorBuilder.ts` (steering wheel)
+- `src/car/CarInterior.ts` / `CarInteriorRenderer.ts` (camera FOV)

--- a/src/car/CarInterior.ts
+++ b/src/car/CarInterior.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { VehicleType, VehicleConfig, getVehicleConfig } from './VehicleManager';
+import { resolveCameraFov } from './vehicleLayout';
 import { 
   setupVehicleInteriorLOD, 
   VehicleLODConfig, 
@@ -145,11 +146,15 @@ export class CarInterior {
             interiorDetails: true
         };
 
-        // Camera at driver seat eye level (~1.2m), slightly angled toward center console.
-        // FOV is set to 60° vertical which corresponds to ~88° horizontal at 16:9 aspect —
-        // this matches Google Maps Street View zoom=1 (~90° horizontal FOV) so the 3D car
-        // interior window openings stay aligned with the background panorama.
-        this.camera = new THREE.PerspectiveCamera(60, container.clientWidth / container.clientHeight, 0.01, 100);
+        // FOV is tuned per vehicle; zoom=1 maps to cameraFov.base so window openings
+        // stay aligned with the Street View panorama behind the glass.
+        const initialFov = resolveCameraFov(this.vehicleConfig);
+        this.camera = new THREE.PerspectiveCamera(
+            initialFov.base,
+            container.clientWidth / container.clientHeight,
+            0.01,
+            100,
+        );
         // Camera starts at origin of driverSeatGroup (position set via driverSeatGroup below)
         this.camera.position.set(0, 0, 0);
         this.camera.rotation.order = 'YXZ';
@@ -288,7 +293,8 @@ export class CarInterior {
             this.camera,
             this.scene,
             this.postProcessing,
-            this.canvas
+            this.canvas,
+            resolveCameraFov(this.vehicleConfig),
         );
         // Post-FX OutputPass forces opaque alpha and blocks the WebGPU panorama through glass.
         this.rendererDelegate.setPostProcessingEnabled(this.postProcessingEnabled);
@@ -533,6 +539,7 @@ export class CarInterior {
         
         // Update camera anchor position for the new vehicle (preserving seat offset)
         this.applySeatPosition();
+        this.rendererDelegate?.setCameraFov(resolveCameraFov(this.vehicleConfig));
         
         // Recreate materials and rebuild
         const mats = createMaterials(this.vehicleConfig, this.gpuProfile);

--- a/src/car/VehicleManager.ts
+++ b/src/car/VehicleManager.ts
@@ -3,6 +3,10 @@
  * Defines vehicle types, their configurations, and manages vehicle switching
  */
 
+import type { CameraFovConfig, GaugeLayoutOverrides, SteeringWheelOverrides } from './vehicleLayout';
+
+export type { Vec3, GaugeLayoutOverrides, SteeringWheelOverrides } from './vehicleLayout';
+
 /**
  * Vehicle type definitions
  * Future additions: 'streetcar' | 'trolley' - for urban transit-style interiors
@@ -24,7 +28,16 @@ export interface VehicleConfig {
     hasWipers: boolean;
     hasDashboard: boolean;
     hasGauges: boolean;
+    /** Driver eye anchor in cabin local space (metres). */
     cameraPosition: { x: number; y: number; z: number };
+    /** Recommended seat-slider default (metres back from cameraPosition.z). */
+    defaultSeatOffset: number;
+    /** Vertical FOV endpoints for zoom sync with Street View. */
+    cameraFov: CameraFovConfig;
+    /** Partial overrides for instrument-cluster placement (see vehicleLayout.ts). */
+    gaugeLayout?: GaugeLayoutOverrides;
+    /** Partial overrides for steering wheel mesh placement. */
+    steeringWheel?: SteeringWheelOverrides;
     dashboardLayout: 'standard' | 'minimal' | 'lab' | 'luxury';
     accentColor: string;
     theme: 'dark' | 'light' | 'neon' | 'clinical';
@@ -45,7 +58,9 @@ export const VEHICLES: Record<VehicleType, VehicleConfig> = {
         hasWipers: true,
         hasDashboard: true,
         hasGauges: true,
-        cameraPosition: { x: -0.3, y: 1.2, z: 0.0 },
+        cameraPosition: { x: -0.3, y: 1.24, z: 0.08 },
+        defaultSeatOffset: 0.28,
+        cameraFov: { base: 58, min: 30, max: 88 },
         dashboardLayout: 'standard',
         accentColor: '#4CAF50',
         theme: 'dark',
@@ -64,7 +79,22 @@ export const VEHICLES: Record<VehicleType, VehicleConfig> = {
         hasWipers: true,
         hasDashboard: true,
         hasGauges: true,
-        cameraPosition: { x: -0.35, y: 1.15, z: 0.05 },
+        cameraPosition: { x: -0.35, y: 1.18, z: 0.06 },
+        defaultSeatOffset: 0.22,
+        cameraFov: { base: 60, min: 32, max: 90 },
+        gaugeLayout: {
+            speed: { y: 0.68, z: -0.82 },
+            tacho: { y: 0.68, z: -0.82 },
+            fuel: { y: 0.56, z: -0.82 },
+            temp: { y: 0.56, z: -0.82 },
+            dialRadius: 0.08,
+            needleLength: 0.062,
+            coverRadius: 0.085,
+        },
+        steeringWheel: {
+            position: { y: 0.84, z: -0.48 },
+            rimRadius: 0.14,
+        },
         dashboardLayout: 'minimal',
         accentColor: '#FF5722',
         theme: 'dark',
@@ -83,7 +113,13 @@ export const VEHICLES: Record<VehicleType, VehicleConfig> = {
         hasWipers: true,
         hasDashboard: true,
         hasGauges: false,
-        cameraPosition: { x: -0.3, y: 1.25, z: -0.1 },
+        cameraPosition: { x: -0.3, y: 1.28, z: -0.05 },
+        defaultSeatOffset: 0.24,
+        cameraFov: { base: 62, min: 34, max: 92 },
+        steeringWheel: {
+            position: { y: 0.88, z: -0.50 },
+            rimRadius: 0.14,
+        },
         dashboardLayout: 'lab',
         accentColor: '#00BCD4',
         theme: 'clinical',
@@ -102,7 +138,21 @@ export const VEHICLES: Record<VehicleType, VehicleConfig> = {
         hasWipers: true,
         hasDashboard: true,
         hasGauges: true,
-        cameraPosition: { x: -0.4, y: 1.3, z: 0.2 },
+        cameraPosition: { x: -0.38, y: 1.32, z: 0.18 },
+        defaultSeatOffset: 0.32,
+        cameraFov: { base: 56, min: 28, max: 86 },
+        gaugeLayout: {
+            speed: { x: -0.50, y: 0.72, z: -0.80 },
+            tacho: { x: -0.16, y: 0.72, z: -0.80 },
+            fuel: { y: 0.60, z: -0.80 },
+            temp: { y: 0.60, z: -0.80 },
+            dialRadius: 0.09,
+        },
+        steeringWheel: {
+            position: { x: -0.38, y: 0.90, z: -0.48 },
+            columnPosition: { x: -0.38, y: 0.74, z: -0.58 },
+            rimRadius: 0.16,
+        },
         dashboardLayout: 'luxury',
         accentColor: '#FFD700',
         theme: 'light',

--- a/src/car/index.ts
+++ b/src/car/index.ts
@@ -41,6 +41,16 @@ export {
     getPreviousVehicle,
 } from './VehicleManager';
 export {
+    resolveGaugeLayout,
+    resolveSteeringWheel,
+    resolveCameraFov,
+    zoomToVerticalFov,
+    DEFAULT_GAUGE_LAYOUT,
+    DEFAULT_STEERING_WHEEL,
+    DEFAULT_CAMERA_FOV,
+} from './vehicleLayout';
+export type { GaugeLayoutConfig, SteeringWheelConfig, CameraFovConfig, GaugeLayoutOverrides, SteeringWheelOverrides, Vec3 } from './vehicleLayout';
+export {
     ConvertibleMode,
     WindParticleSystem,
     SportDashboard,

--- a/src/car/interior/CarInteriorBuilder.ts
+++ b/src/car/interior/CarInteriorBuilder.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { VehicleConfig } from '../VehicleManager';
+import { resolveSteeringWheel } from '../vehicleLayout';
 import { GeometryFactory } from './GeometryFactory';
 import { LODManager } from './LODManager';
 import { CarInteriorDashboardBuilder } from './CarInteriorDashboardBuilder';
@@ -83,8 +84,13 @@ export class CarInteriorBuilder {
     }
 
     private buildSteeringWheel(): void {
+        const wheelCfg = resolveSteeringWheel(this.vehicleConfig);
         this.result.steeringWheelGroup = new THREE.Group();
-        this.result.steeringWheelGroup.position.set(-0.35, 0.95, -0.6);
+        this.result.steeringWheelGroup.position.set(
+            wheelCfg.position.x,
+            wheelCfg.position.y,
+            wheelCfg.position.z,
+        );
         this.interiorGroup.add(this.result.steeringWheelGroup);
 
         const wheelRimMat = new THREE.MeshStandardMaterial({
@@ -95,29 +101,33 @@ export class CarInteriorBuilder {
             side: THREE.DoubleSide,
         });
 
-        const wheelGeo = new THREE.TorusGeometry(0.18, 0.022, 12, 32);
+        const wheelGeo = new THREE.TorusGeometry(wheelCfg.rimRadius, wheelCfg.rimRadius * 0.12, 12, 32);
         const wheel = new THREE.Mesh(wheelGeo, wheelRimMat);
-        wheel.rotation.set(Math.PI * 0.35, 0, 0);
+        wheel.rotation.set(wheelCfg.tilt, 0, 0);
         this.result.steeringWheelGroup.add(wheel);
 
-        const hubGeo = new THREE.CylinderGeometry(0.06, 0.06, 0.02, 16);
+        const hubGeo = new THREE.CylinderGeometry(wheelCfg.rimRadius * 0.33, wheelCfg.rimRadius * 0.33, 0.02, 16);
         const hub = new THREE.Mesh(hubGeo, this.materials.dashboard);
-        hub.rotation.set(Math.PI * 0.35, 0, 0);
+        hub.rotation.set(wheelCfg.tilt, 0, 0);
         this.result.steeringWheelGroup.add(hub);
 
         for (let i = 0; i < 3; i++) {
-            const spokeGeo = new THREE.BoxGeometry(0.015, 0.16, 0.015);
+            const spokeGeo = new THREE.BoxGeometry(0.015, wheelCfg.rimRadius * 0.88, 0.015);
             const spoke = new THREE.Mesh(spokeGeo, this.materials.metal);
-            const angle = (i * Math.PI * 2) / 3 + Math.PI * 0.35;
-            spoke.position.set(Math.cos(angle) * 0.12, Math.sin(angle) * 0.12, 0);
-            spoke.rotation.set(Math.PI * 0.35, 0, angle);
+            const angle = (i * Math.PI * 2) / 3 + wheelCfg.tilt;
+            spoke.position.set(Math.cos(angle) * wheelCfg.rimRadius * 0.67, Math.sin(angle) * wheelCfg.rimRadius * 0.67, 0);
+            spoke.rotation.set(wheelCfg.tilt, 0, angle);
             this.result.steeringWheelGroup.add(spoke);
         }
 
         const columnGeo = new THREE.CylinderGeometry(0.025, 0.03, 0.4, 8);
         const column = new THREE.Mesh(columnGeo, this.materials.metal);
-        column.position.set(-0.35, 0.78, -0.7);
-        column.rotation.set(Math.PI * 0.35, 0, 0);
+        column.position.set(
+            wheelCfg.columnPosition.x,
+            wheelCfg.columnPosition.y,
+            wheelCfg.columnPosition.z,
+        );
+        column.rotation.set(wheelCfg.tilt, 0, 0);
         this.interiorGroup.add(column);
     }
 

--- a/src/car/interior/CarInteriorDashboardBuilder.ts
+++ b/src/car/interior/CarInteriorDashboardBuilder.ts
@@ -1,10 +1,10 @@
 import * as THREE from 'three';
 import { VehicleConfig } from '../VehicleManager';
+import { resolveGaugeLayout } from '../vehicleLayout';
 import { GeometryFactory } from './GeometryFactory';
 import { LODManager } from './LODManager';
 import { createAccentMaterial, registerGlowMaterial } from './MaterialFactory';
 import type { CarInteriorMaterials } from './CarInteriorBuilder';
-import { GAUGE_LAYOUT } from './CarInteriorGauges';
 
 export class CarInteriorDashboardBuilder {
     /** Radial/tubular segment counts scale with quality tier. */
@@ -22,6 +22,7 @@ export class CarInteriorDashboardBuilder {
     }
 
     public build(): { instrumentClusterMat: THREE.MeshStandardMaterial; centerDisplayMat: THREE.MeshStandardMaterial } {
+        const gaugeLayout = resolveGaugeLayout(this.vehicleConfig);
         const dashGeo = new THREE.BoxGeometry(2.0, 0.4, 0.5);
         const dash = new THREE.Mesh(dashGeo, this.materials.dashboard);
         dash.position.set(0, 0.8, -1.0);
@@ -36,13 +37,13 @@ export class CarInteriorDashboardBuilder {
         // Instrument cluster: emissive panel recessed into a chamfered bezel hood.
         const clusterMat = new THREE.MeshStandardMaterial({ color: 0x000000, emissive: 0x001100, emissiveIntensity: 0.5 });
         const clusterW =
-            Math.abs(GAUGE_LAYOUT.tacho.x - GAUGE_LAYOUT.speed.x) + GAUGE_LAYOUT.dialRadius * 2 + 0.06;
-        const clusterH = GAUGE_LAYOUT.dialRadius * 2 + 0.06;
+            Math.abs(gaugeLayout.tacho.x - gaugeLayout.speed.x) + gaugeLayout.dialRadius * 2 + 0.06;
+        const clusterH = gaugeLayout.dialRadius * 2 + 0.06;
         const cluster = new THREE.Mesh(new THREE.BoxGeometry(clusterW, clusterH, 0.04), clusterMat);
         cluster.position.set(
-            (GAUGE_LAYOUT.speed.x + GAUGE_LAYOUT.tacho.x) / 2,
-            GAUGE_LAYOUT.speed.y,
-            GAUGE_LAYOUT.speed.z - 0.02,
+            (gaugeLayout.speed.x + gaugeLayout.tacho.x) / 2,
+            gaugeLayout.speed.y,
+            gaugeLayout.speed.z - 0.02,
         );
         this.interiorGroup.add(cluster);
 
@@ -58,16 +59,16 @@ export class CarInteriorDashboardBuilder {
             // Bezels sit just proud of each panel face so the chamfered lip catches light.
             // Cluster frame tracks GAUGE_LAYOUT (compact dials under the beltline).
             const clusterW =
-                Math.abs(GAUGE_LAYOUT.tacho.x - GAUGE_LAYOUT.speed.x) + GAUGE_LAYOUT.dialRadius * 2 + 0.08;
-            const clusterH = GAUGE_LAYOUT.dialRadius * 2 + 0.08;
+                Math.abs(gaugeLayout.tacho.x - gaugeLayout.speed.x) + gaugeLayout.dialRadius * 2 + 0.08;
+            const clusterH = gaugeLayout.dialRadius * 2 + 0.08;
             const clusterBezel = new THREE.Mesh(
                 this.makeBezelFrameGeometry(clusterW, clusterH, 0.024),
                 this.materials.dashboard,
             );
             clusterBezel.position.set(
-                (GAUGE_LAYOUT.speed.x + GAUGE_LAYOUT.tacho.x) / 2,
-                GAUGE_LAYOUT.speed.y,
-                GAUGE_LAYOUT.speed.z - 0.016,
+                (gaugeLayout.speed.x + gaugeLayout.tacho.x) / 2,
+                gaugeLayout.speed.y,
+                gaugeLayout.speed.z - 0.016,
             );
             this.interiorGroup.add(clusterBezel);
 
@@ -89,12 +90,12 @@ export class CarInteriorDashboardBuilder {
 
             const ringMat = createAccentMaterial(this.vehicleConfig, 0.45);
             const ringGeo = new THREE.TorusGeometry(
-                GAUGE_LAYOUT.dialRadius + 0.008,
+                gaugeLayout.dialRadius + 0.008,
                 0.006,
                 12,
                 this.segments,
             );
-            for (const pos of [GAUGE_LAYOUT.speed, GAUGE_LAYOUT.tacho]) {
+            for (const pos of [gaugeLayout.speed, gaugeLayout.tacho]) {
                 const bezelRing = new THREE.Mesh(ringGeo, ringMat);
                 bezelRing.position.set(pos.x, pos.y, pos.z + 0.004);
                 this.interiorGroup.add(bezelRing);

--- a/src/car/interior/CarInteriorGauges.ts
+++ b/src/car/interior/CarInteriorGauges.ts
@@ -1,28 +1,29 @@
 import * as THREE from 'three';
+import type { VehicleConfig } from '../VehicleManager';
+import { resolveGaugeLayout, type GaugeLayoutConfig } from '../vehicleLayout';
 
 export const SPEED_DIAL_MAX_KMH = 180;
 export const TACHO_DIAL_MAX_RPM = 8000;
 export const TACHO_REDLINE_RPM = 6500;
 
 /**
- * Instrument-cluster layout (metres, driver-camera local space).
- * Kept compact so dials sit under the windshield beltline instead of filling FOV.
+ * Default instrument-cluster layout (metres, driver-camera local space).
+ * Prefer `resolveGaugeLayout(vehicleConfig)` at build time for per-vehicle placement.
  * Dashboard bezel/rings in CarInteriorDashboardBuilder must stay in sync.
  */
-export const GAUGE_LAYOUT = {
-  speed: { x: -0.48, y: 0.88, z: -0.76 },
-  tacho: { x: -0.18, y: 0.88, z: -0.76 },
-  fuel: { x: -0.42, y: 0.74, z: -0.76 },
-  temp: { x: -0.24, y: 0.74, z: -0.76 },
-  dialRadius: 0.10,
-  needleLength: 0.078,
-  coverRadius: 0.105,
-  hubRadius: 0.008,
-  /** Face / needle / hub / cover z offsets relative to dial z */
+export const GAUGE_LAYOUT: GaugeLayoutConfig = {
+  speed: { x: -0.48, y: 0.70, z: -0.84 },
+  tacho: { x: -0.18, y: 0.70, z: -0.84 },
+  fuel: { x: -0.42, y: 0.58, z: -0.84 },
+  temp: { x: -0.24, y: 0.58, z: -0.84 },
+  dialRadius: 0.085,
+  needleLength: 0.066,
+  coverRadius: 0.09,
+  hubRadius: 0.007,
   needleZ: 0.006,
   hubZ: 0.009,
   coverZ: 0.017,
-} as const;
+};
 
 /**
  * Map a 0..1 dial fraction to needle rotation.z.
@@ -74,11 +75,12 @@ export class CarInteriorGauges {
     static build(
         interiorGroup: THREE.Group,
         _metalMaterial: THREE.MeshStandardMaterial,
-        vehicleConfig: { accentColor: string },
+        vehicleConfig: VehicleConfig,
         gpuProfile: { name: string },
         quality: 'high' | 'medium' | 'low'
     ): CarInteriorGaugeResult {
-        const result = CarInteriorGauges.buildGauges(interiorGroup, vehicleConfig, gpuProfile, quality);
+        const layout = resolveGaugeLayout(vehicleConfig);
+        const result = CarInteriorGauges.buildGauges(interiorGroup, vehicleConfig, gpuProfile, quality, layout);
         if (quality !== 'low') {
             const clock = CarInteriorGauges.buildDigitalClock(interiorGroup, vehicleConfig, gpuProfile);
             return {
@@ -237,13 +239,14 @@ export class CarInteriorGauges {
         interiorGroup: THREE.Group,
         _vehicleConfig: { accentColor: string },
         gpuProfile: { name: string },
-        quality: 'high' | 'medium' | 'low'
+        quality: 'high' | 'medium' | 'low',
+        layout: GaugeLayoutConfig,
     ): { speedometerNeedle: THREE.Mesh; tachometerNeedle: THREE.Mesh; gaugeRig: GaugeRig } {
         const dialSize = gpuProfile.name === 'high' ? 512 : 256;
         const anisotropy = gpuProfile.name === 'high' ? 8 : 4;
         const dialMaterials: THREE.MeshStandardMaterial[] = [];
         const needleMaterials: THREE.MeshStandardMaterial[] = [];
-        const L = GAUGE_LAYOUT;
+        const L = layout;
 
         const speedLabels: string[] = [];
         for (let v = 0; v <= SPEED_DIAL_MAX_KMH; v += 30) speedLabels.push(String(v));

--- a/src/car/interior/CarInteriorRenderer.ts
+++ b/src/car/interior/CarInteriorRenderer.ts
@@ -1,17 +1,30 @@
 import * as THREE from 'three';
 import { PostProcessingManager } from './PostProcessingManager';
+import { CameraFovConfig, zoomToVerticalFov } from '../vehicleLayout';
 
 export class CarInteriorRenderer {
     /** Post-FX (bloom/SMAA/OutputPass) breaks alpha compositing over the WebGPU panorama. */
     private postProcessingActive = false;
+    private cameraFov: CameraFovConfig;
 
     constructor(
         private renderer: THREE.WebGLRenderer,
         private camera: THREE.PerspectiveCamera,
         private scene: THREE.Scene,
         private postProcessing: PostProcessingManager | undefined,
-        private canvas: HTMLCanvasElement
-    ) {}
+        private canvas: HTMLCanvasElement,
+        cameraFov: CameraFovConfig,
+    ) {
+        this.cameraFov = cameraFov;
+        this.camera.fov = cameraFov.base;
+        this.camera.updateProjectionMatrix();
+    }
+
+    public setCameraFov(fov: CameraFovConfig): void {
+        this.cameraFov = fov;
+        this.camera.fov = fov.base;
+        this.camera.updateProjectionMatrix();
+    }
 
     public render(): void {
         if (this.postProcessing && this.postProcessingActive) {
@@ -36,9 +49,7 @@ export class CarInteriorRenderer {
     }
 
     public setZoomFOV(zoom: number): void {
-        const minFOV = 30;
-        const maxFOV = 90;
-        this.camera.fov = maxFOV - (zoom * (maxFOV - minFOV));
+        this.camera.fov = zoomToVerticalFov(zoom, this.cameraFov);
         this.camera.updateProjectionMatrix();
     }
 

--- a/src/car/vehicleLayout.test.ts
+++ b/src/car/vehicleLayout.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { getVehicleConfig } from './VehicleManager';
+import {
+  DEFAULT_GAUGE_LAYOUT,
+  DEFAULT_STEERING_WHEEL,
+  resolveCameraFov,
+  resolveGaugeLayout,
+  resolveSteeringWheel,
+  zoomToVerticalFov,
+} from './vehicleLayout';
+
+describe('vehicleLayout', () => {
+  it('resolveGaugeLayout merges per-vehicle partial overrides', () => {
+    const convertible = getVehicleConfig('convertible');
+    const layout = resolveGaugeLayout(convertible);
+    expect(layout.speed.y).toBe(0.68);
+    expect(layout.dialRadius).toBe(0.08);
+    expect(layout.speed.x).toBe(DEFAULT_GAUGE_LAYOUT.speed.x);
+  });
+
+  it('resolveSteeringWheel merges position overrides', () => {
+    const lab = getVehicleConfig('science-lab');
+    const wheel = resolveSteeringWheel(lab);
+    expect(wheel.rimRadius).toBe(0.14);
+    expect(wheel.position.x).toBe(DEFAULT_STEERING_WHEEL.position.x);
+    expect(wheel.position.y).toBe(0.88);
+  });
+
+  it('resolveCameraFov returns per-vehicle endpoints', () => {
+    const sedan = resolveCameraFov(getVehicleConfig('sedan'));
+    expect(sedan.base).toBe(58);
+    expect(sedan.max).toBe(88);
+
+    const limo = resolveCameraFov(getVehicleConfig('limousine'));
+    expect(limo.base).toBe(56);
+  });
+
+  it('zoomToVerticalFov maps zoom=1 to base FOV', () => {
+    const fov = resolveCameraFov(getVehicleConfig('sedan'));
+    expect(zoomToVerticalFov(1, fov)).toBeCloseTo(fov.base, 5);
+  });
+
+  it('zoomToVerticalFov widens at zoom-out and narrows at zoom-in', () => {
+    const fov = resolveCameraFov(getVehicleConfig('sedan'));
+    expect(zoomToVerticalFov(0.5, fov)).toBeGreaterThan(fov.base);
+    expect(zoomToVerticalFov(3, fov)).toBeLessThan(fov.base);
+  });
+
+  it('every vehicle defines defaultSeatOffset and cameraFov', () => {
+    for (const type of ['sedan', 'convertible', 'science-lab', 'limousine'] as const) {
+      const cfg = getVehicleConfig(type);
+      expect(cfg.defaultSeatOffset).toBeGreaterThanOrEqual(0);
+      expect(cfg.cameraFov.base).toBeGreaterThan(cfg.cameraFov.min);
+      expect(cfg.cameraFov.max).toBeGreaterThan(cfg.cameraFov.base);
+    }
+  });
+});

--- a/src/car/vehicleLayout.ts
+++ b/src/car/vehicleLayout.ts
@@ -1,0 +1,133 @@
+/** 3D position in driver-cabin local metres. */
+export interface Vec3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+/** Instrument-cluster layout shared by gauges + dashboard bezel. */
+export interface GaugeLayoutConfig {
+  speed: Vec3;
+  tacho: Vec3;
+  fuel: Vec3;
+  temp: Vec3;
+  dialRadius: number;
+  needleLength: number;
+  coverRadius: number;
+  hubRadius: number;
+  needleZ: number;
+  hubZ: number;
+  coverZ: number;
+}
+
+export interface SteeringWheelConfig {
+  position: Vec3;
+  columnPosition: Vec3;
+  rimRadius: number;
+  /** Wheel plane tilt (radians, rotation.x on the rim). */
+  tilt: number;
+}
+
+export interface CameraFovConfig {
+  /** Vertical FOV at Street View zoom = 1 (degrees). */
+  base: number;
+  /** Narrowest FOV at max zoom-in (degrees). */
+  min: number;
+  /** Widest FOV at max zoom-out (degrees). */
+  max: number;
+}
+
+export interface GaugeLayoutOverrides {
+  speed?: Partial<Vec3>;
+  tacho?: Partial<Vec3>;
+  fuel?: Partial<Vec3>;
+  temp?: Partial<Vec3>;
+  dialRadius?: number;
+  needleLength?: number;
+  coverRadius?: number;
+  hubRadius?: number;
+  needleZ?: number;
+  hubZ?: number;
+  coverZ?: number;
+}
+
+export interface SteeringWheelOverrides {
+  position?: Partial<Vec3>;
+  columnPosition?: Partial<Vec3>;
+  rimRadius?: number;
+  tilt?: number;
+}
+
+/** Sedan defaults — lowered cluster + smaller wheel to clear lower FOV. */
+export const DEFAULT_GAUGE_LAYOUT: GaugeLayoutConfig = {
+  speed: { x: -0.48, y: 0.70, z: -0.84 },
+  tacho: { x: -0.18, y: 0.70, z: -0.84 },
+  fuel: { x: -0.42, y: 0.58, z: -0.84 },
+  temp: { x: -0.24, y: 0.58, z: -0.84 },
+  dialRadius: 0.085,
+  needleLength: 0.066,
+  coverRadius: 0.09,
+  hubRadius: 0.007,
+  needleZ: 0.006,
+  hubZ: 0.009,
+  coverZ: 0.017,
+};
+
+export const DEFAULT_STEERING_WHEEL: SteeringWheelConfig = {
+  position: { x: -0.35, y: 0.86, z: -0.52 },
+  columnPosition: { x: -0.35, y: 0.70, z: -0.62 },
+  rimRadius: 0.15,
+  tilt: Math.PI * 0.35,
+};
+
+export const DEFAULT_CAMERA_FOV: CameraFovConfig = {
+  base: 58,
+  min: 30,
+  max: 88,
+};
+
+export function resolveGaugeLayout(config: { gaugeLayout?: GaugeLayoutOverrides }): GaugeLayoutConfig {
+  const partial = config.gaugeLayout;
+  if (!partial) return { ...DEFAULT_GAUGE_LAYOUT };
+  return {
+    ...DEFAULT_GAUGE_LAYOUT,
+    ...partial,
+    speed: { ...DEFAULT_GAUGE_LAYOUT.speed, ...partial.speed },
+    tacho: { ...DEFAULT_GAUGE_LAYOUT.tacho, ...partial.tacho },
+    fuel: { ...DEFAULT_GAUGE_LAYOUT.fuel, ...partial.fuel },
+    temp: { ...DEFAULT_GAUGE_LAYOUT.temp, ...partial.temp },
+  };
+}
+
+export function resolveSteeringWheel(config: { steeringWheel?: SteeringWheelOverrides }): SteeringWheelConfig {
+  const partial = config.steeringWheel;
+  if (!partial) return { ...DEFAULT_STEERING_WHEEL };
+  return {
+    ...DEFAULT_STEERING_WHEEL,
+    ...partial,
+    position: { ...DEFAULT_STEERING_WHEEL.position, ...partial.position },
+    columnPosition: { ...DEFAULT_STEERING_WHEEL.columnPosition, ...partial.columnPosition },
+  };
+}
+
+export function resolveCameraFov(config: { cameraFov: CameraFovConfig }): CameraFovConfig {
+  return {
+    base: config.cameraFov.base ?? DEFAULT_CAMERA_FOV.base,
+    min: config.cameraFov.min ?? DEFAULT_CAMERA_FOV.min,
+    max: config.cameraFov.max ?? DEFAULT_CAMERA_FOV.max,
+  };
+}
+
+/** Map Street View zoom (0.5–3) to vertical camera FOV using per-vehicle endpoints. */
+export function zoomToVerticalFov(zoom: number, fov: CameraFovConfig): number {
+  const refZoom = 1;
+  const minZoom = 0.5;
+  const maxZoom = 3;
+  const z = Math.max(minZoom, Math.min(maxZoom, zoom));
+  if (z <= refZoom) {
+    const t = (z - minZoom) / (refZoom - minZoom);
+    return fov.max + t * (fov.base - fov.max);
+  }
+  const t = (z - refZoom) / (maxZoom - refZoom);
+  return fov.base + t * (fov.min - fov.base);
+}

--- a/src/hooks/useVehicleSettings.ts
+++ b/src/hooks/useVehicleSettings.ts
@@ -11,8 +11,8 @@ const STORAGE_KEY = 'webgpu_streetview_vehicle';
 const TINT_STORAGE_KEY = 'webgpu_streetview_window_tint';
 const SEAT_STORAGE_KEY = 'webgpu_streetview_seat_distance';
 
-/** Default pullback (metres) off the dashboard for a roomier default driving posture. */
-const DEFAULT_SEAT_DISTANCE = 0.25;
+/** Fallback seat pullback when a vehicle config omits defaultSeatOffset. */
+const FALLBACK_SEAT_DISTANCE = 0.25;
 /** Max seat pullback — keeps the eye ahead of the rear-seat/console geometry. */
 export const MAX_SEAT_DISTANCE = 0.6;
 
@@ -66,7 +66,14 @@ export function useVehicleSettings(): UseVehicleSettingsReturn {
                 if (!isNaN(parsed)) return Math.max(0, Math.min(MAX_SEAT_DISTANCE, parsed));
             }
         }
-        return DEFAULT_SEAT_DISTANCE;
+        const vehicle = typeof window !== 'undefined'
+            ? (() => {
+                const stored = localStorage.getItem(STORAGE_KEY);
+                if (stored && isValidVehicleType(stored)) return stored;
+                return vehicleManager.getCurrentVehicle();
+            })()
+            : vehicleManager.getCurrentVehicle();
+        return getVehicleConfig(vehicle).defaultSeatOffset ?? FALLBACK_SEAT_DISTANCE;
     });
 
     // Sync with vehicle manager


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
The sedan driver camera still showed a large instrument cluster and steering wheel in the lower FOV. All vehicle variants shared one `GAUGE_LAYOUT` and fixed 60° FOV despite different cabin geometry.

## Solution
1. **Per-`VehicleConfig` overrides** for camera seat anchor, FOV endpoints, gauge cluster transform, and steering wheel placement via `vehicleLayout.ts` resolvers.
2. **Lowered default cluster + wheel** — gauges moved from y≈0.88 → 0.70, smaller dials (0.085 m), steering wheel lowered and shrunk.
3. **Per-vehicle seat defaults** — `defaultSeatOffset` on each vehicle; seat slider initializes from the active vehicle config.
4. **Zoom-aware FOV** — `zoomToVerticalFov()` maps Street View zoom=1 to each vehicle's `cameraFov.base`.

## Per-vehicle tuning
| Vehicle | Seat default | Base FOV | Cluster notes |
|---------|-------------|----------|---------------|
| Sedan | 0.28 m | 58° | Lowered default layout |
| Convertible | 0.22 m | 60° | Smaller sport dials + wheel |
| Science Lab | 0.24 m | 62° | No gauges; compact wheel |
| Limousine | 0.32 m | 56° | Wider cluster, further-back eye |

## Files
- `src/car/vehicleLayout.ts` — layout types + resolvers + zoom FOV math
- `src/car/VehicleManager.ts` — per-vehicle overrides
- `src/car/interior/CarInteriorGauges.ts`, `CarInteriorDashboardBuilder.ts`, `CarInteriorBuilder.ts` — consume resolved layout
- `src/car/CarInterior.ts`, `CarInteriorRenderer.ts` — per-vehicle FOV
- `src/hooks/useVehicleSettings.ts` — vehicle-aware seat default
- `docs/CAR_MODE_VEHICLE_QA.md` — manual QA checklist per vehicle

Builds on gauge dedupe work (compact DOM `TelemetryChip` on this branch).

## Testing
- `npm run typecheck` ✓
- `npm test -- src/car/vehicleLayout.test.ts` ✓ (6 tests)
- Manual: see `docs/CAR_MODE_VEHICLE_QA.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0576b00-7bca-4446-a06a-8713cc4e5ecf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0576b00-7bca-4446-a06a-8713cc4e5ecf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

