### PR TITLE
Add physical wiper stalk and gear shifter levers to the cabin

### DIFF
--- a/src/car/CarInterior.ts
+++ b/src/car/CarInterior.ts
@@ -26,7 +26,15 @@ import { RainSystem } from './interior/RainSystem';
 import { DustMoteSystem } from './interior/DustMoteSystem';
 import { WindowWeatherOverlay } from './interior/WindowWeatherOverlay';
 import { InteriorMicroInteractions } from './interior/InteriorMicroInteractions';
-import { CarInteriorDetailProps } from './interior/CarInteriorDetailProps';
+import { CarInteriorDetailProps, CabinLeverCallbacks } from './interior/CarInteriorDetailProps';
+import {
+    GEAR_POSITIONS,
+    SHIFTER_KNOB_MESH,
+    WIPER_STALK_MESH,
+    WIPER_STALK_POSITIONS,
+    type GearPosition,
+    type WiperStalkPosition,
+} from './interior/CabinControls';
 import { VanityMirror } from './interior/VanityMirror';
 import { CenterDisplay } from './interior/CenterDisplay';
 import { SunShafts } from './interior/SunShafts';
@@ -103,6 +111,7 @@ export class CarInterior {
     private dustMoteSystem?: DustMoteSystem;
     private windowWeatherOverlay?: WindowWeatherOverlay;
     private microInteractions: InteriorMicroInteractions;
+    private leverCallbacks: CabinLeverCallbacks = {};
     private cupLiquidMaterial?: THREE.ShaderMaterial;
     private vanityMirror?: VanityMirror;
     private vanityMirrorMesh?: THREE.Mesh;
@@ -490,7 +499,13 @@ export class CarInterior {
                     accent: this.accentMaterial,
                     chrome: (this.chromeMaterial as any) || (this.metalMaterial as any),
                 } as any,
-                this.quality
+                this.quality,
+                // Indirected through the field so callbacks registered before or
+                // after a cabin rebuild both keep working.
+                {
+                    onWiperStalk: (position) => this.leverCallbacks.onWiperStalk?.(position),
+                    onGear: (gear) => this.leverCallbacks.onGear?.(gear),
+                }
             );
             this.cupLiquidMaterial = detail.cupLiquidMaterial;
             this.microInteractions.register(detail.interactives);
@@ -654,6 +669,35 @@ export class CarInterior {
     /** Wiper sweep rate multiplier (0.5 slow … 2.0 fast). */
     public setWiperSpeed(speed: number): void {
         this.animator.setWiperSpeed(speed);
+    }
+
+    /** Pause at the park position between sweeps (intermittent stalk detent). */
+    public setWiperIntermittent(intermittent: boolean): void {
+        this.animator.setWiperIntermittent(intermittent);
+    }
+
+    /** Register handlers for driver-initiated stalk / shifter moves. */
+    public setLeverCallbacks(callbacks: CabinLeverCallbacks): void {
+        this.leverCallbacks = callbacks;
+    }
+
+    /**
+     * Move the wiper stalk mesh to match externally-set state (HUD button,
+     * keyboard shortcut). Does not re-fire the lever callback.
+     */
+    public syncWiperStalkMesh(position: WiperStalkPosition): void {
+        this.microInteractions.setLeverIndexByName(
+            WIPER_STALK_MESH,
+            WIPER_STALK_POSITIONS.indexOf(position)
+        );
+    }
+
+    /** Move the shifter mesh to match externally-set gear state. */
+    public syncShifterMesh(gear: GearPosition): void {
+        this.microInteractions.setLeverIndexByName(
+            SHIFTER_KNOB_MESH,
+            GEAR_POSITIONS.indexOf(gear)
+        );
     }
 
     /**

--- a/src/car/index.ts
+++ b/src/car/index.ts
@@ -10,6 +10,13 @@ import {
 import {
     ConvertibleMode,
 } from './variants';
+import {
+    WIPER_STALK_POSITIONS,
+    WIPER_STALK_SPEEDS,
+    gearHopCount,
+    type GearPosition,
+    type WiperStalkPosition,
+} from './interior/CabinControls';
 
 export { CarInterior } from './CarInterior';
 export { RearviewMirror } from './RearviewMirror';
@@ -25,6 +32,15 @@ export { RainSystem } from './interior/RainSystem';
 export { DustMoteSystem } from './interior/DustMoteSystem';
 export { WindowWeatherOverlay } from './interior/WindowWeatherOverlay';
 export { InteriorMicroInteractions } from './interior/InteriorMicroInteractions';
+export {
+    WIPER_STALK_POSITIONS,
+    WIPER_STALK_SPEEDS,
+    GEAR_POSITIONS,
+    GEAR_HOP_COUNTS,
+    gearHopCount,
+    isGearParked,
+} from './interior/CabinControls';
+export type { WiperStalkPosition, GearPosition } from './interior/CabinControls';
 export { VanityMirror } from './interior/VanityMirror';
 export { PerformanceProfiler } from './interior/PerformanceProfiler';
 export { buildInteriorLighting } from './interior/LightingBuilder';
@@ -123,7 +139,19 @@ export interface CarModeState {
     wipersEnabled: boolean;
     wiperSpeed: number;
     currentVehicle: VehicleType;
+    /** Physical wiper stalk detent. */
+    wiperStalk: WiperStalkPosition;
+    /** Physical gear selector position. */
+    gear: GearPosition;
 }
+
+/** Fired when the driver moves a cabin lever in the 3D scene. */
+export interface CabinLeverHandlers {
+    onWiperStalk?: (position: WiperStalkPosition) => void;
+    onGear?: (gear: GearPosition) => void;
+}
+
+let leverHandlers: CabinLeverHandlers = {};
 
 let carModeState: CarModeState | null = null;
 let lastTimestamp = 0;
@@ -165,7 +193,18 @@ export function initCarMode(container: HTMLElement, initialVehicle: VehicleType 
         wipersEnabled: false,
         wiperSpeed: 1.0,
         currentVehicle: initialVehicle,
+        wiperStalk: 'off',
+        gear: 'D',
     };
+
+    interior.setLeverCallbacks({
+        onWiperStalk: applyWiperStalk,
+        onGear: (gear) => {
+            if (!carModeState || carModeState.gear === gear) return;
+            carModeState.gear = gear;
+            leverHandlers.onGear?.(gear);
+        },
+    });
 
     // Sync with vehicle manager
     vehicleManager.setVehicle(initialVehicle);
@@ -229,17 +268,84 @@ export function setCarZoomFOV(zoom: number): void {
 
 /**
  * Toggle windshield wipers on/off (matches headlights/dome: mutates animator immediately).
+ * Off ↔ low, keeping the physical stalk in step.
  */
 export function toggleWipers(): boolean {
     if (!carModeState) return false;
     const next = !carModeState.wipersEnabled;
-    carModeState.wipersEnabled = next;
-    carModeState.interior.setWipersActive(next);
+    setWiperStalkPosition(next ? 'low' : 'off');
     return next;
 }
 
 /**
- * Set wiper speed (0.5 = slow, 1.0 = normal, 2.0 = fast).
+ * Drive the animator from a stalk detent (shared by mesh + HUD paths) and
+ * notify listeners so the HUD mirrors whichever path moved the stalk.
+ */
+function applyWiperStalk(position: WiperStalkPosition): void {
+    if (!carModeState) return;
+    if (carModeState.wiperStalk === position) return;
+    const active = position !== 'off';
+    carModeState.wiperStalk = position;
+    carModeState.wipersEnabled = active;
+    carModeState.wiperSpeed = WIPER_STALK_SPEEDS[position];
+    carModeState.interior.setWiperSpeed(carModeState.wiperSpeed);
+    carModeState.interior.setWiperIntermittent(position === 'intermittent');
+    carModeState.interior.setWipersActive(active);
+    leverHandlers.onWiperStalk?.(position);
+}
+
+/**
+ * Set the wiper stalk detent from outside the 3D scene (HUD fallback,
+ * keyboard shortcut). Moves the stalk mesh to match.
+ */
+export function setWiperStalkPosition(position: WiperStalkPosition): void {
+    if (!carModeState) return;
+    applyWiperStalk(position);
+    carModeState.interior.syncWiperStalkMesh(position);
+}
+
+/** Advance the wiper stalk one detent, wrapping High → Off. */
+export function cycleWiperStalk(): WiperStalkPosition {
+    if (!carModeState) return 'off';
+    const next = WIPER_STALK_POSITIONS[
+        (WIPER_STALK_POSITIONS.indexOf(carModeState.wiperStalk) + 1) % WIPER_STALK_POSITIONS.length
+    ]!;
+    setWiperStalkPosition(next);
+    return next;
+}
+
+export function getWiperStalkPosition(): WiperStalkPosition {
+    return carModeState?.wiperStalk ?? 'off';
+}
+
+/** Set the gear selector from outside the 3D scene; moves the shifter mesh. */
+export function setCarGear(gear: GearPosition): void {
+    if (!carModeState || carModeState.gear === gear) return;
+    carModeState.gear = gear;
+    carModeState.interior.syncShifterMesh(gear);
+    leverHandlers.onGear?.(gear);
+}
+
+export function getCarGear(): GearPosition {
+    return carModeState?.gear ?? 'D';
+}
+
+/** Panorama hops the current gear consumes per forward input / cruise tick. */
+export function getGearHopCount(): number {
+    return gearHopCount(getCarGear());
+}
+
+/**
+ * Register handlers for driver-initiated stalk / shifter moves so the HUD and
+ * app state can mirror the physical controls.
+ */
+export function setCabinLeverHandlers(handlers: CabinLeverHandlers): void {
+    leverHandlers = handlers;
+}
+
+/**
+ * Set wiper speed directly (0.5 = slow, 1.0 = normal, 2.0 = fast).
+ * Prefer `setWiperStalkPosition` so the stalk mesh stays in sync.
  */
 export function setWiperSpeed(speed: number): void {
     if (!carModeState) return;
@@ -315,8 +421,8 @@ export function setCarSteering(steeringInput: number): void {
  */
 export function setCarWipers(active: boolean): void {
     if (!carModeState) return;
-    carModeState.wipersEnabled = active;
-    carModeState.interior.setWipersActive(active);
+    if (active === carModeState.wipersEnabled) return;
+    setWiperStalkPosition(active ? 'low' : 'off');
 }
 
 /**

--- a/src/car/interior/CabinControls.test.ts
+++ b/src/car/interior/CabinControls.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import {
+  GEAR_POSITIONS,
+  SHIFTER_DETENTS,
+  WIPER_STALK_DETENTS,
+  WIPER_STALK_POSITIONS,
+  WIPER_STALK_SPEEDS,
+  gearHopCount,
+  isGearParked,
+} from './CabinControls';
+
+describe('CabinControls', () => {
+  it('has one detent angle per lever position', () => {
+    expect(WIPER_STALK_DETENTS).toHaveLength(WIPER_STALK_POSITIONS.length);
+    expect(SHIFTER_DETENTS).toHaveLength(GEAR_POSITIONS.length);
+  });
+
+  it('orders wiper detents monotonically from off to high', () => {
+    for (let i = 1; i < WIPER_STALK_DETENTS.length; i++) {
+      expect(WIPER_STALK_DETENTS[i]!).toBeLessThan(WIPER_STALK_DETENTS[i - 1]!);
+    }
+  });
+
+  it('speeds up as the stalk moves toward high', () => {
+    const speeds = WIPER_STALK_POSITIONS.map((p) => WIPER_STALK_SPEEDS[p]);
+    for (let i = 1; i < speeds.length; i++) {
+      expect(speeds[i]!).toBeGreaterThan(speeds[i - 1]!);
+    }
+    // Animator clamps to [0.5, 2.0]; staying inside keeps detents distinguishable.
+    expect(Math.min(...speeds)).toBeGreaterThanOrEqual(0.5);
+    expect(Math.max(...speeds)).toBeLessThanOrEqual(2.0);
+  });
+
+  it('maps gears to advance hop counts', () => {
+    expect(gearHopCount('D')).toBe(1);
+    expect(gearHopCount('2')).toBe(2);
+    expect(gearHopCount('3')).toBe(3);
+    expect(gearHopCount('R')).toBe(1);
+  });
+
+  it('treats P and N as parked', () => {
+    expect(isGearParked('P')).toBe(true);
+    expect(isGearParked('N')).toBe(true);
+    expect(isGearParked('R')).toBe(false);
+    expect(isGearParked('D')).toBe(false);
+  });
+});

--- a/src/car/interior/CabinControls.ts
+++ b/src/car/interior/CabinControls.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared definitions for the physical cabin stalks/levers so the 3D meshes,
+ * the car-mode API and the HUD fallbacks all agree on position names,
+ * ordering and behaviour.
+ */
+
+export const WIPER_STALK_POSITIONS = ['off', 'intermittent', 'low', 'high'] as const;
+export type WiperStalkPosition = (typeof WIPER_STALK_POSITIONS)[number];
+
+/** Sweep-rate multiplier fed to the animator for each stalk detent. */
+export const WIPER_STALK_SPEEDS: Record<WiperStalkPosition, number> = {
+    off: 0.5,
+    intermittent: 0.6,
+    low: 1.0,
+    high: 2.0,
+};
+
+export const GEAR_POSITIONS = ['P', 'R', 'N', 'D', '2', '3'] as const;
+export type GearPosition = (typeof GEAR_POSITIONS)[number];
+
+/**
+ * Panorama hops consumed per forward input (or cruise tick) in each gear.
+ * P/N are parked, R reverses a single hop, D/2/3 step 1/2/3 panoramas.
+ */
+export const GEAR_HOP_COUNTS: Record<GearPosition, number> = {
+    P: 0,
+    R: 1,
+    N: 0,
+    D: 1,
+    '2': 2,
+    '3': 3,
+};
+
+/** Gears that hold the car still regardless of throttle input. */
+export function isGearParked(gear: GearPosition): boolean {
+    return GEAR_HOP_COUNTS[gear] === 0;
+}
+
+export function gearHopCount(gear: GearPosition): number {
+    return GEAR_HOP_COUNTS[gear];
+}
+
+/** Mesh names used for raycast lookups and HUD-driven lever moves. */
+export const WIPER_STALK_MESH = 'wiperStalk';
+export const SHIFTER_KNOB_MESH = 'shifterKnob';
+
+/** Stalk tilt (radians about local X) for off → intermittent → low → high. */
+export const WIPER_STALK_DETENTS = [0.18, 0.06, -0.06, -0.18];
+
+/** Shifter tilt (radians about local X) for P → R → N → D → 2 → 3. */
+export const SHIFTER_DETENTS = GEAR_POSITIONS.map(
+    (_, i) => -0.45 + (0.9 * i) / (GEAR_POSITIONS.length - 1)
+);

--- a/src/car/interior/CarInteriorAnimator.ts
+++ b/src/car/interior/CarInteriorAnimator.ts
@@ -23,11 +23,17 @@ export interface CarInteriorAmbientState {
   convertibleOpen: boolean;
 }
 
+/** Parked pause between intermittent wiper sweeps (seconds). */
+const INTERMITTENT_DWELL_S = 2.5;
+
 export class CarInteriorAnimator {
   private steeringAngle: number = 0;
   private isWiperActive: boolean = false;
   private wiperAnimationTime: number = 0;
   private wiperSpeed: number = 1.0;
+  private wiperIntermittent: boolean = false;
+  /** Seconds left of the parked pause between intermittent sweeps. */
+  private wiperDwell: number = 0;
   private speedometer: number = 0;
   private tachometer: number = 0;
   private isActive: boolean = true;
@@ -142,11 +148,22 @@ export class CarInteriorAnimator {
     }
 
     if (this.isWiperActive && this.quality !== 'low') {
-      this.wiperAnimationTime += clampedDelta * this.wiperSpeed;
-      const wiperCycle = this.wiperAnimationTime % 1.0;
-      const wiperAngle = Math.sin(wiperCycle * Math.PI) * (Math.PI / 4);
-      if (this.wiperLeft) this.wiperLeft.rotation.z = -wiperAngle - Math.PI / 6;
-      if (this.wiperRight) this.wiperRight.rotation.z = wiperAngle + Math.PI / 6;
+      if (this.wiperDwell > 0) {
+        this.wiperDwell -= clampedDelta;
+        this.parkWipers();
+      } else {
+        const before = this.wiperAnimationTime;
+        this.wiperAnimationTime += clampedDelta * this.wiperSpeed;
+        if (this.wiperIntermittent && Math.floor(this.wiperAnimationTime) > Math.floor(before)) {
+          // Land exactly on the park position, then pause before the next sweep.
+          this.wiperAnimationTime = Math.floor(this.wiperAnimationTime);
+          this.wiperDwell = INTERMITTENT_DWELL_S;
+        }
+        const wiperCycle = this.wiperAnimationTime % 1.0;
+        const wiperAngle = Math.sin(wiperCycle * Math.PI) * (Math.PI / 4);
+        if (this.wiperLeft) this.wiperLeft.rotation.z = -wiperAngle - Math.PI / 6;
+        if (this.wiperRight) this.wiperRight.rotation.z = wiperAngle + Math.PI / 6;
+      }
     }
 
     if (this.quality !== 'low') this.updateGauges(clampedDelta);
@@ -256,14 +273,26 @@ export class CarInteriorAnimator {
     if (this.rainSystem) this.rainSystem.setWipersActive(active);
     if (!active) {
       this.wiperAnimationTime = 0;
-      if (this.wiperLeft) this.wiperLeft.rotation.z = -Math.PI / 6;
-      if (this.wiperRight) this.wiperRight.rotation.z = Math.PI / 6;
+      this.wiperDwell = 0;
+      this.parkWipers();
     }
   }
 
   /** Sweep rate multiplier (0.5 = slow, 1 = normal, 2 = fast). */
   public setWiperSpeed(speed: number): void {
     this.wiperSpeed = Math.max(0.5, Math.min(2.0, speed));
+  }
+
+  /** Intermittent mode pauses at the park position between single sweeps. */
+  public setWiperIntermittent(intermittent: boolean): void {
+    if (this.wiperIntermittent === intermittent) return;
+    this.wiperIntermittent = intermittent;
+    this.wiperDwell = 0;
+  }
+
+  private parkWipers(): void {
+    if (this.wiperLeft) this.wiperLeft.rotation.z = -Math.PI / 6;
+    if (this.wiperRight) this.wiperRight.rotation.z = Math.PI / 6;
   }
 
   public setGaugeValues(speed: number, rpm: number): void {

--- a/src/car/interior/CarInteriorBuilder.ts
+++ b/src/car/interior/CarInteriorBuilder.ts
@@ -30,6 +30,9 @@ export interface CarInteriorBuildResult {
     centerDisplayMat: THREE.MeshStandardMaterial;
     domeLightFixtureMesh: THREE.Mesh;
     domeSwitchMesh: THREE.Mesh;
+    /** Wiper stalk lever (absent on vehicles without a steering wheel). */
+    wiperStalkMesh?: THREE.Mesh;
+    wiperStalkPivot?: THREE.Group;
 }
 
 export class CarInteriorBuilder {
@@ -129,6 +132,36 @@ export class CarInteriorBuilder {
         );
         column.rotation.set(wheelCfg.tilt, 0, 0);
         this.interiorGroup.add(column);
+
+        this.buildWiperStalk(wheelCfg.columnPosition, wheelCfg.tilt);
+    }
+
+    /**
+     * Wiper stalk on the right of the steering column. The pivot group carries
+     * the column tilt so the detent rotation applied by the micro-interaction
+     * layer reads as a clean up/down flick.
+     */
+    private buildWiperStalk(columnPosition: { x: number; y: number; z: number }, tilt: number): void {
+        const pivot = new THREE.Group();
+        pivot.position.set(columnPosition.x + 0.055, columnPosition.y + 0.12, columnPosition.z + 0.02);
+        pivot.rotation.set(tilt, 0, 0);
+        this.interiorGroup.add(pivot);
+
+        const stalkGeo = new THREE.CylinderGeometry(0.008, 0.01, 0.16, 8);
+        const stalk = new THREE.Mesh(stalkGeo, this.materials.metal);
+        // Lay the cylinder along +X so it cantilevers out of the column.
+        stalk.geometry.rotateZ(Math.PI / 2);
+        stalk.geometry.translate(0.08, 0, 0);
+        stalk.name = 'wiperStalk';
+        pivot.add(stalk);
+
+        const tipGeo = new THREE.SphereGeometry(0.012, 10, 8);
+        const tip = new THREE.Mesh(tipGeo, this.materials.accent);
+        tip.position.set(0.165, 0, 0);
+        stalk.add(tip);
+
+        this.result.wiperStalkMesh = stalk;
+        this.result.wiperStalkPivot = pivot;
     }
 
     private buildDoorPanels(): void {

--- a/src/car/interior/CarInteriorDetailProps.ts
+++ b/src/car/interior/CarInteriorDetailProps.ts
@@ -2,6 +2,22 @@ import * as THREE from 'three';
 import { createCupLiquidMaterial } from '../../shaders/cupLiquid';
 import type { CarInteriorMaterials } from './CarInteriorBuilder';
 import type { InteriorInteractive } from './InteriorMicroInteractions';
+import {
+  GEAR_POSITIONS,
+  SHIFTER_DETENTS,
+  SHIFTER_KNOB_MESH,
+  WIPER_STALK_DETENTS,
+  WIPER_STALK_MESH,
+  WIPER_STALK_POSITIONS,
+  type GearPosition,
+  type WiperStalkPosition,
+} from './CabinControls';
+
+/** Callbacks fired when the driver moves a physical cabin lever. */
+export interface CabinLeverCallbacks {
+  onWiperStalk?: (position: WiperStalkPosition) => void;
+  onGear?: (gear: GearPosition) => void;
+}
 
 export interface CarInteriorDetailBuildResult {
   interactives: InteriorInteractive[];
@@ -17,7 +33,8 @@ export class CarInteriorDetailProps {
   static build(
     interiorGroup: THREE.Group,
     materials: CarInteriorMaterials,
-    quality: 'high' | 'medium' | 'low'
+    quality: 'high' | 'medium' | 'low',
+    leverCallbacks: CabinLeverCallbacks = {}
   ): CarInteriorDetailBuildResult {
     if (quality === 'low') {
       return { interactives: [] };
@@ -45,15 +62,24 @@ export class CarInteriorDetailProps {
     const knobGeo = new THREE.SphereGeometry(0.028, 12, 10);
     const knob = new THREE.Mesh(knobGeo, materials.accent);
     knob.position.y = 0.2;
-    knob.name = 'shifterKnob';
+    knob.name = SHIFTER_KNOB_MESH;
     shifterGroup.add(knob);
 
+    // The knob is the raycast target so the driver grabs the ball, but the
+    // whole shifter group swings so shaft and boot follow the gate.
     interactives.push({
       mesh: knob,
-      kind: 'knob',
-      minRotation: -0.45,
-      maxRotation: 0.45,
+      kind: 'lever',
+      pivot: shifterGroup,
       axis: 'x',
+      detents: SHIFTER_DETENTS,
+      initialDetent: GEAR_POSITIONS.indexOf('D'),
+      dragAxis: 'y',
+      dragPixelsPerDetent: 22,
+      onDetent: (index) => {
+        const gear = GEAR_POSITIONS[index];
+        if (gear) leverCallbacks.onGear?.(gear);
+      },
     });
 
     // --- Pedal set ---
@@ -137,6 +163,23 @@ export class CarInteriorDetailProps {
         sunVisorGroup!.rotation.x += sunVisorGroup!.rotation.x < -0.2 ? 0.35 : -0.35;
       },
     });
+
+    // Wiper stalk (built with the steering column) → Off / Int / Low / High
+    const wiperStalk = interiorGroup.getObjectByName(WIPER_STALK_MESH) as THREE.Mesh | undefined;
+    if (wiperStalk) {
+      interactives.push({
+        mesh: wiperStalk,
+        kind: 'lever',
+        axis: 'x',
+        detents: WIPER_STALK_DETENTS,
+        dragAxis: 'y',
+        dragPixelsPerDetent: 18,
+        onDetent: (index) => {
+          const position = WIPER_STALK_POSITIONS[index];
+          if (position) leverCallbacks.onWiperStalk?.(position);
+        },
+      });
+    }
 
     // Hazard button on dash (micro-interaction)
     const hazardBtn = interiorGroup.getObjectByName('hazardBtn') as THREE.Mesh | undefined;

--- a/src/car/interior/InteriorMicroInteractions.test.ts
+++ b/src/car/interior/InteriorMicroInteractions.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as THREE from 'three';
+import { InteriorMicroInteractions, InteriorInteractive } from './InteriorMicroInteractions';
+
+const RECT = { left: 0, top: 0, width: 100, height: 100 } as DOMRect;
+const CENTER_X = 50;
+const CENTER_Y = 50;
+
+const DETENTS = [0.2, 0.1, 0, -0.1];
+
+function makeCamera(): THREE.PerspectiveCamera {
+  const camera = new THREE.PerspectiveCamera(60, 1, 0.1, 100);
+  camera.position.set(0, 0, 2);
+  camera.lookAt(0, 0, 0);
+  camera.updateMatrixWorld(true);
+  return camera;
+}
+
+describe('InteriorMicroInteractions levers', () => {
+  let micro: InteriorMicroInteractions;
+  let mesh: THREE.Mesh;
+  let camera: THREE.PerspectiveCamera;
+  let root: THREE.Group;
+  let detents: number[];
+  let lever: InteriorInteractive;
+
+  beforeEach(() => {
+    micro = new InteriorMicroInteractions();
+    mesh = new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1));
+    mesh.name = 'testLever';
+    root = new THREE.Group();
+    root.add(mesh);
+    camera = makeCamera();
+    detents = [];
+    lever = {
+      mesh,
+      kind: 'lever',
+      axis: 'x',
+      detents: DETENTS,
+      onDetent: (index) => detents.push(index),
+    };
+    micro.register([lever]);
+  });
+
+  const tap = () => {
+    micro.handlePointerDown(CENTER_X, CENTER_Y, RECT, camera, root, true);
+    micro.handlePointerUp();
+  };
+
+  it('rests at the first detent after registration', () => {
+    expect(micro.getLeverIndexByName('testLever')).toBe(0);
+    expect(mesh.rotation.x).toBeCloseTo(DETENTS[0]!);
+  });
+
+  it('honours an initial detent', () => {
+    micro.register([{ ...lever, initialDetent: 2 }]);
+    expect(micro.getLeverIndexByName('testLever')).toBe(2);
+    expect(mesh.rotation.x).toBeCloseTo(DETENTS[2]!);
+  });
+
+  it('cycles one detent per tap and wraps at the end', () => {
+    for (let i = 0; i < DETENTS.length; i++) tap();
+    expect(detents).toEqual([1, 2, 3, 0]);
+    expect(micro.getLeverIndexByName('testLever')).toBe(0);
+  });
+
+  it('ignores taps when interior edit mode is off', () => {
+    micro.handlePointerDown(CENTER_X, CENTER_Y, RECT, camera, root, false);
+    micro.handlePointerUp();
+    expect(detents).toEqual([]);
+    expect(micro.getLeverIndexByName('testLever')).toBe(0);
+  });
+
+  it('drags through detents without wrapping past the last one', () => {
+    micro.handlePointerDown(CENTER_X, CENTER_Y, RECT, camera, root, true);
+    micro.handlePointerMove(CENTER_X, CENTER_Y + 60); // ~2 detents at 26px each
+    expect(micro.getLeverIndexByName('testLever')).toBe(2);
+    micro.handlePointerMove(CENTER_X, CENTER_Y + 400);
+    expect(micro.getLeverIndexByName('testLever')).toBe(DETENTS.length - 1);
+    micro.handlePointerUp();
+    // A drag must not also fire the tap-to-cycle wrap.
+    expect(detents[detents.length - 1]).toBe(DETENTS.length - 1);
+  });
+
+  it('drag back toward the start returns to earlier detents', () => {
+    micro.setLeverIndexByName('testLever', 3);
+    micro.handlePointerDown(CENTER_X, CENTER_Y, RECT, camera, root, true);
+    micro.handlePointerMove(CENTER_X, CENTER_Y - 60);
+    expect(micro.getLeverIndexByName('testLever')).toBe(1);
+    micro.handlePointerUp();
+  });
+
+  it('external moves do not re-fire the detent callback', () => {
+    micro.setLeverIndexByName('testLever', 2);
+    expect(micro.getLeverIndexByName('testLever')).toBe(2);
+    expect(detents).toEqual([]);
+  });
+
+  it('eases the pivot toward the selected detent', () => {
+    const pivot = new THREE.Group();
+    mesh.rotation.x = 0;
+    pivot.add(mesh);
+    root.add(pivot);
+    micro.register([{ ...lever, pivot }]);
+    micro.setLeverIndexByName('testLever', 3);
+    for (let i = 0; i < 60; i++) micro.update(1 / 60);
+    expect(pivot.rotation.x).toBeCloseTo(DETENTS[3]!, 3);
+    // The grab target itself stays put; the assembly swings.
+    expect(mesh.rotation.x).toBe(0);
+  });
+});

--- a/src/car/interior/InteriorMicroInteractions.ts
+++ b/src/car/interior/InteriorMicroInteractions.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { InteractionHelper } from './InteractionHelper';
 
-export type InteriorInteractiveKind = 'button' | 'knob';
+export type InteriorInteractiveKind = 'button' | 'knob' | 'lever';
 
 export interface InteriorInteractive {
   mesh: THREE.Mesh;
@@ -14,6 +14,22 @@ export interface InteriorInteractive {
   maxRotation?: number;
   axis?: 'x' | 'y' | 'z';
   onPress?: () => void;
+  /** Lever: rotations (radians, along `axis`) of each detent position. */
+  detents?: number[];
+  /**
+   * Lever: object the detent rotation is applied to. Defaults to `mesh`.
+   * Use when the grab target (a shifter knob) is a child of the part that
+   * should actually swing (the shifter assembly).
+   */
+  pivot?: THREE.Object3D;
+  /** Lever: detent the control rests at when the cabin is (re)built (default 0). */
+  initialDetent?: number;
+  /** Lever: pointer axis the drag is measured along (default 'y'). */
+  dragAxis?: 'x' | 'y';
+  /** Lever: pixels of drag per detent step (default 26). */
+  dragPixelsPerDetent?: number;
+  /** Lever: fired whenever the selected detent changes. */
+  onDetent?: (index: number) => void;
 }
 
 interface ActiveDrag {
@@ -21,11 +37,17 @@ interface ActiveDrag {
   startClientX: number;
   startClientY: number;
   startRotation: number;
+  startIndex: number;
+  moved: boolean;
 }
 
+/** A click that never travels further than this (px) cycles the lever instead of dragging it. */
+const LEVER_CLICK_SLOP_PX = 5;
+
 /**
- * Raycast-driven cabin micro-interactions: button depress + knob drag.
- * Spring-back animation runs in update().
+ * Raycast-driven cabin micro-interactions: button depress, knob drag, and
+ * detented levers (wiper stalk, gear shifter).
+ * Spring-back and detent animation run in update().
  */
 export class InteriorMicroInteractions {
   private readonly raycaster = new InteractionHelper();
@@ -33,20 +55,26 @@ export class InteriorMicroInteractions {
   private readonly restPositions = new Map<THREE.Mesh, THREE.Vector3>();
   private readonly restRotations = new Map<THREE.Mesh, number>();
   private readonly pressState = new Map<THREE.Mesh, number>();
+  private readonly leverIndex = new Map<THREE.Mesh, number>();
   private activeDrag: ActiveDrag | null = null;
   private interiorEditMode = false;
 
   register(items: InteriorInteractive[]): void {
     this.items.length = 0;
     this.items.push(...items);
+    this.activeDrag = null;
+    this.leverIndex.clear();
     for (const item of items) {
       if (item.kind === 'button') {
         this.restPositions.set(item.mesh, item.mesh.position.clone());
         this.pressState.set(item.mesh, 0);
       } else if (item.kind === 'knob') {
-        const axis = item.axis ?? 'z';
-        const rot = axis === 'x' ? item.mesh.rotation.x : axis === 'y' ? item.mesh.rotation.y : item.mesh.rotation.z;
-        this.restRotations.set(item.mesh, rot);
+        this.restRotations.set(item.mesh, this.readRotation(item));
+      } else if (item.kind === 'lever') {
+        const detents = item.detents ?? [];
+        const initial = Math.min(Math.max(item.initialDetent ?? 0, 0), Math.max(detents.length - 1, 0));
+        this.leverIndex.set(item.mesh, initial);
+        this.writeRotation(item, detents[initial] ?? 0);
       }
     }
   }
@@ -58,6 +86,20 @@ export class InteriorMicroInteractions {
 
   isInteriorEditMode(): boolean {
     return this.interiorEditMode;
+  }
+
+  private readRotation(item: InteriorInteractive): number {
+    const axis = item.axis ?? 'z';
+    const target = item.pivot ?? item.mesh;
+    return axis === 'x' ? target.rotation.x : axis === 'y' ? target.rotation.y : target.rotation.z;
+  }
+
+  private writeRotation(item: InteriorInteractive, value: number): void {
+    const axis = item.axis ?? 'z';
+    const target = item.pivot ?? item.mesh;
+    if (axis === 'x') target.rotation.x = value;
+    else if (axis === 'y') target.rotation.y = value;
+    else target.rotation.z = value;
   }
 
   private findHit(
@@ -94,36 +136,64 @@ export class InteriorMicroInteractions {
       return true;
     }
 
-    if (hit.kind === 'knob') {
-      const axis = hit.axis ?? 'z';
-      const rot = axis === 'x' ? hit.mesh.rotation.x : axis === 'y' ? hit.mesh.rotation.y : hit.mesh.rotation.z;
+    if (hit.kind === 'knob' || hit.kind === 'lever') {
       this.activeDrag = {
         interactive: hit,
         startClientX: clientX,
         startClientY: clientY,
-        startRotation: rot,
+        startRotation: this.readRotation(hit),
+        startIndex: this.leverIndex.get(hit.mesh) ?? 0,
+        moved: false,
       };
       return true;
     }
     return false;
   }
 
-  handlePointerMove(clientX: number, _clientY: number): boolean {
-    if (!this.activeDrag || this.activeDrag.interactive.kind !== 'knob') return false;
-    const { interactive, startClientX, startRotation } = this.activeDrag;
+  handlePointerMove(clientX: number, clientY: number): boolean {
+    const drag = this.activeDrag;
+    if (!drag) return false;
+    const { interactive, startClientX, startClientY, startRotation } = drag;
+
+    if (interactive.kind === 'lever') {
+      const detents = interactive.detents;
+      if (!detents || detents.length === 0) return false;
+      const dx = clientX - startClientX;
+      const dy = clientY - startClientY;
+      if (!drag.moved && Math.hypot(dx, dy) > LEVER_CLICK_SLOP_PX) drag.moved = true;
+      if (!drag.moved) return true;
+      // Dragging down (positive dy) or right steps toward later detents.
+      const travel = (interactive.dragAxis ?? 'y') === 'x' ? dx : dy;
+      const step = Math.round(travel / (interactive.dragPixelsPerDetent ?? 26));
+      this.applyDetent(interactive, drag.startIndex + step);
+      return true;
+    }
+
     const delta = (clientX - startClientX) * 0.008;
-    const axis = interactive.axis ?? 'z';
     const min = interactive.minRotation ?? -Math.PI;
     const max = interactive.maxRotation ?? Math.PI;
-    const next = THREE.MathUtils.clamp(startRotation + delta, min, max);
-    if (axis === 'x') interactive.mesh.rotation.x = next;
-    else if (axis === 'y') interactive.mesh.rotation.y = next;
-    else interactive.mesh.rotation.z = next;
+    this.writeRotation(interactive, THREE.MathUtils.clamp(startRotation + delta, min, max));
     return true;
   }
 
   handlePointerUp(): void {
+    const drag = this.activeDrag;
     this.activeDrag = null;
+    if (!drag || drag.interactive.kind !== 'lever' || drag.moved) return;
+    // Tap without travel: advance one detent, wrapping at the end.
+    const detents = drag.interactive.detents;
+    if (!detents || detents.length === 0) return;
+    this.applyDetent(drag.interactive, (drag.startIndex + 1) % detents.length);
+  }
+
+  /** Move a lever to `index`, firing onDetent only when the position actually changes. */
+  private applyDetent(item: InteriorInteractive, index: number, notify = true): void {
+    const detents = item.detents;
+    if (!detents || detents.length === 0) return;
+    const clamped = THREE.MathUtils.clamp(index, 0, detents.length - 1);
+    if ((this.leverIndex.get(item.mesh) ?? 0) === clamped) return;
+    this.leverIndex.set(item.mesh, clamped);
+    if (notify) item.onDetent?.(clamped);
   }
 
   /** Raycast-free press (e.g. W/S pedals from keyboard). */
@@ -135,9 +205,34 @@ export class InteriorMicroInteractions {
     return true;
   }
 
+  /**
+   * Drive a lever from outside the 3D scene (HUD fallback, keyboard shortcut).
+   * Does not fire onDetent — the caller already owns the state change.
+   */
+  setLeverIndexByName(name: string, index: number): boolean {
+    const item = this.items.find((i) => i.mesh.name === name && i.kind === 'lever');
+    if (!item) return false;
+    this.applyDetent(item, index, false);
+    return true;
+  }
+
+  getLeverIndexByName(name: string): number | null {
+    const item = this.items.find((i) => i.mesh.name === name && i.kind === 'lever');
+    if (!item) return null;
+    return this.leverIndex.get(item.mesh) ?? 0;
+  }
+
   update(deltaTime: number): void {
     const dt = Math.min(deltaTime, 0.1);
     for (const item of this.items) {
+      if (item.kind === 'lever') {
+        const detents = item.detents;
+        if (!detents || detents.length === 0) continue;
+        const target = detents[this.leverIndex.get(item.mesh) ?? 0] ?? 0;
+        const current = this.readRotation(item);
+        this.writeRotation(item, THREE.MathUtils.lerp(current, target, 1 - Math.pow(0.0001, dt)));
+        continue;
+      }
       if (item.kind !== 'button') continue;
       const rest = this.restPositions.get(item.mesh);
       if (!rest) continue;

--- a/src/views/CarModeView.tsx
+++ b/src/views/CarModeView.tsx
@@ -32,7 +32,14 @@ import {
   isCarCenterDisplayHit,
   cycleCarDisplayPage,
   setCarWeather,
-  CarModeState
+  setCabinLeverHandlers,
+  cycleWiperStalk,
+  setCarGear,
+  gearHopCount,
+  GEAR_POSITIONS,
+  CarModeState,
+  type GearPosition,
+  type WiperStalkPosition,
 } from '../car';
 import { DashboardUI } from '../car/DashboardUI';
 import { VehicleDynamics, VehicleTelemetry } from '../car/VehicleDynamics';
@@ -45,6 +52,8 @@ type HudMode = 'full' | 'compact' | 'immersive';
 
 const HUD_MODE_STORAGE_KEY = 'webgpu_streetview_car_hud_mode';
 const HUD_LONG_PRESS_MS = 500;
+/** Spacing between the extra panorama hops a 2/3 gear queues. */
+const GEAR_HOP_INTERVAL_MS = 550;
 
 /**
  * CarModeView - The car interior driving experience.
@@ -68,7 +77,7 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
   
   const {
     wipersEnabled,
-    toggleWipers,
+    setWipers,
     headlightsOn,
     toggleHeadlights,
     highBeam,
@@ -161,7 +170,21 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
   
   // GPS/Map state
   const [isMapOpen, setIsMapOpen] = useState(false);
-  
+
+  // Physical cabin levers: the 3D stalk/shifter own this state, the HUD rows
+  // below are thin fallbacks for keyboard users and non-raycastable modes.
+  const [wiperStalk, setWiperStalkState] = useState<WiperStalkPosition>('off');
+  const [gear, setGearState] = useState<GearPosition>('D');
+  const gearRef = useRef<GearPosition>('D');
+  gearRef.current = gear;
+  /** Timers for the extra hops a 2/3 gear queues after the first advance. */
+  const pendingHopsRef = useRef<number[]>([]);
+
+  const cancelPendingHops = useCallback(() => {
+    for (const id of pendingHopsRef.current) window.clearTimeout(id);
+    pendingHopsRef.current = [];
+  }, []);
+
   // Car state refs — carHeading, heading, pitch come from hooks; kept in sync for animate loop
   const carHeadingRef = useRef(carHeading);
   carHeadingRef.current = carHeading;
@@ -424,6 +447,7 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
   // Handle thrust from W/S keys for body pitch effect
   const handleThrust = useCallback((direction: 'forward' | 'backward') => {
     if (controlMode === 'freeLook') return; // Car is locked when looking around
+    if (gearHopCount(gearRef.current) === 0) return; // Parked in P/N
     pitchImpulseRef.current = direction === 'forward' ? -2 : 1;
     dynamicsRef.current?.noteThrust(direction);
     triggerCarInteriorPress(direction === 'forward' ? 'gasPedal' : 'brakePedal');
@@ -439,9 +463,66 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
     setIsMapOpen(prev => !prev);
   }, []);
 
+  /**
+   * Gear-aware movement: P/N hold the car still, R flips forward/backward, and
+   * D/2/3 consume 1/2/3 panorama hops per input. The extra hops are queued
+   * rather than fired at once so each one starts from the panorama the
+   * previous hop landed on.
+   */
   const handleNavigate = useCallback((direction: 'forward' | 'backward' | 'left' | 'right') => {
-    advance(direction, carHeading);
-  }, [advance, carHeading]);
+    const selected = gearRef.current;
+    const hops = gearHopCount(selected);
+    if (hops === 0) return;
+
+    let resolved = direction;
+    if (selected === 'R') {
+      if (direction === 'forward') resolved = 'backward';
+      else if (direction === 'backward') resolved = 'forward';
+    }
+
+    cancelPendingHops();
+    advance(resolved, carHeading);
+    // Only forward/backward travel multiplies; turns stay a single hop.
+    if (resolved !== 'forward' && resolved !== 'backward') return;
+    for (let i = 1; i < hops; i++) {
+      const id = window.setTimeout(() => {
+        if (gearRef.current !== selected) return;
+        advance(resolved, carHeadingRef.current);
+      }, i * GEAR_HOP_INTERVAL_MS);
+      pendingHopsRef.current.push(id);
+    }
+  }, [advance, carHeading, cancelPendingHops]);
+
+  // Keep the HUD, app state and 3D levers in step when the driver grabs a
+  // stalk or the shifter in the cabin.
+  useEffect(() => {
+    setCabinLeverHandlers({
+      onWiperStalk: (position) => {
+        setWiperStalkState(position);
+        setWipers(position !== 'off');
+      },
+      onGear: (next) => {
+        cancelPendingHops();
+        setGearState(next);
+      },
+    });
+    return () => setCabinLeverHandlers({});
+  }, [setWipers, cancelPendingHops]);
+
+  useEffect(() => cancelPendingHops, [cancelPendingHops]);
+
+  // HUD fallbacks — drive the same API the physical levers do.
+  const handleCycleWipers = useCallback(() => {
+    const next = cycleWiperStalk();
+    setWiperStalkState(next);
+    setWipers(next !== 'off');
+  }, [setWipers]);
+
+  const handleSelectGear = useCallback((next: GearPosition) => {
+    cancelPendingHops();
+    setGearState(next);
+    setCarGear(next);
+  }, [cancelPendingHops]);
   
   const handleToggleRadio = useCallback(async () => {
     const newState = !isRadioPlaying;
@@ -591,7 +672,7 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
         onWind={setWind}
         onTimeOfDay={handleTimeOfDayChange}
         onToggleRoof={toggleRoof}
-        onToggleWipers={toggleWipers}
+        onToggleWipers={handleCycleWipers}
         onToggleVehicle={handleToggleVehicle}
         onToggleHeadlights={toggleHeadlights}
         onToggleHighBeam={toggleHighBeam}
@@ -619,7 +700,7 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
         stationTags={stationTags}
         speedKmh={telemetry.speedKmh}
         rpm={telemetry.rpm}
-        gear={telemetry.gear}
+        gear={gear === 'D' || gear === '2' || gear === '3' ? telemetry.gear : gear}
       />
       
       {/* Control Mode Indicator (small overlay) */}
@@ -745,6 +826,78 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
         </button>
       </div>
       
+      {/* Lever fallbacks — the cabin stalk/shifter are the primary controls, but
+          free-look and keyboard-only users still need to reach them. */}
+      {hudMode !== 'immersive' && (
+        <div
+          onMouseDown={(e) => e.stopPropagation()}
+          onMouseUp={(e) => e.stopPropagation()}
+          onMouseMove={(e) => e.stopPropagation()}
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            position: 'absolute',
+            top: 10,
+            right: 10,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '6px',
+            padding: '8px 10px',
+            background: 'rgba(15, 20, 25, 0.8)',
+            backdropFilter: 'blur(8px)',
+            border: '1px solid rgba(255,255,255,0.1)',
+            borderRadius: '12px',
+            color: '#fff',
+            fontFamily: "'SF Pro Display', system-ui, sans-serif",
+            fontSize: '10px',
+            zIndex: 101,
+            userSelect: 'none',
+            pointerEvents: 'auto',
+          }}
+        >
+          <div style={{ opacity: 0.7 }}>Gear</div>
+          <div role="group" aria-label="Gear selector" style={{ display: 'flex', gap: '3px' }}>
+            {GEAR_POSITIONS.map((option) => (
+              <button
+                key={option}
+                onClick={() => handleSelectGear(option)}
+                aria-pressed={gear === option}
+                aria-label={`Select gear ${option}`}
+                style={{
+                  width: '22px',
+                  padding: '4px 0',
+                  background: gear === option ? 'rgba(0,212,255,0.25)' : 'rgba(255,255,255,0.05)',
+                  border: '1px solid rgba(255,255,255,0.1)',
+                  borderRadius: '6px',
+                  color: gear === option ? '#00d4ff' : 'rgba(255,255,255,0.6)',
+                  cursor: 'pointer',
+                  fontSize: '10px',
+                  fontWeight: 600,
+                }}
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+          <button
+            onClick={handleCycleWipers}
+            aria-label={`Wiper stalk: ${wiperStalk}. Activate to cycle.`}
+            title="Wiper stalk — Off / Int / Low / High"
+            style={{
+              padding: '4px 8px',
+              background: wiperStalk === 'off' ? 'rgba(255,255,255,0.05)' : 'rgba(0,212,255,0.2)',
+              border: '1px solid rgba(255,255,255,0.1)',
+              borderRadius: '6px',
+              color: wiperStalk === 'off' ? 'rgba(255,255,255,0.6)' : '#00d4ff',
+              cursor: 'pointer',
+              fontSize: '10px',
+              textTransform: 'capitalize',
+            }}
+          >
+            {`Wipers: ${wiperStalk}`}
+          </button>
+        </div>
+      )}
+
       {/* Steering wheel overlay - shows when steering */}
       <div style={{
         position: 'absolute',


### PR DESCRIPTION
Moves vehicle systems off HUD on/off buttons and onto the column and shifter meshes that previously did nothing.

## What changed

**New `lever` interactive kind** (`InteriorMicroInteractions.ts`)
- A detented control: tap cycles to the next detent (wrapping), drag steps through detents along a configurable pointer axis, and `update()` eases the rotation into place.
- Optional `pivot` lets a small grab target (the shifter knob) drive a larger assembly (shaft + boot), and `initialDetent` sets the resting position at build time.
- `setLeverIndexByName` / `getLeverIndexByName` let HUD fallbacks move a lever without re-firing its callback.

**`CabinControls.ts`** — one place for position names, detent angles, wiper speeds, mesh names and the gear → hop-count table, shared by the meshes, the car-mode API and the HUD.

**Wiper stalk** (`CarInteriorBuilder.ts`) — built on the right of the steering column, carrying the column tilt so the detent reads as an up/down flick. Cycles Off → Intermittent → Low → High, driving the existing `setWipersActive` / `setWiperSpeed` path. The animator gained a real intermittent mode that parks the blades between single sweeps rather than just sweeping slowly.

**Gear shifter** (`CarInteriorDetailProps.ts`) — the existing `shifterKnob` becomes a P/R/N/D/2/3 gate, resting in D so current behaviour is unchanged until the driver shifts.

**Gears drive advance hop count** (`CarModeView.tsx`) — P/N hold the car still (throttle input included), R flips forward/backward, and D/2/3 consume 1/2/3 panorama hops per forward input. Extra hops are queued on a timer instead of fired at once so each starts from the panorama the previous one landed on, and they are cancelled if the gear changes mid-sequence.

**Two-way sync** — `setCabinLeverHandlers` reports driver-initiated lever moves so app state and the HUD follow the physical controls; `setWiperStalkPosition` / `setCarGear` move the meshes when the change starts from a button or keyboard shortcut. `toggleWipers` and `setCarWipers` now route through the stalk, so the existing wipers shortcut keeps the stalk in step.

**HUD fallbacks** — a compact gear selector and wiper-stalk readout (aria-labelled, hidden in immersive mode) for keyboard users and modes where raycasting can't reach the cabin. The existing dashboard wipers button now cycles the stalk instead of driving the animator directly.

## Testing

- `npx vitest run` — 40 files, 328 tests pass, including new coverage for the lever state machine (tap cycling, drag clamping, edit-mode gating, pivot easing, external moves not re-firing callbacks) and the gear/wiper tables.
- `npx tsc --noEmit` clean.
- `npm run build` fails the bundle-budget check, but that predates this branch: `main` at `1623fea` builds to 424.43 KB gzip against a 400 KB budget; this diff adds ~0.7 KB. Not addressed here.

Interaction still goes through `uiMouse` / Shift+click so free-look doesn't steal hits. Redundant HUD toggles were deliberately kept rather than trimmed — they're the accessibility path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoJs5RPKm5K3j2xmdhujzd)_