### PR TITLE
Gear-linked multi-hop advance in cruise mode + ×N HUD chip

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -16,6 +16,7 @@ import { useSnapshots } from '../hooks/useSnapshots';
 import { useGlobeMode } from '../hooks/useGlobeMode';
 import { useKeyboardShortcuts, useAnnouncer, SkipLink } from '../hooks/useKeyboardShortcuts';
 import { useCruiseMode } from '../hooks/useCruiseMode';
+import { getGearHopCount } from '../car';
 import { useAutopilot } from '../hooks/useAutopilot';
 import { buildAppKeyboardShortcuts } from '../hooks/useAppKeyboardShortcuts';
 import { useGlobeTeleport } from '../hooks/useGlobeTeleport';
@@ -58,6 +59,9 @@ export function AppShell() {
   const { advanceSafe, teleportSafe, teleportToPanoSafe, panoCache } = useAdvanceSafe();
   const routePrefetch = useRoutePrefetch();
   const { viewMode, toggleViewMode } = useViewMode();
+  // Read by the cruise tick, which must see the live mode without re-arming.
+  const viewModeRef = useRef(viewMode);
+  viewModeRef.current = viewMode;
   const env = useEnvironmentSettings();
   const panels = useAppPanels();
   const { isOnline, hasServiceWorker } = useOfflineStatus();
@@ -145,6 +149,10 @@ export function AppShell() {
     isTransitioning,
     setNavPending: connection.setNavPending,
     loadOfflineRouteGraphNodes: routePrefetch.loadAllCachedNodes,
+    // In car mode the gearshift is the speed selector: P/N park cruise, D
+    // keeps the classic single hop, 2/3 chain extra hops per tick. Free-look
+    // has no gearbox, so it always cruises one hop at a time.
+    hopsPerTick: () => (viewModeRef.current === 'car' ? getGearHopCount() : 1),
   });
   onAuthFailureRef.current = () => setIsCruiseMode(false);
 

--- a/src/hooks/__tests__/useCruiseMode.gear.test.tsx
+++ b/src/hooks/__tests__/useCruiseMode.gear.test.tsx
@@ -1,0 +1,111 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { useCruiseMode } from '../useCruiseMode';
+
+/**
+ * Cruise ticks are gear-aware: P/N park, D does one hop, 2/3 chain extra hops
+ * within a single tick. These tests drive the tick timer directly.
+ */
+
+function makePanorama(panoIds: string[]) {
+  let index = 0;
+  return {
+    pano: {
+      getPano: () => panoIds[Math.min(index, panoIds.length - 1)],
+      getPosition: () => null,
+    } as unknown as google.maps.StreetViewPanorama,
+    step: () => {
+      index++;
+    },
+  };
+}
+
+function setup(hopsPerTick: () => number, panoIds: string[]) {
+  const harness = makePanorama(panoIds);
+  const advanceSafe = vi.fn(async () => {
+    harness.step();
+  });
+  const view = renderHook(() =>
+    useCruiseMode({
+      panorama: harness.pano,
+      advanceSafe,
+      mapsAuthFailed: false,
+      heading: 0,
+      isTransitioning: false,
+      setNavPending: () => {},
+      hopsPerTick,
+    })
+  );
+  return { advanceSafe, view };
+}
+
+/**
+ * Fire exactly one cruise tick, then disengage so the interval stops before
+ * letting the tick's chained hops settle (disengaging does not cancel the
+ * in-flight chain, which is what we want to observe).
+ */
+async function runTick(view: { result: { current: { setIsCruiseMode: (v: boolean) => void } } }) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(3000);
+  });
+  act(() => view.result.current.setIsCruiseMode(false));
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(10000);
+  });
+}
+
+describe('useCruiseMode gear-aware hops', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('advances once per tick in D', async () => {
+    const { advanceSafe, view } = setup(() => 1, ['a', 'b', 'c', 'd']);
+    act(() => view.result.current.setIsCruiseMode(true));
+    await runTick(view);
+    expect(advanceSafe).toHaveBeenCalledTimes(1);
+  });
+
+  it('chains three hops in one tick in gear 3', async () => {
+    const { advanceSafe, view } = setup(() => 3, ['a', 'b', 'c', 'd']);
+    act(() => view.result.current.setIsCruiseMode(true));
+    await runTick(view);
+    expect(advanceSafe).toHaveBeenCalledTimes(3);
+  });
+
+  it('issues no hop while parked in P/N', async () => {
+    const { advanceSafe, view } = setup(() => 0, ['a', 'b']);
+    act(() => view.result.current.setIsCruiseMode(true));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(9000); // three parked ticks
+    });
+    expect(advanceSafe).not.toHaveBeenCalled();
+    // Parked ticks are not "stuck" hops, so cruise stays engaged.
+    expect(view.result.current.isCruiseMode).toBe(true);
+  });
+
+  it('stops the chain early at a dead end', async () => {
+    // Pano id never changes → the first hop reports no movement.
+    const { advanceSafe, view } = setup(() => 3, ['a']);
+    act(() => view.result.current.setIsCruiseMode(true));
+    await runTick(view);
+    expect(advanceSafe).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts the remaining chain when the driver shifts to P mid-tick', async () => {
+    let hops = 3;
+    const { advanceSafe, view } = setup(() => hops, ['a', 'b', 'c', 'd']);
+    act(() => view.result.current.setIsCruiseMode(true));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+      await vi.advanceTimersByTimeAsync(1600); // first hop resolved
+    });
+    hops = 0;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000);
+    });
+    expect(advanceSafe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useCruiseMode.ts
+++ b/src/hooks/useCruiseMode.ts
@@ -18,7 +18,16 @@ export interface UseCruiseModeOptions {
    * the actual hop.
    */
   loadOfflineRouteGraphNodes?: () => Promise<RouteGraphNode[]>;
+  /**
+   * Panorama hops to consume per cruise tick, read fresh on every tick so a
+   * mid-cruise gear change takes effect immediately. `0` (P/N) parks the car:
+   * cruise stays engaged but no hop is issued. Defaults to a single hop.
+   */
+  hopsPerTick?: () => number;
 }
+
+/** Spacing between the extra hops a 2/3 gear queues within one cruise tick. */
+export const CRUISE_CHAINED_HOP_INTERVAL_MS = 550;
 
 /** Initial bearing (degrees, 0–360) from point A to point B. */
 function bearingBetween(
@@ -43,6 +52,7 @@ export function useCruiseMode({
   isTransitioning,
   setNavPending,
   loadOfflineRouteGraphNodes,
+  hopsPerTick,
 }: UseCruiseModeOptions) {
   const [isCruiseMode, setIsCruiseMode] = useState(false);
   const offlineNodesRef = useRef<RouteGraphNode[]>([]);
@@ -61,6 +71,10 @@ export function useCruiseMode({
   const useTransitionRef = useRef(isTransitioning);
   useTransitionRef.current = isTransitioning;
   const cruiseFailCountRef = useRef(0);
+  // A multi-hop tick can outlast the tick interval; this keeps ticks serial.
+  const hopInFlightRef = useRef(false);
+  const hopsPerTickRef = useRef(hopsPerTick);
+  hopsPerTickRef.current = hopsPerTick;
 
   useEffect(() => {
     if (!isCruiseMode || !panorama || !advanceSafe) {
@@ -69,6 +83,7 @@ export function useCruiseMode({
         cruiseIntervalRef.current = null;
       }
       cruiseFailCountRef.current = 0;
+      hopInFlightRef.current = false;
       return;
     }
     // Commit the current view heading as the travel direction the moment cruise
@@ -84,15 +99,12 @@ export function useCruiseMode({
         })
         .catch((err) => console.warn('[CruiseMode] Failed to load offline route graph nodes', err));
     }
-    const hop = async () => {
-      if (useTransitionRef.current) {
-        console.log('[CruiseMode] Skipping hop - still transitioning');
-        return;
-      }
-      if (mapsAuthFailed) {
-        setIsCruiseMode(false);
-        return;
-      }
+    /**
+     * One panorama hop along the committed travel heading. Returns true when
+     * the panorama actually changed, and self-corrects the travel heading to
+     * the direction we really moved so the next hop follows the road.
+     */
+    const singleHop = async (): Promise<boolean> => {
       const panoIdBefore = panorama.getPano();
       const posBefore = panorama.getPosition() ?? null;
       // Prefer a known next pano from a prefetched route graph, if we have
@@ -112,13 +124,54 @@ export function useCruiseMode({
       await new Promise(r => setTimeout(r, 1500));
       const panoIdAfter = panorama.getPano();
       if (panoIdAfter && panoIdAfter !== panoIdBefore) {
-        cruiseFailCountRef.current = 0;
         // Follow the road: steer future hops along the direction actually
         // travelled, independent of where the head is looking.
         const posAfter = panorama.getPosition() ?? null;
         if (posBefore && posAfter) {
           cruiseHeadingRef.current = bearingBetween(posBefore, posAfter);
         }
+        return true;
+      }
+      return false;
+    };
+
+    const hop = async () => {
+      if (hopInFlightRef.current) return;
+      if (useTransitionRef.current) {
+        console.log('[CruiseMode] Skipping hop - still transitioning');
+        return;
+      }
+      if (mapsAuthFailed) {
+        setIsCruiseMode(false);
+        return;
+      }
+
+      // Gear decides how far one tick travels: P/N park, D one hop, 2/3 chain
+      // two or three. Read fresh each tick so shifting takes effect at once.
+      const hops = hopsPerTickRef.current ? hopsPerTickRef.current() : 1;
+      if (hops <= 0) return;
+
+      hopInFlightRef.current = true;
+      let movedAny = false;
+      try {
+        for (let i = 0; i < hops; i++) {
+          // Re-read the gear between chained hops so shifting into P/N (or
+          // disengaging cruise) stops the chain instead of finishing it.
+          if (i > 0) {
+            await new Promise(r => setTimeout(r, CRUISE_CHAINED_HOP_INTERVAL_MS));
+            if (hopsPerTickRef.current && hopsPerTickRef.current() <= 0) break;
+          }
+          const moved = await singleHop();
+          movedAny = movedAny || moved;
+          // Dead end: no point spending the remaining hops of this tick.
+          if (!moved) break;
+        }
+      } finally {
+        hopInFlightRef.current = false;
+      }
+
+      if (movedAny) {
+        cruiseFailCountRef.current = 0;
       } else {
         cruiseFailCountRef.current += 1;
         console.warn(`[CruiseMode] Hop did not advance (${cruiseFailCountRef.current}/3)`);
@@ -133,6 +186,7 @@ export function useCruiseMode({
     return () => {
       if (cruiseIntervalRef.current) clearInterval(cruiseIntervalRef.current);
       cruiseIntervalRef.current = null;
+      hopInFlightRef.current = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isCruiseMode, panorama, advanceSafe, mapsAuthFailed]);

--- a/src/views/CarModeView.tsx
+++ b/src/views/CarModeView.tsx
@@ -179,10 +179,13 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
   gearRef.current = gear;
   /** Timers for the extra hops a 2/3 gear queues after the first advance. */
   const pendingHopsRef = useRef<number[]>([]);
+  /** Hop multiplier currently being served (0 when not multi-hopping). */
+  const [chainingHops, setChainingHops] = useState(0);
 
   const cancelPendingHops = useCallback(() => {
     for (const id of pendingHopsRef.current) window.clearTimeout(id);
     pendingHopsRef.current = [];
+    setChainingHops(0);
   }, []);
 
   // Car state refs — carHeading, heading, pitch come from hooks; kept in sync for animate loop
@@ -483,11 +486,14 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
     cancelPendingHops();
     advance(resolved, carHeading);
     // Only forward/backward travel multiplies; turns stay a single hop.
-    if (resolved !== 'forward' && resolved !== 'backward') return;
+    if ((resolved !== 'forward' && resolved !== 'backward') || hops < 2) return;
+
+    setChainingHops(hops);
     for (let i = 1; i < hops; i++) {
       const id = window.setTimeout(() => {
         if (gearRef.current !== selected) return;
         advance(resolved, carHeadingRef.current);
+        if (i === hops - 1) setChainingHops(0);
       }, i * GEAR_HOP_INTERVAL_MS);
       pendingHopsRef.current.push(id);
     }
@@ -703,6 +709,36 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
         gear={gear === 'D' || gear === '2' || gear === '3' ? telemetry.gear : gear}
       />
       
+      {/* Multi-hop chip — shows the gear's hop multiplier while a 2/3 gear is
+          working through the extra panorama hops it queued. */}
+      {chainingHops > 1 && (
+        <div
+          role="status"
+          aria-live="polite"
+          aria-label={`Advancing ${chainingHops} panoramas`}
+          style={{
+            position: 'absolute',
+            top: 10,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            padding: '4px 12px',
+            background: 'rgba(0, 212, 255, 0.18)',
+            border: '1px solid rgba(0,212,255,0.5)',
+            borderRadius: '999px',
+            color: '#00d4ff',
+            fontFamily: "'SF Pro Display', system-ui, sans-serif",
+            fontSize: '13px',
+            fontWeight: 700,
+            letterSpacing: '0.5px',
+            zIndex: 102,
+            pointerEvents: 'none',
+            userSelect: 'none',
+          }}
+        >
+          ×{chainingHops}
+        </div>
+      )}
+
       {/* Control Mode Indicator (small overlay) */}
       <div
         onMouseDown={(e) => e.stopPropagation()}


### PR DESCRIPTION
Closes #167.

The manual side of this issue already landed with the physical shifter: `GEAR_HOP_COUNTS` in `src/car/interior/CabinControls.ts` maps P/N → 0, R → 1 reversed, D → 1, 2 → 2, 3 → 3, and `CarModeView.handleNavigate` queues the extra hops sequentially. This PR finishes the remaining two pieces from the proposal.

## Cruise mode is now gear-aware

`useCruiseMode` takes an optional `hopsPerTick: () => number`, read fresh on every tick so a mid-cruise shift takes effect immediately. `AppShell` supplies `getGearHopCount()` in car mode and a constant `1` in free-look (no gearbox there).

Per tick:
- **P / N (0 hops)** — no hop issued; cruise stays engaged rather than counting the tick as a stuck hop.
- **D (1 hop)** — unchanged behaviour.
- **2 / 3** — two or three hops chained sequentially, spaced by `CRUISE_CHAINED_HOP_INTERVAL_MS` (550 ms, matching the manual `GEAR_HOP_INTERVAL_MS`).

The existing single hop was factored into `singleHop()`, which keeps the road-following bearing correction, so each chained hop starts from the panorama the previous one landed on and re-aims along the direction actually travelled.

Chain safety:
- Re-checks the gear between hops, so shifting into P mid-chain stops the rest of the tick.
- Stops early at a dead end instead of spending the remaining hops (also limits wasted pano loads / billing).
- A tick is marked in-flight, so a 3-hop chain that outlasts the 3 s interval can't overlap the next tick.
- The stuck-hop auto-disable now keys off "did any hop in this tick move", not just the last one.

**Hold-pause:** sequential holds, per hop — the option the issue left open. Each hop goes through the existing `advanceSafe` → `armHold` path unchanged, so panorama stability behaves exactly as it does today; nothing new can flash tiles.

## HUD chip

Car mode shows a `×2` / `×3` chip (top centre, `role="status"`, `aria-live="polite"`) while a multi-hop input is being served, cleared on the last queued hop or whenever pending hops are cancelled (gear change, unmount).

## Testing

- New `src/hooks/__tests__/useCruiseMode.gear.test.tsx` — 5 cases: one hop in D, three chained in gear 3, no hop while parked with cruise still engaged, early stop at a dead end, and abort on a mid-tick shift to P.
- `npm run typecheck`, `npm run lint`, and the full suite pass (41 files, 333 tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CDmUPy19TP8xg9dK8QEVry)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cruise mode now advances multiple panorama hops per tick based on the selected gear.
  * Cruise automatically stops advancing when parked or shifted into neutral.
  * Added a “Multi-hop” status indicator showing chained navigation progress.
  * Cruise navigation adapts safely to dead ends and mid-sequence gear changes.

* **Bug Fixes**
  * Prevented overlapping cruise movements and ensured navigation stops cleanly when cruise mode is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->