### PR TITLE
Weather effects cohesion: unify presets, wire compute storage, add cinematic camera FX

### DIFF
--- a/docs/GRAPHICS.md
+++ b/docs/GRAPHICS.md
@@ -1,0 +1,221 @@
+# Graphics — Weather & Atmosphere Look Targets
+
+Reference for the WebGPU weather post-process stack: what each preset is
+*supposed* to look like, which knob controls it, and how the three render paths
+are kept in agreement.
+
+Related: `docs/RENDERER_FALLBACK.md` (backend selection), `AGENTS.md`
+("Shader Uniform Layouts"), `src/renderer/weatherUniformLayout.ts` (the 40-float
+contract).
+
+---
+
+## 1. The three paths
+
+| Path | Entry point | Notes |
+|------|-------------|-------|
+| Fragment (default) | `public/shaders/weather-post.wgsl` | HDR `rgba16float`, full effect set |
+| Compute (`?weather=compute`) | `public/shaders/weather-post-compute.wgsl` | `rgba32float` storage texture + blit; adds the depth-proxy storage target |
+| WebGL2 fallback | `FRAGMENT_SHADER` in `src/renderer/WebGLFallbackRenderer.ts` | SDR approximation, no fbm rolling layer, no camera FX |
+
+All three read the same 40-float uniform block. Shared WGSL helpers are held
+byte-identical between the two WGSL paths and guarded by
+`src/renderer/weatherShaderParity.test.ts` — if you edit one, edit both.
+
+---
+
+## 2. Cohesion model
+
+Atmospheric channels are no longer independent sliders. `src/renderer/weatherCohesion.ts`
+derives them together on the CPU (cheap, testable, identical for every backend)
+from four rules:
+
+1. **Precipitation implies cloud cover.** `overcast = 0.85·precip + 0.45·fog`,
+   and overcast multiplies down `lightShaftsIntensity`, `lensFlareIntensity`
+   and `anamorphicStreak`.
+2. **Rain wets the air.** `humidityHaze` follows rain (and, weakly, snow/fog);
+   precipitation adds its own low ground mist to `fogDensity` even with the fog
+   slider at zero.
+3. **Rain scrubs dust.** `dustIntensity` scales with `(1 − rain)`; snow only
+   halves it.
+4. **Fog is two different quantities.** `fogDensity` is a Beer–Lambert
+   extinction coefficient integrated along the view-depth proxy; `fogIntensity`
+   is a flat screen-wide aerial wash. They used to carry the *same* slider
+   value into both slots, which double-counted inside the shader.
+
+### View-depth proxy
+
+Street View gives us no depth buffer, so `viewDepthProxy()` reconstructs a
+usable one from screen Y and camera pitch:
+
+- `viewHorizonY(cameraPitch)` — where the horizon sits on screen (0.5 = level,
+  ~90° vertical FOV ⇒ one pitch unit ≈ two screens).
+- Above that line ⇒ depth `1.0` (sky / skyline, effectively at infinity).
+- Below it ⇒ `0.06 / (uv.y − horizonY)`, a hyperbolic falloff standing in for
+  `eyeHeight / tan(angleBelowHorizon)`.
+
+This one function now feeds height fog, precipitation attenuation and the DOF
+circle of confusion, so those three effects agree about where the ground is.
+In the compute path the value is also written to the `r32float` storage texture
+at binding 6 every dispatch.
+
+---
+
+## 3. Preset look targets
+
+Slider values are the UI 0–100 range from `WeatherPanel.tsx`.
+
+### ☀️ Clear (rain 0 / snow 0 / fog 0)
+Untouched panorama plus grading. Sun FX at full strength: shafts sit at their
+0.35 floor (nothing in the air to scatter in), flare 0.4, anamorphic 0.5.
+No fog, no haze; dust visible only when the WASM tile is feeding.
+
+### 🌧️ Rain (rain 60, wind 30)
+Cool blue-grey overcast. Direct-sun FX drop by about half (overcast 0.51).
+Streaks slant with wind, lens droplets refract the scene, humidity haze
+softens the far field, and a shallow ground mist appears at the horizon line.
+Scene darkening −26% by day, easing to −12% at night so the readable-night
+floor from #171 survives. Dust drops to ~40% of its clear-day level.
+
+### ⛈️ Storm (rain 100, wind 80)
+As above, pushed to a near-black sky: overcast 0.85 ⇒ lens flare 0.4 → 0.06.
+Ground mist reaches `fogDensity` 0.28 with the fog slider still at zero.
+
+### ❄️ Snow / 🌨️ Blizzard (snow 70–100)
+Flakes stay bright and gain a further +35% when headlights are on at night —
+they should read as *lit by the car*, not self-luminous. Snow suppresses dust
+only halfway and adds far less humidity haze than rain (cold air holds less
+water). Overcast is slightly weaker than the equivalent rain value.
+
+### 🌫️ Fog (fog slider)
+Thin fog (≤20) lifts into an elevated haze band that leaves the road clear;
+heavy fog (≥60) settles into a low bank hugging the ground and reaching full
+extinction at the horizon. At night the palette switches from neutral grey to
+the blue index, and any indexed colour is blended toward the night fog colour
+so a coloured fog can't stay bright in the dark.
+
+### 🌅 Sunrise / 🌇 Sunset
+Both are now camera-aware. Warm light concentrates around the sun's *actual*
+screen azimuth and the tracked horizon line; the cool shadow tint fills the
+opposite half of the sky.
+
+---
+
+## 4. Before / after notes
+
+Measured from the shader math (this container has no GPU; these are the
+analytic coverage values the code produces, not screenshots).
+
+**Fog, slider at 40, level camera.** Old code keyed everything off
+`smoothstep(0.35, 0, |uv.y − 0.5|)`, i.e. a horizontal stripe pinned to the
+middle of the screen regardless of where the camera was pointing:
+
+| Pixel | Old coverage | New coverage |
+|-------|--------------|--------------|
+| Near ground (`uv.y` 0.9) | 0.06 | 0.38 |
+| Horizon (`uv.y` 0.51) | 0.60 | 0.88 |
+| Sky (`uv.y` 0.2) | 0.06 | 0.54 |
+
+Before: a band across the middle of the frame that stayed put when you pitched
+the camera, with the road in front of you *clearer* than the mid-distance.
+After: coverage grows monotonically with distance, tracks the horizon as you
+look up and down, and thins overhead — aerial perspective instead of a stripe.
+
+**Fog double-count.** `fogIntensity` and `fogDensity` both received
+`slider/100`. At slider 100 their sum reached `0.2 + 1.8·groundProximity`
+before the `×(0.75 + roll)` rolling factor, saturating the 0.95 clamp wherever
+`groundProximity > 0.6` — so the top half of the fog slider did nothing
+visible. They are now 0.55× and 1.15× the slider respectively, feeding
+different terms.
+
+**Precipitation vs. fog.** Rain streaks and snowflakes previously composited at
+full brightness *over* the fog wash, so a blizzard in dense fog showed crisp
+flakes on a flat grey wall. They now fade with `precipVisibility = 1 − 0.75·fogMask`.
+
+**Precipitation vs. sun.** A downpour used to sit under a lens-flared,
+light-shafted sky. Overcast now suppresses all three sun FX together.
+
+**Sunrise.** `applySunrise` was pinned to `uv.y 0.5` and ignored heading
+entirely — dawn light stayed glued to the same screen region while you turned,
+and disagreed with `sunsetHorizonGlow`, which was already camera-aware. Both
+now use `worldAzimuthToScreenX` and `viewHorizonY`.
+
+**Night rain.** Rain multiplied the scene by `1 − 0.22·rain` regardless of time
+of day, which crushed the #171 readable-night floor during a night storm.
+The factor now interpolates to `0.10` at full night, and streaks pick up
+headlight warmth.
+
+**Compute-path dust.** The compute variant had no access to the WASM noise tile,
+so its dust was uniform speckle while the fragment path showed drifting
+clumps — the two paths visibly disagreed under `?weather=compute`. The tile is
+now bound and both sample it identically.
+
+**Compute path did not compile at all.** `weather-post-compute.wgsl` called
+`applyVolumetricLightShafts` with four arguments against a three-parameter
+declaration, so Tint rejected the whole module and `?weather=compute` (and the
+Ultra preset default) never produced a frame from the compute pipeline. WGSL is
+only compiled when a real GPU device exists, so no GPU-less CI run could catch
+it. Fixed by matching the fragment path's signature, and
+`src/renderer/weatherShaderCallArity.test.ts` now checks every local call's
+argument count statically. Validate locally with
+[`naga`](https://github.com/gfx-rs/wgpu/tree/trunk/naga):
+
+```bash
+cargo install naga-cli
+naga --validate 31 public/shaders/weather-post.wgsl
+naga --validate 31 public/shaders/weather-post-compute.wgsl
+```
+
+---
+
+## 5. Compute-path storage surfaces
+
+`ComputeWeatherPostProcessor` follows the `image_video_effects` 13-binding
+header. Status of each reserved surface:
+
+| Binding | Resource | Status |
+|---------|----------|--------|
+| 6 `writeDepthTexture` | full-res `r32float` | **real** — view-depth proxy, written every dispatch |
+| 12 `plasmaBuffer` | 64×64 WASM Perlin tile as 1024 `vec4`s | **real** — drives dust turbulence |
+| 4 `readDepthTexture` | 1×1 `rgba8unorm` | dummy — needs a ping-pong to be useful |
+| 7/8 `dataTextureA/B` | 1×1 `rgba32float` | dummy — reserved for GPU particle state |
+| 9 `dataTextureC` | 1×1 `rgba8unorm` | dummy |
+
+Still open: GPU-simulated precipitation particles (would use 7/8 for
+position/velocity state across frames) and reading last frame's depth from
+binding 4 for temporal effects.
+
+---
+
+## 6. Cinematic camera FX
+
+Depth of field and motion blur live behind `src/renderer/cinematicCameraFx.ts`
+and occupy uniform slots 38/39. They turn on only when **both** hold:
+
+- the active quality preset enables them — High = DOF, Ultra = DOF + motion blur
+  (`getActiveQualityLevel()`, overridable with `?quality=high|ultra`)
+- the user has not asked for reduced motion (`prefers-reduced-motion: reduce`)
+
+Motion blur additionally scales with travel speed published by
+`src/renderer/cameraMotionSignal.ts` (car telemetry, decaying to zero ~400 ms
+after the publisher stops), so a parked car gets none of it and it ramps in over
+the first ~40% of the speed range.
+
+Both effects share one 6-tap loop and early-out when both strengths are zero,
+so the default fragment path pays a single branch. DOF focuses at depth 0.45
+and defocuses toward infinity; motion blur streaks radially away from screen
+centre and is biased toward the frame edges.
+
+The WebGL2 fallback does not implement either — it ignores slots 38/39.
+
+---
+
+## 7. Editing checklist
+
+- Shared WGSL helper changed? Update **both** `weather-post.wgsl` and
+  `weather-post-compute.wgsl`; `weatherShaderParity.test.ts` will fail otherwise.
+- New uniform? It must fit the existing 40 floats or every consumer in
+  `weatherUniformLayout.ts`'s header comment changes in lockstep.
+- Preset retune? Put the intended look in §3 above and the measured delta in §4.
+- Coupling between channels belongs in `weatherCohesion.ts` (CPU, testable),
+  not duplicated into three shaders.

--- a/docs/RENDERER_FALLBACK.md
+++ b/docs/RENDERER_FALLBACK.md
@@ -102,7 +102,7 @@ Use this when changing rain/snow particle math in `weather-post.wgsl`, `weather-
 The WebGPU backend's second pass (weather rain/snow/fog/color grading) has two implementations that render the same effects from the same 40-float parameter layout:
 
 - **Fragment** (default): `src/renderer/WeatherPostProcessor.ts` + `public/shaders/weather-post.wgsl`. A single fullscreen-triangle render pass sampling the HDR intermediate texture.
-- **Compute**: `src/renderer/ComputeWeatherPostProcessor.ts` + `public/shaders/weather-post-compute.wgsl`. A compute pass (`@workgroup_size(16, 16, 1)`) writes into an `rgba32float` storage texture, followed by a cheap `textureLoad` blit render pass to the canvas. It exposes `image_video_effects`-compatible bindings for depth textures, data textures, and a `plasmaBuffer` storage array — currently bound to 1x1 dummy resources, reserved for future WASM-fed noise tiles (#128), volumetric fog, and GPU particles that want storage-buffer access a fragment pass can't offer efficiently.
+- **Compute**: `src/renderer/ComputeWeatherPostProcessor.ts` + `public/shaders/weather-post-compute.wgsl`. A compute pass (`@workgroup_size(16, 16, 1)`) writes into an `rgba32float` storage texture, followed by a cheap `textureLoad` blit render pass to the canvas. It exposes `image_video_effects`-compatible bindings for depth textures, data textures, and a `plasmaBuffer` storage array. Two of those are now backed by real resources: `writeDepthTexture` (binding 6) receives a full-res `r32float` view-depth proxy every dispatch, and `plasmaBuffer` (binding 12) carries the WASM-fed 64x64 noise tile (#128) as 1024 `vec4`s. The rest remain 1x1 dummies, reserved for GPU particles and temporal effects that want storage-buffer access a fragment pass can't offer efficiently.
 
 Both read the same `40-float` weather parameter layout, defined once in `src/renderer/weatherUniformLayout.ts` (`WeatherParamIndex`) and mirrored in both WGSL files' comments — see "Shader Uniform Layouts" in `AGENTS.md`.
 
@@ -125,9 +125,9 @@ Like `setBackend`, `setWeatherMode` persists to `localStorage` (`streetview.weat
 
 **This is WebGPU-only.** The WebGL2 fallback renderer remains fragment-only (a single-pass SDR approximation) — there is no WebGL2 compute path, and `?weather=compute` has no effect when the WebGL2 backend is active.
 
-Known gap: the compute path does not yet sample the WASM-computed 64x64 noise tile (`wasmNoiseTile` in `weather-post.wgsl`) that the fragment path uses for dust-cloud turbulence — `wasmNoiseEnabled` is read but has no visual effect in the compute shader yet. Rain, snow, fog, color grading, night/headlight lighting, and astronomical effects are otherwise at parity between the two paths.
+Rain, snow, fog, color grading, night/headlight lighting, astronomical effects, WASM dust turbulence, and the cinematic camera FX are at parity between the two paths; shared helper bodies are enforced identical by `src/renderer/weatherShaderParity.test.ts`.
 
-Compute bindings `readDepthTexture` / `writeDepthTexture` / `dataTextureA/B/C` / `plasmaBuffer` are intentionally backed by 1x1 dummy resources today. They are reserved extension points for WASM-fed noise tiles, volumetric fog, and GPU particles.
+Compute bindings still backed by 1x1 dummies: `readDepthTexture` (needs a ping-pong to read last frame's depth), `dataTextureA/B` (reserved for GPU particle state), and `dataTextureC`. See `docs/GRAPHICS.md` §5 for the current status table.
 
 ## Parity Notes
 

--- a/public/shaders/weather-post-compute.wgsl
+++ b/public/shaders/weather-post-compute.wgsl
@@ -11,12 +11,16 @@
 // 22:fogIntensity 23:fogDensity 24:fogHeight 25:fogColorIndex 26:lightShaftsIntensity
 // 27:heatShimmerIntensity 28:lensFlareIntensity 29:chromaticAberration 30:dustIntensity
 // 31:humidityHaze 32:shaderEffectsEnabled 33:cameraHeading 34:cameraPitch 35:wasmNoiseEnabled
-// 36:sunrise 37:anamorphicStreak 38-39:padding
+// 36:sunrise 37:anamorphicStreak 38:dofStrength 39:motionBlurStrength (padding slots reclaimed)
 //
-// NOTE: the compute path does not currently bind the 64x64 WASM noise tile
-// (see weather-post.wgsl's `wasmNoiseTile` storage buffer / #128), so
-// wasmNoiseEnabled is read but has no effect here yet — dust cloud density
-// stays uniform instead of following WASM-driven turbulence.
+// STORAGE SURFACES IN USE (formerly 1x1 dummies):
+//  - binding 6  writeDepthTexture : full-res r32float view-depth proxy, written
+//    every dispatch so later passes / probes can read the same depth the fog
+//    and DOF use. See viewDepthProxy() below.
+//  - binding 12 plasmaBuffer : the real 64x64 WASM Perlin tile (#128/#189),
+//    packed as 1024 vec4s, driving dust turbulence exactly like the fragment
+//    path's `wasmNoiseTile`.
+// Still dummies: readDepthTexture (4), dataTextureA/B (7/8), dataTextureC (9).
 
 // --- STANDARD image_video_effects HEADER ---
 @group(0) @binding(0) var u_sampler: sampler;
@@ -84,6 +88,36 @@ fn p_cameraPitch() -> f32     { return ep(34); }
 fn p_wasmNoiseEnabled() -> f32 { return ep(35); }
 fn p_sunrise() -> f32         { return ep(36); }
 fn p_anamorphicStreak() -> f32 { return ep(37); }
+fn p_dofStrength() -> f32     { return ep(38); }
+fn p_motionBlurStrength() -> f32 { return ep(39); }
+
+// ============================================================================
+// WASM noise tile (binding 12) — 64x64 f32 tile packed as 1024 vec4s.
+// Uploaded by src/wasm/wasmNoiseFeeder.ts via ComputeWeatherPostProcessor.
+// ============================================================================
+fn wasmNoiseAt(index: i32) -> f32 {
+    let i = clamp(index, 0, 4095);
+    let packed = plasmaBuffer[i / 4];
+    return packed[u32(i % 4)];
+}
+
+// Bilinear sample of the WASM tile — same filtering as weather-post.wgsl's
+// sampleWasmNoiseTile, reading through the vec4 packing.
+fn sampleWasmNoiseTile(uv: vec2<f32>) -> f32 {
+    let tileSize = 64.0;
+    let scaled = fract(uv) * tileSize;
+    let x0 = i32(floor(scaled.x)) & 63;
+    let y0 = i32(floor(scaled.y)) & 63;
+    let x1 = (x0 + 1) & 63;
+    let y1 = (y0 + 1) & 63;
+    let fx = fract(scaled.x);
+    let fy = fract(scaled.y);
+    let v00 = wasmNoiseAt(y0 * 64 + x0);
+    let v10 = wasmNoiseAt(y0 * 64 + x1);
+    let v01 = wasmNoiseAt(y1 * 64 + x0);
+    let v11 = wasmNoiseAt(y1 * 64 + x1);
+    return mix(mix(v00, v10, fx), mix(v01, v11, fx), fy);
+}
 
 // ============================================================================
 // NOISE AND UTILITY FUNCTIONS
@@ -154,6 +188,36 @@ fn normalizedDistance(a: f32, b: f32) -> f32 {
     if (d > 0.5) { d = d - 1.0; }
     if (d < -0.5) { d = d + 1.0; }
     return d;
+}
+
+// ============================================================================
+// CHEAP DEPTH PROXY — bodies kept byte-identical with weather-post.wgsl
+// (guarded by src/renderer/weatherShaderParity.test.ts). The result is also
+// stored into writeDepthTexture (binding 6) each dispatch.
+// ============================================================================
+
+// Screen-space Y (top-origin, 0-1) of the horizon for a normalized camera
+// pitch (0.5 = level). ~90 degree vertical FOV => 1 pitch unit ~ 2 screens.
+fn viewHorizonY(cameraPitchNorm: f32) -> f32 {
+    return clamp(0.5 + (cameraPitchNorm - 0.5) * 2.0, -0.75, 1.75);
+}
+
+// Normalized view distance: 0 = right in front of the camera, 1 = horizon or
+// beyond. Hyperbolic falloff below the horizon approximates eyeHeight/tan(angle).
+fn viewDepthProxy(uv: vec2<f32>, horizonY: f32) -> f32 {
+    let below = uv.y - horizonY;
+    if (below <= 0.0) { return 1.0; }
+    return clamp(0.06 / max(below, 0.0025), 0.0, 1.0);
+}
+
+// Vertical density profile of a fog layer. `height` 0 keeps the bank hugging
+// the ground (dense at the horizon line, thinning upward); 1 lifts it into an
+// elevated haze band that leaves the road clear.
+fn fogHeightFalloff(uv: vec2<f32>, horizonY: f32, height: f32) -> f32 {
+    let altitude = clamp((horizonY - uv.y) / max(horizonY, 0.15), 0.0, 1.0);
+    let ground   = exp(-altitude * 3.2);
+    let elevated = smoothstep(0.0, 0.5, altitude) * exp(-max(altitude - 0.5, 0.0) * 2.4);
+    return mix(ground, elevated, clamp(height, 0.0, 1.0));
 }
 
 // ============================================================================
@@ -286,30 +350,41 @@ fn getFogColor(fogIndex: f32) -> vec3<f32> {
     return grayFog;
 }
 
-fn applyFog(col: vec3<f32>, uv: vec2<f32>, night: f32) -> vec3<f32> {
-    let intensity = p_fogIntensity();
-    let density = p_fogDensity();
-    if (intensity < 0.001 && density < 0.001) { return col; }
-    let horizonDist = abs(uv.y - 0.5);
-    let groundProximity = smoothstep(0.35, 0.0, horizonDist);
-    var fogAmount = density * groundProximity;
-    fogAmount = fogAmount + intensity * (0.2 + groundProximity * 0.8);
-    let t = p_time() * p_speed();
+// Fog coverage at a pixel, 0-1 — reused to attenuate dust/rain/snow so nothing
+// suspended in the fog punches through it. `density` is a Beer-Lambert
+// extinction coefficient integrated along the depth proxy; `intensity` is the
+// flat aerial wash. Mirrors fogAmountAt() in weather-post.wgsl.
+fn fogAmountAt(uv: vec2<f32>, intensity: f32, density: f32, height: f32, t: f32) -> f32 {
+    if (intensity < 0.001 && density < 0.001) { return 0.0; }
+
+    let horizonY = viewHorizonY(p_cameraPitch());
+    let depth = viewDepthProxy(uv, horizonY);
+    let profile = fogHeightFalloff(uv, horizonY, height);
+
     let fogUV1 = vec3<f32>(uv * 4.0 + vec2<f32>(t * 0.07, t * 0.04), t * 0.05);
     let fogUV2 = vec3<f32>(uv * 8.0 - vec2<f32>(t * 0.05, t * 0.03), t * 0.08);
     let roll = fbm(fogUV1, 2) * 0.18 + fbm(fogUV2, 2) * 0.08;
-    fogAmount = fogAmount * (0.75 + roll);
+
+    let sigma = density * 2.6 * profile * (0.78 + roll);
+    var fogAmount = 1.0 - exp(-sigma * (0.12 + depth * 1.9));
+    fogAmount = fogAmount + intensity * (0.25 + profile * 0.75) * (0.78 + roll);
+    return clamp(fogAmount, 0.0, 0.95);
+}
+
+fn applyFog(col: vec3<f32>, fogAmount: f32, colorIdx: f32, night: f32) -> vec3<f32> {
+    if (fogAmount < 0.001) { return col; }
     let dayFog = vec3<f32>(0.71, 0.76, 0.78);
     let nightFog = vec3<f32>(0.08, 0.12, 0.22);
     var fogColor = mix(dayFog, nightFog, clamp(night, 0.0, 1.0));
-    let colorIdx = p_fogColorIndex();
     let indexedColor = getFogColor(colorIdx);
-    if (colorIdx > 0.5) { fogColor = indexedColor; }
-    return mix(col, fogColor, clamp(fogAmount, 0.0, 0.95));
+    if (colorIdx > 0.5) { fogColor = mix(indexedColor, nightFog, clamp(night, 0.0, 1.0) * 0.6); }
+    return mix(col, fogColor, fogAmount);
 }
 
-fn applyVolumetricLightShafts(col: vec3<f32>, uv: vec2<f32>, t: f32) -> vec3<f32> {
-    let intensity = p_lightShaftsIntensity();
+// Signature matches weather-post.wgsl (intensity passed in, not read from the
+// uniform block) — main() was already calling it with four arguments, which
+// meant this whole module failed to compile and ?weather=compute never ran.
+fn applyVolumetricLightShafts(col: vec3<f32>, uv: vec2<f32>, intensity: f32, t: f32) -> vec3<f32> {
     if (intensity < 0.001) { return col; }
     let sunScreenX = worldAzimuthToScreenX(p_sunAzimuth(), p_cameraHeading());
     let dSunX = normalizedDistance(uv.x, sunScreenX);
@@ -419,6 +494,16 @@ fn applyDustParticles(col: vec3<f32>, uv: vec2<f32>, intensity: f32, t: f32) -> 
     let sunDist = length(vec2<f32>(dSunX * 2.0, uv.y - sunUvY));
     let sunVisible = smoothstep(0.0, 0.1, p_sunAltitude());
     let towardSun = smoothstep(0.5, 0.0, sunDist);
+
+    // WASM-driven cloud density from the real noise tile at binding 12, so dust
+    // clumps into drifting patches instead of uniform speckle — parity with the
+    // fragment path. ?wasmNoise=off zeroes wasmNoiseEnabled and falls back to 1.
+    var cloudDensity = 1.0;
+    if (p_wasmNoiseEnabled() > 0.5) {
+        let cloudUV = uv * 1.5 + vec2<f32>(t * 0.015, t * 0.008);
+        cloudDensity = 0.35 + 0.65 * (0.5 + 0.5 * sampleWasmNoiseTile(cloudUV));
+    }
+
     for (var i: i32 = 0; i < 3; i = i + 1) {
         let layer = f32(i);
         var particleUV = uv * (15.0 + layer * 10.0);
@@ -429,7 +514,7 @@ fn applyDustParticles(col: vec3<f32>, uv: vec2<f32>, intensity: f32, t: f32) -> 
         if (rnd > 0.7) {
             let pos = fract(particleUV) - vec2<f32>(0.5);
             let dist = length(pos);
-            let particle = smoothstep(0.15, 0.0, dist) * (0.5 + rnd * 0.5);
+            let particle = smoothstep(0.15, 0.0, dist) * (0.5 + rnd * 0.5) * cloudDensity;
             let sparklePhase = t * (3.0 + rnd * 2.0) + layer * 5.0;
             let sparkle = pow(sin(sparklePhase) * 0.5 + 0.5, 10.0) * towardSun * sunVisible;
             let dustColor = vec3<f32>(0.9, 0.85, 0.7) + vec3<f32>(0.3, 0.25, 0.1) * sparkle;
@@ -580,15 +665,21 @@ fn sunsetHorizonGlow(uv: vec2<f32>, sunAz: f32, sunAlt: f32, night: f32) -> vec3
     return glow * (1.0 + glow * 0.5) + glow * 0.2;
 }
 
+// Camera-aware sunrise wash — anchored to the tracked horizon and the sun's
+// screen azimuth so dawn light pans with the view (matches weather-post.wgsl).
 fn applySunrise(col: vec3<f32>, uv: vec2<f32>, sunrise: f32) -> vec3<f32> {
     if (sunrise < 0.001) { return col; }
-    let horizonGlow = smoothstep(0.5, 0.0, uv.y);
-    let warmHighlight = vec3<f32>(1.0, 0.65, 0.35) * horizonGlow * sunrise * 0.4;
+    let horizonY = viewHorizonY(p_cameraPitch());
+    let sunScreenX = worldAzimuthToScreenX(p_sunAzimuth(), p_cameraHeading());
+    let dSunX = normalizedDistance(uv.x, sunScreenX);
+    let towardSun = smoothstep(0.45, 0.0, abs(dSunX));
+    let horizonGlow = smoothstep(horizonY + 0.12, horizonY - 0.38, uv.y);
+    let warmHighlight = vec3<f32>(1.0, 0.65, 0.35) * horizonGlow * towardSun * sunrise * 0.42;
     let shadowTint = mix(vec3<f32>(0.72, 0.58, 0.85), vec3<f32>(0.35, 0.45, 0.82), uv.y);
-    let shadowMask = (1.0 - horizonGlow) * sunrise * 0.18;
+    let shadowMask = (1.0 - horizonGlow * towardSun) * sunrise * 0.14;
     var result = col + warmHighlight;
     result = result + shadowTint * shadowMask;
-    let goldBoost = vec3<f32>(0.15, 0.05, -0.05) * horizonGlow * sunrise;
+    let goldBoost = vec3<f32>(0.15, 0.05, -0.05) * horizonGlow * towardSun * sunrise;
     result = result + goldBoost;
     return result;
 }
@@ -643,6 +734,41 @@ fn applyLensDroplets(col: vec3<f32>, uv: vec2<f32>, t: f32, intensity: f32) -> v
 }
 
 // ============================================================================
+// CINEMATIC CAMERA FX (depth of field + speed blur)
+// ============================================================================
+// Off unless src/renderer/cinematicCameraFx.ts opens the gate (quality >= high,
+// prefers-reduced-motion off). Mirrors applyCameraFX in weather-post.wgsl.
+
+const DOF_FOCUS_DEPTH: f32 = 0.45;
+
+fn applyCameraFX(col: vec3<f32>, uv: vec2<f32>, dof: f32, mblur: f32) -> vec3<f32> {
+    if (dof < 0.001 && mblur < 0.001) { return col; }
+
+    let horizonY = viewHorizonY(p_cameraPitch());
+    let depth = viewDepthProxy(uv, horizonY);
+
+    let coc = smoothstep(DOF_FOCUS_DEPTH, 1.0, depth) * dof;
+    let toCenter = uv - vec2<f32>(0.5, 0.5);
+
+    var accum = col;
+    var weight = 1.0;
+    for (var i: i32 = 0; i < 6; i = i + 1) {
+        let fi = f32(i);
+        let angle = fi * 1.0471975 + 0.3;
+        let ring = vec2<f32>(cos(angle), sin(angle)) * coc * 0.012;
+        let streak = -toCenter * mblur * 0.09 * ((fi + 1.0) / 6.0);
+        let tapUV = clamp(uv + ring + streak, vec2<f32>(0.001), vec2<f32>(0.999));
+        accum = accum + textureSampleLevel(readTexture, u_sampler, tapUV, 0.0).rgb;
+        weight = weight + 1.0;
+    }
+    let blurred = accum / weight;
+
+    let edgeBias = smoothstep(0.05, 0.55, length(toCenter));
+    let blend = clamp(max(coc, mblur * edgeBias), 0.0, 0.85);
+    return mix(col, blurred, blend);
+}
+
+// ============================================================================
 // HDR TONEMAPPING
 // ============================================================================
 
@@ -668,6 +794,13 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let uv = vec2<f32>(global_id.xy) / resolution;
     let t = p_time() * p_speed();
 
+    // View-depth proxy for this pixel, published to the r32float storage
+    // texture at binding 6 (replaces the old 1x1 dummy) and reused below for
+    // height fog and depth of field.
+    let horizonY = viewHorizonY(p_cameraPitch());
+    let viewDepth = viewDepthProxy(uv, horizonY);
+    textureStore(writeDepthTexture, vec2<i32>(global_id.xy), vec4<f32>(viewDepth, 0.0, 0.0, 1.0));
+
     // Bypass mode
     if (p_shaderEffectsEnabled() < 0.5) {
         let raw = textureSampleLevel(readTexture, u_sampler, uv, 0.0).rgb;
@@ -680,6 +813,9 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 
     // Chromatic aberration
     var col = applyChromaticAberration(uv, p_chromaticAberration());
+
+    // Cinematic camera FX (DOF + speed blur; no-op unless gated on)
+    col = applyCameraFX(col, uv, p_dofStrength(), p_motionBlurStrength());
 
     // Heat shimmer
     let heatOffset = getHeatShimmerOffset(uv, p_heatShimmerIntensity(), t);
@@ -727,23 +863,28 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     col = applySunrise(col, uv, p_sunrise());
     col = directionalMoonlight(col, uv, p_moonAzimuth(), p_moonAltitude(), p_nightIntensity());
 
-    // Atmospheric effects
-    col = applyFog(col, uv, p_nightIntensity());
+    // Atmospheric effects — fog coverage computed once, reused to attenuate
+    // everything suspended in it (dust, rain, snow).
+    let fogMask = fogAmountAt(uv, p_fogIntensity(), p_fogDensity(), p_fogHeight(), t);
+    col = applyFog(col, fogMask, p_fogColorIndex(), p_nightIntensity());
     col = applyVolumetricLightShafts(col, uv, p_lightShaftsIntensity(), t);
     col = applyHumidityHaze(col, uv, p_humidityHaze(), t);
-    col = applyDustParticles(col, uv, p_dustIntensity(), t);
+    col = applyDustParticles(col, uv, p_dustIntensity() * (1.0 - fogMask * 0.8), t);
     col = applyLensFlare(col, uv, p_lensFlareIntensity());
     col = applyVignette(col, uv);
 
-    // Weather effects (rain/snow)
+    // Weather effects (rain/snow) — fog-attenuated, night-aware darkening
+    let precipVisibility = 1.0 - fogMask * 0.75;
     if (p_rainIntensity() > 0.001) {
-        let r = rain(uv, t, panX, panY) * p_rainIntensity();
-        col = col + r * vec3<f32>(0.78, 0.88, 1.15);
-        col = col * (1.0 - p_rainIntensity() * 0.22);
+        let r = rain(uv, t, panX, panY) * p_rainIntensity() * precipVisibility;
+        let rainTint = mix(vec3<f32>(0.78, 0.88, 1.15), vec3<f32>(0.60, 0.70, 1.02), p_nightIntensity());
+        col = col + r * rainTint * (1.0 + p_headlightsOn() * p_nightIntensity() * 0.5);
+        col = col * (1.0 - p_rainIntensity() * mix(0.22, 0.10, p_nightIntensity()));
     }
     if (p_snowIntensity() > 0.001) {
-        let s = snow(uv, t, panX, panY) * p_snowIntensity();
-        col = col + s * vec3<f32>(1.15, 1.18, 1.22);
+        let s = snow(uv, t, panX, panY) * p_snowIntensity() * precipVisibility;
+        let snowLit = 1.0 + p_headlightsOn() * p_nightIntensity() * 0.35;
+        col = col + s * vec3<f32>(1.15, 1.18, 1.22) * snowLit;
     }
 
     // Refractive lens droplets

--- a/public/shaders/weather-post.wgsl
+++ b/public/shaders/weather-post.wgsl
@@ -52,9 +52,10 @@ struct WeatherParams {
     sunrise           : f32,  // 0.0 = no sunrise, 1.0 = full sunrise
     // 37: anamorphic lens flare streak width (0 = off, 0.5 = moderate)
     anamorphicStreak  : f32,
-    // 38-39: padding to reach 40 floats (160 bytes total)
-    _pad2             : f32,
-    _pad3             : f32,
+    // 38-39: cinematic camera FX — gated on CPU by quality >= high and
+    // prefers-reduced-motion (src/renderer/cinematicCameraFx.ts). 0 = off.
+    dofStrength        : f32,  // 0.0-1.0 far-field lens defocus
+    motionBlurStrength : f32,  // 0.0-1.0 radial speed blur (car/cruise coupled)
 }
 
 @group(0) @binding(0) var<uniform> p: WeatherParams;
@@ -100,6 +101,41 @@ fn normalizedDistance(a: f32, b: f32) -> f32 {
     if (d > 0.5) { d = d - 1.0; }
     if (d < -0.5) { d = d + 1.0; }
     return d;
+}
+
+// ============================================================================
+// CHEAP DEPTH PROXY (no depth buffer — Street View gives us none)
+// ============================================================================
+// The panorama is a sphere around the eye, so screen Y alone tells us a lot:
+// everything above the horizon line is effectively at infinity (sky/skyline),
+// and ground pixels below it get closer as they approach the bottom of the
+// frame. `viewHorizonY` tracks where that line sits as the camera pitches.
+//
+// Kept byte-identical with weather-post-compute.wgsl — see the parity guard in
+// src/renderer/weatherShaderParity.test.ts.
+
+// Screen-space Y (top-origin, 0-1) of the horizon for a normalized camera
+// pitch (0.5 = level). ~90 degree vertical FOV => 1 pitch unit ~ 2 screens.
+fn viewHorizonY(cameraPitchNorm: f32) -> f32 {
+    return clamp(0.5 + (cameraPitchNorm - 0.5) * 2.0, -0.75, 1.75);
+}
+
+// Normalized view distance: 0 = right in front of the camera, 1 = horizon or
+// beyond. Hyperbolic falloff below the horizon approximates eyeHeight/tan(angle).
+fn viewDepthProxy(uv: vec2<f32>, horizonY: f32) -> f32 {
+    let below = uv.y - horizonY;
+    if (below <= 0.0) { return 1.0; }
+    return clamp(0.06 / max(below, 0.0025), 0.0, 1.0);
+}
+
+// Vertical density profile of a fog layer. `height` 0 keeps the bank hugging
+// the ground (dense at the horizon line, thinning upward); 1 lifts it into an
+// elevated haze band that leaves the road clear.
+fn fogHeightFalloff(uv: vec2<f32>, horizonY: f32, height: f32) -> f32 {
+    let altitude = clamp((horizonY - uv.y) / max(horizonY, 0.15), 0.0, 1.0);
+    let ground   = exp(-altitude * 3.2);
+    let elevated = smoothstep(0.0, 0.5, altitude) * exp(-max(altitude - 0.5, 0.0) * 2.4);
+    return mix(ground, elevated, clamp(height, 0.0, 1.0));
 }
 
 // ============================================================================
@@ -312,33 +348,46 @@ fn getFogColor(fogIndex: f32) -> vec3<f32> {
     return grayFog;
 }
 
-fn applyFog(col: vec3<f32>, uv: vec2<f32>, intensity: f32, density: f32, height: f32, colorIdx: f32, night: f32) -> vec3<f32> {
-    if (intensity < 0.001 && density < 0.001) { return col; }
-    
-    let horizonDist = abs(uv.y - 0.5);
-    let groundProximity = smoothstep(0.35, 0.0, horizonDist);
-    
-    var fogAmount = density * groundProximity;
-    fogAmount = fogAmount + intensity * (0.2 + groundProximity * 0.8);
+// Fog coverage at a pixel, 0-1. Split out from applyFog so the same value can
+// attenuate rain, snow and dust — particles seen *through* fog have to fade
+// with it, otherwise streaks punch through a wall of mist (the single biggest
+// cohesion break in the old presets).
+//
+// `density` is an extinction coefficient integrated along the depth proxy
+// (Beer-Lambert), `intensity` is a flat screen-wide aerial wash. packWeatherParams
+// now feeds those two different numbers instead of the same slider twice.
+fn fogAmountAt(uv: vec2<f32>, intensity: f32, density: f32, height: f32, t: f32) -> f32 {
+    if (intensity < 0.001 && density < 0.001) { return 0.0; }
+
+    let horizonY = viewHorizonY(p.cameraPitch);
+    let depth = viewDepthProxy(uv, horizonY);
+    let profile = fogHeightFalloff(uv, horizonY, height);
 
     // Animated fractal fog: two fbm layers scrolling at different speeds/directions
     // create a "rolling" volumetric appearance instead of a static wash
-    let t = p.time * p.speed;
     let fogUV1 = vec3<f32>(uv * 4.0 + vec2<f32>(t * 0.07, t * 0.04), t * 0.05);
     let fogUV2 = vec3<f32>(uv * 8.0 - vec2<f32>(t * 0.05, t * 0.03), t * 0.08);
     let roll = fbm(fogUV1, 2) * 0.18 + fbm(fogUV2, 2) * 0.08;
-    fogAmount = fogAmount * (0.75 + roll);
-    
+
+    let sigma = density * 2.6 * profile * (0.78 + roll);
+    var fogAmount = 1.0 - exp(-sigma * (0.12 + depth * 1.9));
+    fogAmount = fogAmount + intensity * (0.25 + profile * 0.75) * (0.78 + roll);
+    return clamp(fogAmount, 0.0, 0.95);
+}
+
+fn applyFog(col: vec3<f32>, fogAmount: f32, colorIdx: f32, night: f32) -> vec3<f32> {
+    if (fogAmount < 0.001) { return col; }
+
     // Day fog: #b5c1c8, Night fog: dark blue
     let dayFog = vec3<f32>(0.71, 0.76, 0.78);
     let nightFog = vec3<f32>(0.08, 0.12, 0.22);
     var fogColor = mix(dayFog, nightFog, clamp(night, 0.0, 1.0));
-    
+
     // Override with indexed fog color if non-zero index
     let indexedColor = getFogColor(colorIdx);
-    if (colorIdx > 0.5) { fogColor = indexedColor; }
-    
-    return mix(col, fogColor, clamp(fogAmount, 0.0, 0.95));
+    if (colorIdx > 0.5) { fogColor = mix(indexedColor, nightFog, clamp(night, 0.0, 1.0) * 0.6); }
+
+    return mix(col, fogColor, fogAmount);
 }
 
 // === 2. VOLUMETRIC LIGHT SHAFTS (Camera-Aware) ===
@@ -750,22 +799,33 @@ fn sunsetHorizonGlow(uv: vec2<f32>, sunAz: f32, sunAlt: f32, night: f32) -> vec3
     return glow * (1.0 + glow * 0.5) + glow * 0.2;
 }
 
+// Sunrise wash. Anchored to the *tracked* horizon line and the sun's actual
+// screen azimuth so it pans with the camera exactly like sunsetHorizonGlow —
+// previously it was pinned to uv.y 0.5 and ignored heading entirely, which made
+// dawn light stay glued to the same corner of the screen while you turned.
 fn applySunrise(col: vec3<f32>, uv: vec2<f32>, sunrise: f32) -> vec3<f32> {
     if (sunrise < 0.001) { return col; }
-    
-    let horizonGlow = smoothstep(0.5, 0.0, uv.y);
-    let warmHighlight = vec3<f32>(1.0, 0.65, 0.35) * horizonGlow * sunrise * 0.4;
-    
+
+    let horizonY = viewHorizonY(p.cameraPitch);
+    let sunScreenX = worldAzimuthToScreenX(p.sunAzimuth, p.cameraHeading);
+    let dSunX = normalizedDistance(uv.x, sunScreenX);
+
+    // Warm light concentrates around the sun's bearing, cool shadow fills the
+    // opposite half of the sky.
+    let towardSun = smoothstep(0.45, 0.0, abs(dSunX));
+    let horizonGlow = smoothstep(horizonY + 0.12, horizonY - 0.38, uv.y);
+    let warmHighlight = vec3<f32>(1.0, 0.65, 0.35) * horizonGlow * towardSun * sunrise * 0.42;
+
     let shadowTint = mix(vec3<f32>(0.72, 0.58, 0.85), vec3<f32>(0.35, 0.45, 0.82), uv.y);
-    let shadowMask = (1.0 - horizonGlow) * sunrise * 0.18;
-    
+    let shadowMask = (1.0 - horizonGlow * towardSun) * sunrise * 0.14;
+
     var result = col + warmHighlight;
     result = result + shadowTint * shadowMask;
-    
-    // Pink/gold color grading boost
-    let goldBoost = vec3<f32>(0.15, 0.05, -0.05) * horizonGlow * sunrise;
+
+    // Pink/gold color grading boost, strongest looking into the dawn
+    let goldBoost = vec3<f32>(0.15, 0.05, -0.05) * horizonGlow * towardSun * sunrise;
     result = result + goldBoost;
-    
+
     return result;
 }
 
@@ -845,6 +905,50 @@ fn applyLensDroplets(col: vec3<f32>, uv: vec2<f32>, t: f32, intensity: f32) -> v
 }
 
 // ============================================================================
+// CINEMATIC CAMERA FX (depth of field + speed blur)
+// ============================================================================
+// Both are off unless the CPU gate in src/renderer/cinematicCameraFx.ts opens
+// them (quality >= high, prefers-reduced-motion off), so the default fragment
+// path costs exactly one early-out branch.
+//
+// DOF focuses the mid-ground and defocuses the far field using the same depth
+// proxy the fog uses — no depth buffer needed. Motion blur streaks radially
+// away from the screen centre, which reads as forward travel, and its strength
+// is already speed-scaled on the CPU.
+
+const DOF_FOCUS_DEPTH: f32 = 0.45;
+
+fn applyCameraFX(col: vec3<f32>, uv: vec2<f32>, dof: f32, mblur: f32) -> vec3<f32> {
+    if (dof < 0.001 && mblur < 0.001) { return col; }
+
+    let horizonY = viewHorizonY(p.cameraPitch);
+    let depth = viewDepthProxy(uv, horizonY);
+
+    // Circle of confusion: sharp at the focus plane, widening toward infinity.
+    let coc = smoothstep(DOF_FOCUS_DEPTH, 1.0, depth) * dof;
+    // Radial offset direction for the speed streak.
+    let toCenter = uv - vec2<f32>(0.5, 0.5);
+
+    var accum = col;
+    var weight = 1.0;
+    for (var i: i32 = 0; i < 6; i = i + 1) {
+        let fi = f32(i);
+        let angle = fi * 1.0471975 + 0.3;
+        let ring = vec2<f32>(cos(angle), sin(angle)) * coc * 0.012;
+        let streak = -toCenter * mblur * 0.09 * ((fi + 1.0) / 6.0);
+        let tapUV = clamp(uv + ring + streak, vec2<f32>(0.001), vec2<f32>(0.999));
+        accum = accum + textureSampleLevel(sceneTex, linearSampler, tapUV, 0.0).rgb;
+        weight = weight + 1.0;
+    }
+    let blurred = accum / weight;
+
+    // Blend by whichever effect is asking for more softening at this pixel.
+    let edgeBias = smoothstep(0.05, 0.55, length(toCenter));
+    let blend = clamp(max(coc, mblur * edgeBias), 0.0, 0.85);
+    return mix(col, blurred, blend);
+}
+
+// ============================================================================
 // HDR TONEMAPPING
 // ============================================================================
 
@@ -889,7 +993,10 @@ fn fs_main(@builtin(position) fragCoord: vec4<f32>) -> @location(0) vec4<f32> {
     
     // === CHROMATIC ABERRATION ===
     var col = applyChromaticAberration(uv, p.chromaticAberration);
-    
+
+    // === CINEMATIC CAMERA FX (DOF + speed blur; no-op unless gated on) ===
+    col = applyCameraFX(col, uv, p.dofStrength, p.motionBlurStrength);
+
     // === HEAT SHIMMER ===
     col = applyHeatShimmer(col, uv, p.heatShimmerIntensity, t);
     
@@ -933,23 +1040,32 @@ fn fs_main(@builtin(position) fragCoord: vec4<f32>) -> @location(0) vec4<f32> {
     col = directionalMoonlight(col, uv, p.moonAzimuth, p.moonAltitude, p.nightIntensity);
 
     // === ATMOSPHERIC EFFECTS ===
-    col = applyFog(col, uv, p.fogIntensity, p.fogDensity, p.fogHeight, p.fogColorIndex, p.nightIntensity);
+    // Fog coverage is computed once and reused: it tints the scene *and*
+    // attenuates everything suspended in it (dust, rain, snow).
+    let fogMask = fogAmountAt(uv, p.fogIntensity, p.fogDensity, p.fogHeight, t);
+    col = applyFog(col, fogMask, p.fogColorIndex, p.nightIntensity);
     col = applyVolumetricLightShafts(col, uv, p.lightShaftsIntensity, t);
     col = applyHumidityHaze(col, uv, p.humidityHaze, t);
-    col = applyDustParticles(col, uv, p.dustIntensity, t);
+    col = applyDustParticles(col, uv, p.dustIntensity * (1.0 - fogMask * 0.8), t);
     col = applyLensFlare(col, uv, p.lensFlareIntensity);
     col = applyVignette(col, uv);
 
     // === WEATHER EFFECTS (RAIN/SNOW with world-space camera offset) ===
+    // Precipitation sits in the same volume as the fog, so it fades into it
+    // rather than punching through, and its scene darkening eases off at night
+    // to keep the readable-night floor from #171 intact.
+    let precipVisibility = 1.0 - fogMask * 0.75;
     if (p.rainIntensity > 0.001) {
-        let r = rain(uv, t, panX, panY) * p.rainIntensity;
-        col = col + r * vec3<f32>(0.78, 0.88, 1.15);
-        col = col * (1.0 - p.rainIntensity * 0.22);
+        let r = rain(uv, t, panX, panY) * p.rainIntensity * precipVisibility;
+        let rainTint = mix(vec3<f32>(0.78, 0.88, 1.15), vec3<f32>(0.60, 0.70, 1.02), p.nightIntensity);
+        col = col + r * rainTint * (1.0 + p.headlightsOn * p.nightIntensity * 0.5);
+        col = col * (1.0 - p.rainIntensity * mix(0.22, 0.10, p.nightIntensity));
     }
-    
+
     if (p.snowIntensity > 0.001) {
-        let s = snow(uv, t, panX, panY) * p.snowIntensity;
-        col = col + s * vec3<f32>(1.15, 1.18, 1.22);
+        let s = snow(uv, t, panX, panY) * p.snowIntensity * precipVisibility;
+        let snowLit = 1.0 + p.headlightsOn * p.nightIntensity * 0.35;
+        col = col + s * vec3<f32>(1.15, 1.18, 1.22) * snowLit;
     }
 
     // === REFRACTIVE LENS DROPLETS ===

--- a/src/components/WebGPUCanvas.tsx
+++ b/src/components/WebGPUCanvas.tsx
@@ -8,6 +8,9 @@ import { getMemoryProfiler } from '../utils/memoryProfiler';
 import { streetViewProbe } from '../utils/streetViewProbe';
 import { shouldBypassAdaptiveSkip, shouldRenderHeldFrameThisTick } from './holdRenderLoop';
 import { WasmNoiseFeeder, getWasmNoisePreference } from '../wasm/wasmNoiseFeeder';
+import { getActiveQualityLevel } from '../config/visualPresets';
+import { resolveCinematicCameraFx, prefersReducedMotion } from '../renderer/cinematicCameraFx';
+import { getCameraSpeedNormalized } from '../renderer/cameraMotionSignal';
 
 /**
  * ⚠️ CRITICAL INTEGRATION NOTES - DO NOT REMOVE ⚠️
@@ -65,6 +68,12 @@ const WebGPUCanvas: React.FC<WebGPUCanvasProps> = ({ onWebGPUStatus, onBackendIn
     // ?wasmNoise=off (or a stored streetview.wasmNoise=off preference) disables it.
     const noiseFeederRef = useRef<WasmNoiseFeeder>(new WasmNoiseFeeder());
     const wasmNoiseEnabledRef = useRef<boolean>(getWasmNoisePreference());
+
+    // Cinematic camera FX gate (DOF + motion blur). Quality and the reduced-motion
+    // preference are read once — both require a reload to change — while speed is
+    // polled per frame from the car/cruise loops. See cinematicCameraFx.ts.
+    const qualityRef = useRef(getActiveQualityLevel());
+    const reducedMotionRef = useRef(prefersReducedMotion());
 
     const currentRendererRef = internalRendererRef;
 
@@ -267,6 +276,11 @@ const WebGPUCanvas: React.FC<WebGPUCanvasProps> = ({ onWebGPUStatus, onBackendIn
                     cameraHeading: weatherHeading,
                     cameraPitch: weatherPitch,
                     wasmNoiseActive,
+                    cinematic: resolveCinematicCameraFx({
+                        quality: qualityRef.current,
+                        reducedMotion: reducedMotionRef.current,
+                        speedNormalized: getCameraSpeedNormalized(),
+                    }),
                 });
 
                 currentRendererRef.current.updateWeatherParams(params);

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -4,6 +4,7 @@ export {
   getPreset,
   createCustomPreset,
   detectRecommendedQuality,
+  getActiveQualityLevel,
 } from './visualPresets';
 
 export type { QualityLevel, VisualPreset } from './visualPresets';

--- a/src/config/visualPresets.ts
+++ b/src/config/visualPresets.ts
@@ -246,6 +246,34 @@ export function createCustomPreset(
 // Auto-Detection
 // ============================================================
 
+const VALID_QUALITY_LEVELS: ReadonlySet<string> = new Set(['low', 'medium', 'high', 'ultra']);
+
+/**
+ * The quality level actually in force: `?quality=` URL flag wins, then a
+ * persisted `streetview.quality` preference, then hardware auto-detection.
+ * Used by gates that must agree with what the renderer is doing (e.g. the
+ * cinematic camera FX in src/renderer/cinematicCameraFx.ts).
+ */
+export function getActiveQualityLevel(): QualityLevel {
+  if (typeof window === 'undefined') return DEFAULT_QUALITY;
+
+  try {
+    const param = new URLSearchParams(window.location.search).get('quality')?.toLowerCase();
+    if (param && VALID_QUALITY_LEVELS.has(param)) return param as QualityLevel;
+  } catch {
+    // Malformed URL — fall through to storage / detection.
+  }
+
+  try {
+    const stored = window.localStorage.getItem('streetview.quality');
+    if (stored && VALID_QUALITY_LEVELS.has(stored)) return stored as QualityLevel;
+  } catch {
+    // Storage may be unavailable in hardened browsers.
+  }
+
+  return detectRecommendedQuality();
+}
+
 export function detectRecommendedQuality(): QualityLevel {
   if (typeof navigator === 'undefined' || typeof window === 'undefined') {
     return DEFAULT_QUALITY;

--- a/src/docs/GRAPHICS.md
+++ b/src/docs/GRAPHICS.md
@@ -1,5 +1,10 @@
 # Graphics & Rendering Pipeline
 
+> **Weather & atmosphere look targets live in [`docs/GRAPHICS.md`](../../docs/GRAPHICS.md)** —
+> preset intent, the CPU cohesion model, the view-depth proxy, before/after
+> tuning notes, and the cinematic camera FX gate. This file covers the broader
+> pipeline and material system.
+
 ## Architecture Overview
 
 The WebGPU StreetView application uses a **dual-renderer architecture**:

--- a/src/effects/PostProcessing.ts
+++ b/src/effects/PostProcessing.ts
@@ -165,15 +165,21 @@ export interface PostProcessingConfig {
     filmGrainIntensity: number;
     chromaticAberrationEnabled: boolean;
     chromaticAberrationStrength: number;
-    /** Reserved for future implementation. */
+    /**
+     * Depth of field and motion blur ship in the WebGPU weather post pass, not
+     * in this Three.js car-interior pipeline — see applyCameraFX in
+     * public/shaders/weather-post.wgsl, gated by
+     * src/renderer/cinematicCameraFx.ts (quality >= high + reduced motion off).
+     *
+     * These fields mirror VisualPreset so a preset can be spread into this
+     * config without losing keys; the passes below ignore them. Wiring a
+     * Three-side equivalent needs a depth texture on the scene render target,
+     * which this pipeline does not currently allocate.
+     */
     depthOfFieldEnabled: boolean;
-    /** Reserved for future implementation. */
     depthOfFieldFocalLength: number;
-    /** Reserved for future implementation. */
     depthOfFieldBokehScale: number;
-    /** Reserved for future implementation. */
     motionBlurEnabled: boolean;
-    /** Reserved for future implementation. */
     motionBlurStrength: number;
 }
 

--- a/src/renderer/ComputeWeatherPostProcessor.ts
+++ b/src/renderer/ComputeWeatherPostProcessor.ts
@@ -6,11 +6,10 @@ import {
 import { createDefaultWeatherParams } from './packWeatherParams';
 import type { WeatherPostProcessorLike } from './weatherPostProcessorTypes';
 
-// Must match NOISE_TILE_SIZE in src/wasm/wasmNoiseFeeder.ts and the
-// storage buffer declared in weather-post.wgsl. The compute variant does
-// not yet bind this tile to the shader (see weather-post-compute.wgsl
-// header) — the buffer is kept here only so the public API matches
-// WeatherPostProcessor and callers don't need to branch.
+// Must match NOISE_TILE_SIZE in src/wasm/wasmNoiseFeeder.ts and the storage
+// buffer declared in weather-post.wgsl. The compute variant binds this tile at
+// binding 12 (the image_video_effects `plasmaBuffer` slot), where the shader
+// reads it as 1024 vec4s — 4096 floats, exactly one 64x64 tile.
 const NOISE_TILE_SIZE = 64;
 const NOISE_BUFFER_BYTES = NOISE_TILE_SIZE * NOISE_TILE_SIZE * 4;
 
@@ -49,9 +48,11 @@ fn fs_main(@builtin(position) fragCoord: vec4<f32>) -> @location(0) vec4<f32> {
  * texture to the canvas. Exposes the same public API as
  * WeatherPostProcessor so Renderer.ts can use either interchangeably.
  *
- * Foundation for WASM noise buffers (#128), volumetric fog, and GPU
- * particles, all of which want storage-buffer access that a fragment pass
- * can't offer efficiently. See docs/RENDERER_FALLBACK.md.
+ * Two of the image_video_effects storage surfaces carry real data: binding 6
+ * receives a full-res view-depth proxy each dispatch, and binding 12 carries
+ * the WASM noise tile (#128) that drives dust turbulence. The remaining
+ * surfaces are still 1x1 dummies reserved for GPU particles and temporal
+ * effects. See docs/RENDERER_FALLBACK.md and docs/GRAPHICS.md.
  */
 export class ComputeWeatherPostProcessor implements WeatherPostProcessorLike {
     private device: GPUDevice;
@@ -66,20 +67,21 @@ export class ComputeWeatherPostProcessor implements WeatherPostProcessorLike {
     private computeUniformsBuffer: GPUBuffer | null = null;
     private noiseBuffer: GPUBuffer | null = null;
     private writeTexture: GPUTexture | null = null;
+    /** Full-res r32float view-depth proxy written by the compute pass. */
+    private depthProxyTexture: GPUTexture | null = null;
     private writeWidth: number = 0;
     private writeHeight: number = 0;
 
-    // Dummy 1x1 resources for image_video_effects bindings this shader
-    // doesn't use yet (depth, data textures, plasma buffer).
     private filteringSampler: GPUSampler | null = null;
     private nonFilteringSampler: GPUSampler | null = null;
     private comparisonSampler: GPUSampler | null = null;
+    // Dummy 1x1 resources for image_video_effects bindings this shader still
+    // doesn't use (depth read-back, scratch data textures). Bindings 6 and 12
+    // are now backed by real resources — see the shader header.
     private dummyReadDepthTexture: GPUTexture | null = null;
-    private dummyWriteDepthTexture: GPUTexture | null = null;
     private dummyDataTextureA: GPUTexture | null = null;
     private dummyDataTextureB: GPUTexture | null = null;
     private dummyDataTextureC: GPUTexture | null = null;
-    private dummyPlasmaBuffer: GPUBuffer | null = null;
 
     private weatherParams: Float32Array = new Float32Array(WEATHER_PARAMS_FLOAT_COUNT);
     private startTime: number = Date.now();
@@ -115,10 +117,6 @@ export class ComputeWeatherPostProcessor implements WeatherPostProcessorLike {
             size: NOISE_BUFFER_BYTES,
             usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
         });
-        this.dummyPlasmaBuffer = this.device.createBuffer({
-            size: 16,
-            usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
-        });
 
         this.dummyReadDepthTexture = this.device.createTexture({
             size: [1, 1],
@@ -129,11 +127,6 @@ export class ComputeWeatherPostProcessor implements WeatherPostProcessorLike {
             size: [1, 1],
             format: 'rgba8unorm',
             usage: GPUTextureUsage.TEXTURE_BINDING,
-        });
-        this.dummyWriteDepthTexture = this.device.createTexture({
-            size: [1, 1],
-            format: 'r32float',
-            usage: GPUTextureUsage.STORAGE_BINDING,
         });
         this.dummyDataTextureA = this.device.createTexture({
             size: [1, 1],
@@ -206,12 +199,21 @@ export class ComputeWeatherPostProcessor implements WeatherPostProcessorLike {
     private ensureWriteTexture(width: number, height: number): void {
         if (this.writeTexture && this.writeWidth === width && this.writeHeight === height) return;
         if (this.writeTexture) this.writeTexture.destroy();
+        if (this.depthProxyTexture) this.depthProxyTexture.destroy();
 
         this.writeWidth = width;
         this.writeHeight = height;
+        const size: [number, number] = [Math.max(1, width), Math.max(1, height)];
         this.writeTexture = this.device.createTexture({
-            size: [Math.max(1, width), Math.max(1, height)],
+            size,
             format: 'rgba32float',
+            usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+        });
+        // Real view-depth proxy target (was a 1x1 dummy). TEXTURE_BINDING keeps
+        // it readable by future passes / debug probes without another resize path.
+        this.depthProxyTexture = this.device.createTexture({
+            size,
+            format: 'r32float',
             usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
         });
     }
@@ -227,17 +229,16 @@ export class ComputeWeatherPostProcessor implements WeatherPostProcessorLike {
             || !this.nonFilteringSampler
             || !this.comparisonSampler
             || !this.dummyReadDepthTexture
-            || !this.dummyWriteDepthTexture
             || !this.dummyDataTextureA
             || !this.dummyDataTextureB
             || !this.dummyDataTextureC
-            || !this.dummyPlasmaBuffer
+            || !this.noiseBuffer
         ) {
             return;
         }
 
         this.ensureWriteTexture(width || 1, height || 1);
-        if (!this.writeTexture) return;
+        if (!this.writeTexture || !this.depthProxyTexture) return;
 
         this.computeBindGroup = this.device.createBindGroup({
             layout: this.computePipeline.getBindGroupLayout(0),
@@ -248,13 +249,15 @@ export class ComputeWeatherPostProcessor implements WeatherPostProcessorLike {
                 { binding: 3, resource: { buffer: this.computeUniformsBuffer } },
                 { binding: 4, resource: this.dummyReadDepthTexture.createView() },
                 { binding: 5, resource: this.nonFilteringSampler },
-                { binding: 6, resource: this.dummyWriteDepthTexture.createView() },
+                { binding: 6, resource: this.depthProxyTexture.createView() },
                 { binding: 7, resource: this.dummyDataTextureA.createView() },
                 { binding: 8, resource: this.dummyDataTextureB.createView() },
                 { binding: 9, resource: this.dummyDataTextureC.createView() },
                 { binding: 10, resource: { buffer: this.extraBuffer } },
                 { binding: 11, resource: this.comparisonSampler },
-                { binding: 12, resource: { buffer: this.dummyPlasmaBuffer } },
+                // The image_video_effects "plasma" slot carries the real WASM
+                // noise tile here (4096 floats read as 1024 vec4s).
+                { binding: 12, resource: { buffer: this.noiseBuffer } },
             ],
         });
 
@@ -404,10 +407,9 @@ export class ComputeWeatherPostProcessor implements WeatherPostProcessorLike {
             if (this.extraBuffer) this.extraBuffer.destroy();
             if (this.computeUniformsBuffer) this.computeUniformsBuffer.destroy();
             if (this.noiseBuffer) this.noiseBuffer.destroy();
-            if (this.dummyPlasmaBuffer) this.dummyPlasmaBuffer.destroy();
             if (this.writeTexture) this.writeTexture.destroy();
+            if (this.depthProxyTexture) this.depthProxyTexture.destroy();
             if (this.dummyReadDepthTexture) this.dummyReadDepthTexture.destroy();
-            if (this.dummyWriteDepthTexture) this.dummyWriteDepthTexture.destroy();
             if (this.dummyDataTextureA) this.dummyDataTextureA.destroy();
             if (this.dummyDataTextureB) this.dummyDataTextureB.destroy();
             if (this.dummyDataTextureC) this.dummyDataTextureC.destroy();
@@ -418,6 +420,7 @@ export class ComputeWeatherPostProcessor implements WeatherPostProcessorLike {
         this.computeUniformsBuffer = null;
         this.noiseBuffer = null;
         this.writeTexture = null;
+        this.depthProxyTexture = null;
         this.computePipeline = null;
         this.computeBindGroup = null;
         this.blitPipeline = null;
@@ -426,10 +429,8 @@ export class ComputeWeatherPostProcessor implements WeatherPostProcessorLike {
         this.nonFilteringSampler = null;
         this.comparisonSampler = null;
         this.dummyReadDepthTexture = null;
-        this.dummyWriteDepthTexture = null;
         this.dummyDataTextureA = null;
         this.dummyDataTextureB = null;
         this.dummyDataTextureC = null;
-        this.dummyPlasmaBuffer = null;
     }
 }

--- a/src/renderer/WebGLFallbackRenderer.ts
+++ b/src/renderer/WebGLFallbackRenderer.ts
@@ -114,11 +114,50 @@ vec3 applyNight(vec3 col, vec2 uv) {
     return max(col, vec3(0.01));
 }
 
+// SDR approximations of viewHorizonY / viewDepthProxy / fogHeightFalloff from
+// weather-post.wgsl. Same shape, no fbm rolling layer (cost) — see docs/GRAPHICS.md.
+float viewHorizonY() {
+    return clamp(0.5 + (uWeather[34] - 0.5) * 2.0, -0.75, 1.75);
+}
+
+float viewDepthProxy(vec2 uv, float horizonY) {
+    float below = uv.y - horizonY;
+    if (below <= 0.0) return 1.0;
+    return clamp(0.06 / max(below, 0.0025), 0.0, 1.0);
+}
+
+float fogHeightFalloff(vec2 uv, float horizonY) {
+    float height = clamp(uWeather[24], 0.0, 1.0);
+    float altitude = clamp((horizonY - uv.y) / max(horizonY, 0.15), 0.0, 1.0);
+    float ground = exp(-altitude * 3.2);
+    float elevated = smoothstep(0.0, 0.5, altitude) * exp(-max(altitude - 0.5, 0.0) * 2.4);
+    return mix(ground, elevated, height);
+}
+
+// Beer-Lambert fog coverage along the depth proxy, matching fogAmountAt().
+float fogAmountAt(vec2 uv) {
+    float intensity = uWeather[22];
+    float density = uWeather[23];
+    if (intensity < 0.001 && density < 0.001) return 0.0;
+    float horizonY = viewHorizonY();
+    float depth = viewDepthProxy(uv, horizonY);
+    float profile = fogHeightFalloff(uv, horizonY);
+    float sigma = density * 2.6 * profile * 0.78;
+    float fogAmount = 1.0 - exp(-sigma * (0.12 + depth * 1.9));
+    fogAmount += intensity * (0.25 + profile * 0.75) * 0.78;
+    return clamp(fogAmount, 0.0, 0.95);
+}
+
 vec3 applyWeather(vec3 col, vec2 uv) {
     float time = uWeather[6] * max(uWeather[10], 0.2);
     float rain = clamp(uWeather[7], 0.0, 2.0);
     float snow = clamp(uWeather[8], 0.0, 2.0);
     float wind = uWeather[9];
+    float night = clamp(uWeather[11], 0.0, 1.0);
+
+    // Precipitation fades into the fog volume instead of punching through it,
+    // matching the WebGPU paths' precipVisibility term.
+    float precipVisibility = 1.0 - fogAmountAt(uv) * 0.75;
 
     // Top-origin UV (vertex shader flips y). Negative Y time term => fall downward,
     // matching WebGPU weather-post.wgsl (st.y - t * speed). See carSpatialModel.WEATHER_FALL_Y_SIGN.
@@ -126,14 +165,17 @@ vec3 applyWeather(vec3 col, vec2 uv) {
         vec2 rainUv = uv * vec2(120.0, 34.0) + vec2(wind * time * 10.0, -time * 24.0);
         float streak = smoothstep(0.965, 1.0, noise2D(rainUv));
         streak *= smoothstep(0.35, 1.0, fract(rainUv.y));
-        col = mix(col, vec3(0.64, 0.78, 0.95), streak * rain * 0.18);
-        col *= 1.0 - rain * 0.045;
+        vec3 rainTint = mix(vec3(0.64, 0.78, 0.95), vec3(0.50, 0.62, 0.90), night);
+        col = mix(col, rainTint, streak * rain * 0.18 * precipVisibility);
+        // Ease the wet-scene darkening at night so the #171 readable floor holds.
+        col *= 1.0 - rain * mix(0.045, 0.020, night);
     }
 
     if (snow > 0.001) {
         vec2 snowUv = uv * vec2(44.0, 26.0) + vec2(wind * time * 1.2, -time * 2.2);
         float flakes = smoothstep(0.986, 1.0, noise2D(snowUv));
-        col += vec3(0.95, 0.98, 1.0) * flakes * snow * 0.32;
+        float snowLit = 1.0 + uWeather[12] * night * 0.35;
+        col += vec3(0.95, 0.98, 1.0) * flakes * snow * 0.32 * precipVisibility * snowLit;
         col = mix(col, vec3(dot(col, vec3(0.299, 0.587, 0.114))), snow * 0.035);
     }
 
@@ -141,10 +183,13 @@ vec3 applyWeather(vec3 col, vec2 uv) {
 }
 
 vec3 applyFogAndLighting(vec3 col, vec2 uv) {
-    float fog = clamp(uWeather[22] + uWeather[23] * 0.65, 0.0, 1.0);
-    float horizon = smoothstep(1.0, 0.2, abs(uv.y - 0.5));
-    col = mix(col, vec3(0.72, 0.76, 0.8), fog * (0.35 + horizon * 0.3));
+    float fog = fogAmountAt(uv);
+    float night = clamp(uWeather[11], 0.0, 1.0);
+    vec3 fogColor = mix(vec3(0.72, 0.76, 0.8), vec3(0.08, 0.12, 0.22), night);
+    col = mix(col, fogColor, fog);
 
+    // Overcast suppression already applied on the CPU (weatherCohesion.ts), so
+    // the sun terms below just follow the packed shaft/flare intensities.
     float sunVisible = clamp(uWeather[19] / 0.3, 0.0, 1.0);
     float sunX = fract((uWeather[18] + 3.14159265) / 6.2831853 - uWeather[33] + 0.5);
     vec2 sunPos = vec2(sunX, clamp(0.5 - uWeather[19] * 0.9, 0.02, 0.98));

--- a/src/renderer/cameraMotionSignal.test.ts
+++ b/src/renderer/cameraMotionSignal.test.ts
@@ -1,0 +1,44 @@
+import {
+    publishCameraSpeed,
+    getCameraSpeedNormalized,
+    resetCameraSpeed,
+    MOTION_SIGNAL_MAX_KMH,
+    MOTION_SIGNAL_STALE_MS,
+} from './cameraMotionSignal';
+
+describe('cameraMotionSignal', () => {
+    beforeEach(() => resetCameraSpeed());
+
+    it('reads zero before anything is published', () => {
+        expect(getCameraSpeedNormalized()).toBe(0);
+    });
+
+    it('normalizes published speed against the max', () => {
+        publishCameraSpeed(MOTION_SIGNAL_MAX_KMH / 2, 1000);
+        expect(getCameraSpeedNormalized(1000)).toBeCloseTo(0.5);
+    });
+
+    it('clamps above the max', () => {
+        publishCameraSpeed(MOTION_SIGNAL_MAX_KMH * 3, 1000);
+        expect(getCameraSpeedNormalized(1000)).toBe(1);
+    });
+
+    it('decays to zero once the publisher goes quiet', () => {
+        publishCameraSpeed(MOTION_SIGNAL_MAX_KMH, 1000);
+        expect(getCameraSpeedNormalized(1000 + MOTION_SIGNAL_STALE_MS - 1)).toBe(1);
+        expect(getCameraSpeedNormalized(1000 + MOTION_SIGNAL_STALE_MS + 1)).toBe(0);
+    });
+
+    it('ignores negative and non-finite speeds', () => {
+        publishCameraSpeed(-40, 1000);
+        expect(getCameraSpeedNormalized(1000)).toBe(0);
+        publishCameraSpeed(Number.NaN, 1000);
+        expect(getCameraSpeedNormalized(1000)).toBe(0);
+    });
+
+    it('resets immediately on request', () => {
+        publishCameraSpeed(MOTION_SIGNAL_MAX_KMH, 1000);
+        resetCameraSpeed();
+        expect(getCameraSpeedNormalized(1000)).toBe(0);
+    });
+});

--- a/src/renderer/cameraMotionSignal.ts
+++ b/src/renderer/cameraMotionSignal.ts
@@ -1,0 +1,40 @@
+/**
+ * cameraMotionSignal.ts — one-way speed channel from the car/cruise loops to
+ * the WebGPU render loop.
+ *
+ * WebGPUCanvas needs the current travel speed every frame to drive motion
+ * blur, but car telemetry lives in CarModeView's animation loop behind refs
+ * that never reach React state at frame rate. Threading it through context
+ * would re-render the canvas 60x/s, so publishers push a plain number here and
+ * the render loop polls it.
+ *
+ * The value decays on its own: if nothing publishes for ~400 ms (car mode
+ * exited, cruise stopped) it falls back to zero so blur can't get stuck on.
+ */
+
+/** Speed treated as "full throttle" for normalization purposes (km/h). */
+export const MOTION_SIGNAL_MAX_KMH = 90;
+
+/** After this long with no publisher the signal decays to zero. */
+export const MOTION_SIGNAL_STALE_MS = 400;
+
+let speedKmh = 0;
+let lastPublishedAt = 0;
+
+/** Publish the current travel speed in km/h. Called from animation loops. */
+export function publishCameraSpeed(kmh: number, now: number = Date.now()): void {
+    speedKmh = Number.isFinite(kmh) ? Math.max(0, kmh) : 0;
+    lastPublishedAt = now;
+}
+
+/** Normalized 0–1 travel speed, or 0 when the signal has gone stale. */
+export function getCameraSpeedNormalized(now: number = Date.now()): number {
+    if (lastPublishedAt === 0 || now - lastPublishedAt > MOTION_SIGNAL_STALE_MS) return 0;
+    return Math.min(1, speedKmh / MOTION_SIGNAL_MAX_KMH);
+}
+
+/** Clear the signal immediately (car mode exit, teardown, tests). */
+export function resetCameraSpeed(): void {
+    speedKmh = 0;
+    lastPublishedAt = 0;
+}

--- a/src/renderer/cinematicCameraFx.test.ts
+++ b/src/renderer/cinematicCameraFx.test.ts
@@ -1,0 +1,54 @@
+import {
+    resolveCinematicCameraFx,
+    isCinematicQuality,
+    CINEMATIC_FX_OFF,
+} from './cinematicCameraFx';
+import { QualityLevel } from '../config/visualPresets';
+
+function fx(quality: QualityLevel, reducedMotion = false, speedNormalized = 1) {
+    return resolveCinematicCameraFx({ quality, reducedMotion, speedNormalized });
+}
+
+describe('resolveCinematicCameraFx', () => {
+    it('stays off below High quality', () => {
+        expect(fx('low')).toEqual(CINEMATIC_FX_OFF);
+        expect(fx('medium')).toEqual(CINEMATIC_FX_OFF);
+        expect(isCinematicQuality('low')).toBe(false);
+        expect(isCinematicQuality('medium')).toBe(false);
+    });
+
+    it('stays off entirely when reduced motion is requested', () => {
+        expect(fx('high', true)).toEqual(CINEMATIC_FX_OFF);
+        expect(fx('ultra', true)).toEqual(CINEMATIC_FX_OFF);
+    });
+
+    it('enables depth of field at High and widens it at Ultra', () => {
+        expect(fx('high').dofStrength).toBeGreaterThan(0);
+        expect(fx('ultra').dofStrength).toBeGreaterThan(fx('high').dofStrength);
+    });
+
+    it('only enables motion blur where the preset asks for it (Ultra)', () => {
+        expect(fx('high').motionBlurStrength).toBe(0);
+        expect(fx('ultra').motionBlurStrength).toBeGreaterThan(0);
+    });
+
+    it('gives a stationary camera no motion blur', () => {
+        expect(fx('ultra', false, 0).motionBlurStrength).toBe(0);
+        expect(fx('ultra', false, 0.1).motionBlurStrength).toBe(0);
+    });
+
+    it('ramps motion blur with speed and clamps at the top', () => {
+        const slow = fx('ultra', false, 0.3).motionBlurStrength;
+        const fast = fx('ultra', false, 0.8).motionBlurStrength;
+        expect(fast).toBeGreaterThan(slow);
+        expect(fx('ultra', false, 5).motionBlurStrength).toBeCloseTo(0.6);
+    });
+
+    it('does not let DOF depend on speed', () => {
+        expect(fx('ultra', false, 0).dofStrength).toBe(fx('ultra', false, 1).dofStrength);
+    });
+
+    it('treats a non-finite speed as stationary', () => {
+        expect(fx('ultra', false, Number.NaN).motionBlurStrength).toBe(0);
+    });
+});

--- a/src/renderer/cinematicCameraFx.ts
+++ b/src/renderer/cinematicCameraFx.ts
@@ -1,0 +1,81 @@
+/**
+ * cinematicCameraFx.ts — gating policy for depth of field and motion blur.
+ *
+ * Both effects cost extra scene taps in the weather post pass and both can
+ * provoke motion sickness, so they only turn on when *all* of these hold:
+ *   - the active quality preset enables them (High = DOF, Ultra = DOF + blur)
+ *   - the user has not asked for reduced motion (OS media query or the
+ *     in-app accessibility toggle)
+ *
+ * Motion blur additionally scales with car/cruise speed so a parked car gets
+ * none of it; DOF is speed-independent (it's a lens property, not motion).
+ *
+ * Pure functions — covered by cinematicCameraFx.test.ts. The resolved numbers
+ * land in weather uniform slots 38/39 (see weatherUniformLayout.ts).
+ */
+
+import { PRESETS, QualityLevel } from '../config/visualPresets';
+
+export interface CinematicCameraFxInput {
+    quality: QualityLevel;
+    /** True when either the OS media query or the a11y panel asks for it. */
+    reducedMotion: boolean;
+    /** Normalized 0–1 travel speed (see cameraMotionSignal.ts). */
+    speedNormalized: number;
+}
+
+export interface CinematicCameraFx {
+    /** Uniform 38 — 0 disables the DOF taps entirely. */
+    dofStrength: number;
+    /** Uniform 39 — 0 disables the radial blur taps entirely. */
+    motionBlurStrength: number;
+}
+
+export const CINEMATIC_FX_OFF: CinematicCameraFx = {
+    dofStrength: 0,
+    motionBlurStrength: 0,
+};
+
+/** Quality levels allowed to spend frame budget on camera FX. */
+const CINEMATIC_QUALITY_LEVELS: ReadonlySet<QualityLevel> = new Set<QualityLevel>(['high', 'ultra']);
+
+export function isCinematicQuality(quality: QualityLevel): boolean {
+    return CINEMATIC_QUALITY_LEVELS.has(quality);
+}
+
+const clamp01 = (v: number): number => Math.min(1, Math.max(0, Number.isFinite(v) ? v : 0));
+
+export function resolveCinematicCameraFx(input: CinematicCameraFxInput): CinematicCameraFx {
+    if (input.reducedMotion || !isCinematicQuality(input.quality)) {
+        return { ...CINEMATIC_FX_OFF };
+    }
+
+    const preset = PRESETS[input.quality];
+    const speed = clamp01(input.speedNormalized);
+
+    // DOF: a light lens defocus on the far field. Ultra gets a wider bokeh.
+    const dofStrength = preset.depthOfFieldEnabled
+        ? (input.quality === 'ultra' ? 0.55 : 0.35)
+        : 0;
+
+    // Motion blur: nothing while stationary, ramping in over the first ~40% of
+    // the speed range so gentle cruising stays crisp.
+    const motionBlurStrength = preset.motionBlurEnabled
+        ? clamp01((speed - 0.12) / 0.5) * 0.6
+        : 0;
+
+    return { dofStrength, motionBlurStrength };
+}
+
+/**
+ * True when the OS asks for reduced motion. Safe to call outside a browser
+ * (SSR / vitest node env) — returns false when matchMedia is unavailable.
+ */
+export function prefersReducedMotion(): boolean {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+    try {
+        return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    } catch {
+        return false;
+    }
+}

--- a/src/renderer/packWeatherParams.test.ts
+++ b/src/renderer/packWeatherParams.test.ts
@@ -69,12 +69,14 @@ describe('packWeatherParams', () => {
         expect(params[I.cameraPitch]).toBeCloseTo(0.5);
         expect(params[I.wasmNoiseEnabled]).toBe(0);
         expect(params[I.dustIntensity]).toBe(0);
-        // sunAltitude 0.6 → sunVisible = 1 → shafts 0.5, flare 0.4, streak 0.5
-        expect(params[I.lightShaftsIntensity]).toBeCloseTo(0.5);
+        // sunAltitude 0.6, clear sky → sunVisibility 1. Shafts need something to
+        // scatter in, so with zero haze they sit at their 0.35 floor.
+        expect(params[I.lightShaftsIntensity]).toBeCloseTo(0.35);
         expect(params[I.lensFlareIntensity]).toBeCloseTo(0.4);
         expect(params[I.anamorphicStreak]).toBeCloseTo(0.5);
-        expect(params[I._pad2]).toBe(0);
-        expect(params[I._pad3]).toBe(0);
+        // Cinematic FX default off when no gate result is supplied
+        expect(params[I.dofStrength]).toBe(0);
+        expect(params[I.motionBlurStrength]).toBe(0);
     });
 
     it('packs a night preset with headlights and dome light', () => {
@@ -122,11 +124,52 @@ describe('packWeatherParams', () => {
         expect(params[I.rainIntensity]).toBeCloseTo(1.0); // 50/100*2
         expect(params[I.snowIntensity]).toBeCloseTo(0.5); // 25/100*2
         expect(params[I.wind]).toBeCloseTo(1.0); // 100/100*2-1
-        expect(params[I.fogIntensity]).toBeCloseTo(0.4);
-        expect(params[I.fogDensity]).toBeCloseTo(0.4);
+        // Fog now splits into an ambient wash + a depth-integrated ground bank,
+        // and rain contributes its own low mist (see weatherCohesion.ts).
+        expect(params[I.fogIntensity]).toBeCloseTo(0.22);
+        expect(params[I.fogDensity]).toBeCloseTo(0.6);
         expect(params[I.sunrise]).toBe(1);
         expect(params[I.wasmNoiseEnabled]).toBe(1);
-        expect(params[I.dustIntensity]).toBeCloseTo(0.3);
+        // Rain washes dust out of the air: 0.3 * (1 - 0.5) * (1 - 0.25*0.5)
+        expect(params[I.dustIntensity]).toBeCloseTo(0.13125);
+        expect(params[I.humidityHaze]).toBeGreaterThan(0);
+    });
+
+    it('couples atmospheric channels: rain implies overcast and wet air', () => {
+        const clear = packWeatherParams({
+            env: baseEnv({ sunAltitude: 0.6 }),
+            timeSeconds: 0,
+            cameraHeading: 0,
+            cameraPitch: 0.5,
+            wasmNoiseActive: true,
+        });
+        const storm = packWeatherParams({
+            env: baseEnv({ sunAltitude: 0.6, rainIntensity: 100, wind: 90 }),
+            timeSeconds: 0,
+            cameraHeading: 0,
+            cameraPitch: 0.5,
+            wasmNoiseActive: true,
+        });
+        const I = WeatherParamIndex;
+
+        expect(storm[I.lensFlareIntensity]!).toBeLessThan(clear[I.lensFlareIntensity]!);
+        expect(storm[I.anamorphicStreak]!).toBeLessThan(clear[I.anamorphicStreak]!);
+        expect(storm[I.humidityHaze]!).toBeGreaterThan(clear[I.humidityHaze]!);
+        expect(storm[I.dustIntensity]!).toBeLessThan(clear[I.dustIntensity]!);
+        expect(storm[I.fogDensity]!).toBeGreaterThan(0);
+    });
+
+    it('passes resolved cinematic camera FX through to slots 38/39', () => {
+        const params = packWeatherParams({
+            env: baseEnv(),
+            timeSeconds: 0,
+            cameraHeading: 0,
+            cameraPitch: 0.5,
+            wasmNoiseActive: false,
+            cinematic: { dofStrength: 0.55, motionBlurStrength: 0.42 },
+        });
+        expect(params[WeatherParamIndex.dofStrength]).toBeCloseTo(0.55);
+        expect(params[WeatherParamIndex.motionBlurStrength]).toBeCloseTo(0.42);
     });
 
     it('createDefaultWeatherParams matches historical processor defaults', () => {

--- a/src/renderer/packWeatherParams.ts
+++ b/src/renderer/packWeatherParams.ts
@@ -2,6 +2,8 @@ import {
     WEATHER_PARAMS_FLOAT_COUNT,
     WeatherParamIndex,
 } from './weatherUniformLayout';
+import { resolveWeatherCohesion } from './weatherCohesion';
+import { CINEMATIC_FX_OFF, CinematicCameraFx } from './cinematicCameraFx';
 
 /** Env + frame fields needed to pack the 40-float weather uniform array. */
 export interface WeatherParamsEnvInput {
@@ -37,6 +39,12 @@ export interface PackWeatherParamsOptions {
     cameraPitch: number;
     /** True when WASM noise tile is enabled and ready. */
     wasmNoiseActive: boolean;
+    /**
+     * Resolved depth-of-field / motion-blur strengths (uniforms 38-39). Omit
+     * to ship the pass with both effects off — see cinematicCameraFx.ts for
+     * the quality + reduced-motion gate that produces this.
+     */
+    cinematic?: CinematicCameraFx;
 }
 
 /**
@@ -56,12 +64,24 @@ export function createDefaultWeatherParams(): Float32Array {
 /**
  * Pack environment settings into the shared 40-float weather layout.
  * Preserves UI→shader scaling used by WebGPUCanvas (rain/snow /100*2, wind
- * /100*2-1, fog /100, sun-driven shafts/flare/anamorphic, dust tied to WASM).
+ * /100*2-1). Atmospheric channels (fog, haze, dust, sun FX) are derived
+ * together by resolveWeatherCohesion so presets tell one physical story —
+ * see weatherCohesion.ts and docs/GRAPHICS.md.
  */
 export function packWeatherParams(options: PackWeatherParamsOptions): Float32Array {
     const { env: e, timeSeconds, cameraHeading, cameraPitch, wasmNoiseActive } = options;
     const params = new Float32Array(WEATHER_PARAMS_FLOAT_COUNT);
     const I = WeatherParamIndex;
+
+    const atmosphere = resolveWeatherCohesion({
+        rainIntensity: e.rainIntensity,
+        snowIntensity: e.snowIntensity,
+        fogDensity: e.fogDensity,
+        sunAltitude: e.sunAltitude,
+        nightIntensity: e.nightIntensity,
+        wasmNoiseActive,
+    });
+    const cinematic = options.cinematic ?? CINEMATIC_FX_OFF;
 
     // [0-5]: Color grading (UI 1.0 = neutral for vibrance/saturation/contrast)
     params[I.vibrance] = e.vibrance - 1.0;
@@ -95,18 +115,18 @@ export function packWeatherParams(options: PackWeatherParamsOptions): Float32Arr
     params[I.moonAzimuth] = e.moonAzimuth;
     params[I.moonAltitude] = e.moonAltitude;
 
-    // [22-31]: Atmospheric effects
-    params[I.fogIntensity] = e.fogDensity / 100.0;
-    params[I.fogDensity] = e.fogDensity / 100.0;
-    params[I.fogHeight] = 0.0;
-    params[I.fogColorIndex] = 0.0;
-    const sunVisible = e.sunAltitude > 0 ? Math.min(e.sunAltitude / 0.3, 1.0) : 0.0;
-    params[I.lightShaftsIntensity] = sunVisible * 0.5;
+    // [22-31]: Atmospheric effects (cohesive — precipitation implies overcast,
+    // overcast suppresses direct-sun FX, rain wets the air and scrubs dust)
+    params[I.fogIntensity] = atmosphere.fogIntensity;
+    params[I.fogDensity] = atmosphere.fogDensity;
+    params[I.fogHeight] = atmosphere.fogHeight;
+    params[I.fogColorIndex] = atmosphere.fogColorIndex;
+    params[I.lightShaftsIntensity] = atmosphere.lightShaftsIntensity;
     params[I.heatShimmerIntensity] = 0.0;
-    params[I.lensFlareIntensity] = sunVisible * 0.4;
+    params[I.lensFlareIntensity] = atmosphere.lensFlareIntensity;
     params[I.chromaticAberration] = 0.0;
-    params[I.dustIntensity] = wasmNoiseActive ? 0.3 : 0.0;
-    params[I.humidityHaze] = 0.0;
+    params[I.dustIntensity] = atmosphere.dustIntensity;
+    params[I.humidityHaze] = atmosphere.humidityHaze;
 
     // [32]: Shader effects enabled flag
     params[I.shaderEffectsEnabled] = e.shaderEffectsEnabled ? 1.0 : 0.0;
@@ -116,13 +136,13 @@ export function packWeatherParams(options: PackWeatherParamsOptions): Float32Arr
     params[I.cameraPitch] = cameraPitch;
     params[I.wasmNoiseEnabled] = wasmNoiseActive ? 1.0 : 0.0;
 
-    // [36-37]
+    // [36-37]: sunrise wash + anamorphic streak (also overcast-suppressed)
     params[I.sunrise] = e.timeOfDay === 'sunrise' ? 1.0 : 0.0;
-    params[I.anamorphicStreak] = sunVisible * 0.5;
+    params[I.anamorphicStreak] = atmosphere.anamorphicStreak;
 
-    // [38-39]: padding (already 0)
-    params[I._pad2] = 0.0;
-    params[I._pad3] = 0.0;
+    // [38-39]: cinematic camera FX — zero unless quality + a11y gates pass
+    params[I.dofStrength] = cinematic.dofStrength;
+    params[I.motionBlurStrength] = cinematic.motionBlurStrength;
 
     return params;
 }

--- a/src/renderer/weatherCohesion.test.ts
+++ b/src/renderer/weatherCohesion.test.ts
@@ -1,0 +1,117 @@
+import { resolveWeatherCohesion, resolveSunVisibility, FogColorIndex } from './weatherCohesion';
+
+function baseInput(overrides: Partial<Parameters<typeof resolveWeatherCohesion>[0]> = {}) {
+    return {
+        rainIntensity: 0,
+        snowIntensity: 0,
+        fogDensity: 0,
+        sunAltitude: 0.6,
+        nightIntensity: 0,
+        wasmNoiseActive: false,
+        ...overrides,
+    };
+}
+
+describe('resolveWeatherCohesion', () => {
+    it('leaves a clear day fully sunlit with no fog or haze', () => {
+        const r = resolveWeatherCohesion(baseInput());
+        expect(r.precipitation).toBe(0);
+        expect(r.overcast).toBe(0);
+        expect(r.sunVisibility).toBe(1);
+        expect(r.fogIntensity).toBe(0);
+        expect(r.fogDensity).toBe(0);
+        expect(r.humidityHaze).toBe(0);
+        expect(r.lensFlareIntensity).toBeCloseTo(0.4);
+    });
+
+    it('suppresses direct-sun FX under heavy rain (overcast sky)', () => {
+        const clear = resolveWeatherCohesion(baseInput());
+        const storm = resolveWeatherCohesion(baseInput({ rainIntensity: 100 }));
+
+        expect(storm.overcast).toBeGreaterThan(0.8);
+        expect(storm.sunVisibility).toBeLessThan(0.2);
+        expect(storm.lensFlareIntensity).toBeLessThan(clear.lensFlareIntensity);
+        expect(storm.anamorphicStreak).toBeLessThan(clear.anamorphicStreak);
+        expect(storm.lightShaftsIntensity).toBeLessThan(clear.lightShaftsIntensity);
+    });
+
+    it('wets the air with rain and scrubs dust out of it', () => {
+        const dry = resolveWeatherCohesion(baseInput({ wasmNoiseActive: true }));
+        const wet = resolveWeatherCohesion(baseInput({ rainIntensity: 80, wasmNoiseActive: true }));
+
+        expect(wet.humidityHaze).toBeGreaterThan(dry.humidityHaze);
+        expect(wet.dustIntensity).toBeLessThan(dry.dustIntensity);
+        expect(dry.dustIntensity).toBeCloseTo(0.3);
+    });
+
+    it('keeps dust at zero when the WASM noise tile is unavailable', () => {
+        expect(resolveWeatherCohesion(baseInput()).dustIntensity).toBe(0);
+    });
+
+    it('separates the fog wash from the depth-integrated ground bank', () => {
+        const r = resolveWeatherCohesion(baseInput({ fogDensity: 40 }));
+        // Previously both slots carried the identical 0.4 slider value, which
+        // double-counted inside the shader.
+        expect(r.fogIntensity).not.toBeCloseTo(r.fogDensity);
+        expect(r.fogIntensity).toBeCloseTo(0.22);
+        expect(r.fogDensity).toBeCloseTo(0.46);
+    });
+
+    it('adds low ground mist under precipitation even with the fog slider at zero', () => {
+        const r = resolveWeatherCohesion(baseInput({ rainIntensity: 100 }));
+        expect(r.fogDensity).toBeGreaterThan(0);
+        expect(r.fogHeight).toBeLessThan(0.2); // pushed down to the ground
+    });
+
+    it('lifts thin fog into a higher haze band and settles thick fog low', () => {
+        const thin = resolveWeatherCohesion(baseInput({ fogDensity: 10 }));
+        const thick = resolveWeatherCohesion(baseInput({ fogDensity: 100 }));
+        expect(thin.fogHeight).toBeGreaterThan(thick.fogHeight);
+        expect(thick.fogHeight).toBe(0);
+    });
+
+    it('switches fog to the blue palette at night', () => {
+        expect(resolveWeatherCohesion(baseInput({ fogDensity: 50 })).fogColorIndex)
+            .toBe(FogColorIndex.gray);
+        expect(resolveWeatherCohesion(baseInput({ fogDensity: 50, nightIntensity: 1 })).fogColorIndex)
+            .toBe(FogColorIndex.blue);
+    });
+
+    it('takes the dominant precipitation channel rather than summing them', () => {
+        const both = resolveWeatherCohesion(baseInput({ rainIntensity: 100, snowIntensity: 100 }));
+        const rainOnly = resolveWeatherCohesion(baseInput({ rainIntensity: 100 }));
+        expect(both.precipitation).toBeCloseTo(rainOnly.precipitation);
+    });
+
+    it('clamps all outputs into shader-safe ranges', () => {
+        const r = resolveWeatherCohesion(baseInput({
+            rainIntensity: 999,
+            snowIntensity: 999,
+            fogDensity: 999,
+            nightIntensity: 5,
+        }));
+        for (const value of [
+            r.precipitation, r.overcast, r.sunVisibility, r.fogDensity,
+            r.fogHeight, r.humidityHaze, r.dustIntensity,
+        ]) {
+            expect(value).toBeGreaterThanOrEqual(0);
+            expect(value).toBeLessThanOrEqual(1);
+        }
+    });
+});
+
+describe('resolveSunVisibility', () => {
+    it('is zero below the horizon regardless of cloud cover', () => {
+        expect(resolveSunVisibility(-0.2, 0)).toBe(0);
+    });
+
+    it('ramps in over the first ~17 degrees of altitude', () => {
+        expect(resolveSunVisibility(0.15, 0)).toBeCloseTo(0.5);
+        expect(resolveSunVisibility(0.3, 0)).toBeCloseTo(1);
+        expect(resolveSunVisibility(1.2, 0)).toBeCloseTo(1);
+    });
+
+    it('is fully occluded by total overcast', () => {
+        expect(resolveSunVisibility(1.0, 1)).toBe(0);
+    });
+});

--- a/src/renderer/weatherCohesion.ts
+++ b/src/renderer/weatherCohesion.ts
@@ -1,0 +1,133 @@
+/**
+ * weatherCohesion.ts — CPU-side coupling between weather channels.
+ *
+ * Before this module every atmospheric channel was independent: rain could
+ * fall under a clear lens-flared sky, fog and precipitation both wrote the
+ * same `fogDensity` value into two different uniform slots (double counting),
+ * and dust motes kept sparkling through a downpour.
+ *
+ * The rules below give the presets a single physical story:
+ *   1. Precipitation implies cloud cover, and cloud cover kills direct-sun FX.
+ *   2. Rain wets the air — humidity haze and low ground mist follow it.
+ *   3. Rain washes dust out of the air; snow does not (it *is* the particle).
+ *   4. Fog splits into a screen-wide ambient wash (`fogIntensity`) and a
+ *      depth-integrated ground bank (`fogDensity`) instead of both carrying
+ *      the same number.
+ *
+ * Pure functions only — consumed by packWeatherParams.ts and covered by
+ * weatherCohesion.test.ts. Look targets are documented in docs/GRAPHICS.md.
+ */
+
+/** Raw UI-space inputs (all 0–100 sliders except sunAltitude in radians). */
+export interface WeatherCohesionInput {
+    /** UI slider 0–100. */
+    rainIntensity: number;
+    /** UI slider 0–100. */
+    snowIntensity: number;
+    /** UI slider 0–100. */
+    fogDensity: number;
+    /** Sun altitude in radians (negative = below horizon). */
+    sunAltitude: number;
+    /** 0 = day, 1 = full night. */
+    nightIntensity: number;
+    /** True while the WASM noise tile is uploading usable data. */
+    wasmNoiseActive: boolean;
+}
+
+/** Shader-space atmospheric values derived from the raw inputs. */
+export interface WeatherCohesionResult {
+    /** 0–1 combined precipitation load. */
+    precipitation: number;
+    /** 0–1 sky occlusion from precipitation + fog. */
+    overcast: number;
+    /** 0–1 direct-sun visibility after cloud cover. */
+    sunVisibility: number;
+    fogIntensity: number;
+    fogDensity: number;
+    fogHeight: number;
+    fogColorIndex: number;
+    humidityHaze: number;
+    dustIntensity: number;
+    lightShaftsIntensity: number;
+    lensFlareIntensity: number;
+    anamorphicStreak: number;
+}
+
+const clamp01 = (v: number): number => Math.min(1, Math.max(0, v));
+
+/** Fog colour palette indices shared with `getFogColor()` in both WGSL paths. */
+export const FogColorIndex = {
+    gray: 0,
+    blue: 1,
+    brown: 2,
+    green: 3,
+} as const;
+
+/**
+ * Direct-sun visibility ramp: fades in over the first ~17° of altitude, then
+ * is attenuated by cloud cover. Used for shafts, flare and anamorphic streak
+ * so all three agree on "is the sun actually shining".
+ */
+export function resolveSunVisibility(sunAltitude: number, overcast: number): number {
+    const altitudeRamp = sunAltitude > 0 ? Math.min(sunAltitude / 0.3, 1.0) : 0.0;
+    return altitudeRamp * (1.0 - clamp01(overcast));
+}
+
+export function resolveWeatherCohesion(input: WeatherCohesionInput): WeatherCohesionResult {
+    const rain = clamp01(input.rainIntensity / 100);
+    const snow = clamp01(input.snowIntensity / 100);
+    const fog = clamp01(input.fogDensity / 100);
+    const night = clamp01(input.nightIntensity);
+
+    // Rain and snow rarely co-exist; take the dominant channel rather than
+    // summing so "rain 100 + snow 100" doesn't read as double-overcast.
+    const precipitation = clamp01(Math.max(rain, snow * 0.9));
+
+    // Precipitation always implies cloud; fog only partially hides the sun
+    // (thin ground fog under a clear sky is a real look worth keeping).
+    const overcast = clamp01(precipitation * 0.85 + fog * 0.45);
+
+    const sunVisibility = resolveSunVisibility(input.sunAltitude, overcast);
+
+    // Fog splits into two channels the shader treats differently:
+    //  - fogIntensity: flat, screen-wide ambient wash (aerial perspective)
+    //  - fogDensity:   extinction coefficient integrated along the depth proxy
+    // Precipitation adds its own low ground mist on top of the slider.
+    const fogIntensity = fog * 0.55;
+    const fogDensity = clamp01(fog * 1.15 + precipitation * 0.28);
+
+    // Height: heavy fog settles into a low bank (0), thin fog sits higher and
+    // reads more like haze (up to 0.45). Rain pushes mist back down to ground.
+    const fogHeight = clamp01((1.0 - fog) * 0.45 * (1.0 - precipitation * 0.6));
+
+    // Night fog picks up the blue palette; heavy daytime fog stays neutral gray.
+    const fogColorIndex = night > 0.6 && fogDensity > 0.05
+        ? FogColorIndex.blue
+        : FogColorIndex.gray;
+
+    // Rain saturates the air; snow does so far less (cold air holds less water).
+    const humidityHaze = clamp01(rain * 0.55 + snow * 0.15 + fog * 0.25);
+
+    // Rain scrubs airborne dust out of the sky. Dust still needs the WASM
+    // turbulence tile to look like anything other than uniform speckle.
+    const dustIntensity = input.wasmNoiseActive
+        ? clamp01(0.3 * (1.0 - rain) * (1.0 - snow * 0.5))
+        : 0.0;
+
+    return {
+        precipitation,
+        overcast,
+        sunVisibility,
+        fogIntensity,
+        fogDensity,
+        fogHeight,
+        fogColorIndex,
+        humidityHaze,
+        dustIntensity,
+        // Shafts need both a visible sun and something to scatter in — a little
+        // haze actually helps them read, so they scale with humidity.
+        lightShaftsIntensity: sunVisibility * (0.35 + humidityHaze * 0.35),
+        lensFlareIntensity: sunVisibility * 0.4,
+        anamorphicStreak: sunVisibility * 0.5,
+    };
+}

--- a/src/renderer/weatherShaderCallArity.test.ts
+++ b/src/renderer/weatherShaderCallArity.test.ts
@@ -1,0 +1,115 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * Static arity guard for the weather WGSL.
+ *
+ * `weather-post-compute.wgsl` shipped for some time with
+ * `applyVolumetricLightShafts(col, uv, intensity, t)` in main() against a
+ * 3-parameter definition. WGSL is only compiled when a GPU device exists, so
+ * nothing in CI (or in any GPU-less environment) noticed that the entire
+ * compute module failed to build and `?weather=compute` silently did nothing.
+ *
+ * This walks every locally-defined function call in both shaders and checks the
+ * argument count against the declaration — the cheap half of what a real WGSL
+ * compiler would tell us, minus the GPU.
+ */
+
+function readShader(name: string): string {
+    return fs.readFileSync(path.join(__dirname, '..', '..', 'public', 'shaders', name), 'utf8');
+}
+
+/** Strip line comments so commented-out code can't produce phantom calls. */
+function stripComments(source: string): string {
+    return source.replace(/\/\/.*$/gm, '');
+}
+
+/** Map of locally-declared function name → declared parameter count. */
+function declaredFunctions(source: string): Map<string, number> {
+    const declarations = new Map<string, number>();
+    const re = /\bfn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)/g;
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(source)) !== null) {
+        const params = match[2]!.trim();
+        declarations.set(match[1]!, params === '' ? 0 : params.split(',').length);
+    }
+    return declarations;
+}
+
+/** Argument count of the call starting at `openParen`, respecting nesting. */
+function countArguments(source: string, openParen: number): number | null {
+    let depth = 0;
+    let args = 0;
+    let sawContent = false;
+    for (let i = openParen; i < source.length; i += 1) {
+        const ch = source[i]!;
+        if (ch === '(' || ch === '[' || ch === '<') depth += 1;
+        else if (ch === ')' || ch === ']' || ch === '>') {
+            depth -= 1;
+            if (depth === 0) return sawContent ? args + 1 : 0;
+        } else if (ch === ',' && depth === 1) args += 1;
+        else if (!/\s/.test(ch) && depth >= 1) sawContent = true;
+    }
+    return null;
+}
+
+interface ArityMismatch {
+    fn: string;
+    declared: number;
+    called: number;
+}
+
+function findArityMismatches(rawSource: string): ArityMismatch[] {
+    const source = stripComments(rawSource);
+    const declarations = declaredFunctions(source);
+    const mismatches: ArityMismatch[] = [];
+
+    for (const [name, declared] of declarations) {
+        // Match calls but not the declaration itself (`fn name(`).
+        const re = new RegExp(`(^|[^A-Za-z0-9_])${name}\\s*\\(`, 'g');
+        let match: RegExpExecArray | null;
+        while ((match = re.exec(source)) !== null) {
+            const before = source.slice(Math.max(0, match.index - 4), match.index + match[1]!.length);
+            if (/\bfn\s*$/.test(before)) continue;
+
+            const openParen = source.indexOf('(', match.index + match[0]!.length - 1);
+            const called = countArguments(source, openParen);
+            if (called !== null && called !== declared) {
+                mismatches.push({ fn: name, declared, called });
+            }
+        }
+    }
+    return mismatches;
+}
+
+describe('weather WGSL call arity', () => {
+    it.each(['weather-post.wgsl', 'weather-post-compute.wgsl'])(
+        '%s calls every locally-defined function with its declared argument count',
+        (shader) => {
+            expect(findArityMismatches(readShader(shader))).toEqual([]);
+        }
+    );
+
+    it('detects a mismatched call (guard is actually working)', () => {
+        const broken = `
+            fn helper(a: f32, b: f32) -> f32 { return a + b; }
+            fn main() -> f32 { return helper(1.0, 2.0, 3.0); }
+        `;
+        expect(findArityMismatches(broken)).toEqual([
+            { fn: 'helper', declared: 2, called: 3 },
+        ]);
+    });
+
+    it('accepts nested calls and zero-argument functions', () => {
+        const fine = `
+            fn zero() -> f32 { return 1.0; }
+            fn add(a: f32, b: f32) -> f32 { return a + b; }
+            fn main() -> f32 { return add(add(zero(), 2.0), zero()); }
+        `;
+        expect(findArityMismatches(fine)).toEqual([]);
+    });
+});

--- a/src/renderer/weatherShaderParity.test.ts
+++ b/src/renderer/weatherShaderParity.test.ts
@@ -50,6 +50,18 @@ function normalizeSnowBody(code: string): string {
     .replace(/p\.snowIntensity/g, 'snowInt');
 }
 
+/**
+ * Compute-path helpers read uniforms through `p_name()` accessors where the
+ * fragment path uses `p.name`. Normalize that difference so shared bodies can
+ * be compared verbatim.
+ */
+function normalizeAccessors(code: string): string {
+  return normalizeWgsl(code)
+    .replace(/p_([A-Za-z0-9]+)\(\)/g, 'p.$1')
+    .replace(/readTexture/g, 'sceneTex')
+    .replace(/u_sampler/g, 'linearSampler');
+}
+
 describe('weather shader parity guard', () => {
   it('keeps applyNight identical between fragment and compute paths', () => {
     const fragment = readShader('weather-post.wgsl');
@@ -69,6 +81,64 @@ describe('weather shader parity guard', () => {
     const computeSnow = normalizeSnowBody(extractFunctionBody(compute, 'snow'));
 
     expect(computeSnow).toBe(fragmentSnow);
+  });
+
+  it.each(['viewHorizonY', 'viewDepthProxy', 'fogHeightFalloff'])(
+    'keeps the %s depth-proxy helper identical between fragment and compute paths',
+    (fnName) => {
+      const fragment = readShader('weather-post.wgsl');
+      const compute = readShader('weather-post-compute.wgsl');
+
+      expect(normalizeWgsl(extractFunctionBody(compute, fnName)))
+        .toBe(normalizeWgsl(extractFunctionBody(fragment, fnName)));
+    }
+  );
+
+  it.each([
+    'fogAmountAt',
+    'applyFog',
+    'applySunrise',
+    'applyCameraFX',
+    'applyDustParticles',
+    'applyVolumetricLightShafts',
+  ])(
+    'keeps %s aligned between fragment and compute paths',
+    (fnName) => {
+      const fragment = readShader('weather-post.wgsl');
+      const compute = readShader('weather-post-compute.wgsl');
+
+      expect(normalizeAccessors(extractFunctionBody(compute, fnName)))
+        .toBe(normalizeAccessors(extractFunctionBody(fragment, fnName)));
+    }
+  );
+
+  it('binds the WASM noise tile in both paths (no compute-only dust regression)', () => {
+    const fragment = readShader('weather-post.wgsl');
+    const compute = readShader('weather-post-compute.wgsl');
+
+    // Both must sample the tile for dust cloud density.
+    for (const source of [fragment, compute]) {
+      expect(source).toContain('fn sampleWasmNoiseTile(');
+      expect(source).toMatch(/cloudDensity = 0\.35 \+ 0\.65 \* \(0\.5 \+ 0\.5 \* sampleWasmNoiseTile\(cloudUV\)\)/);
+    }
+
+    // The compute path reads it through the plasmaBuffer slot (binding 12).
+    expect(compute).toMatch(/@group\(0\) @binding\(12\) var<storage, read> plasmaBuffer/);
+    expect(compute).toContain('plasmaBuffer[i / 4]');
+  });
+
+  it('writes the depth proxy into the compute pass storage texture', () => {
+    const compute = readShader('weather-post-compute.wgsl');
+    expect(compute).toMatch(/textureStore\(\s*writeDepthTexture/);
+  });
+
+  it('keeps precipitation fog attenuation aligned across WGSL paths', () => {
+    const fragment = readShader('weather-post.wgsl');
+    const compute = readShader('weather-post-compute.wgsl');
+
+    for (const source of [fragment, compute]) {
+      expect(source).toContain('let precipVisibility = 1.0 - fogMask * 0.75;');
+    }
   });
 
   it('keeps night headlight multipliers aligned across WGSL paths', () => {

--- a/src/renderer/weatherUniformLayout.test.ts
+++ b/src/renderer/weatherUniformLayout.test.ts
@@ -57,8 +57,8 @@ const DOCUMENTED_LAYOUT: ReadonlyArray<[WeatherParamName, number]> = [
     ['wasmNoiseEnabled', 35],
     ['sunrise', 36],
     ['anamorphicStreak', 37],
-    ['_pad2', 38],
-    ['_pad3', 39],
+    ['dofStrength', 38],
+    ['motionBlurStrength', 39],
 ];
 
 describe('weatherUniformLayout', () => {

--- a/src/renderer/weatherUniformLayout.ts
+++ b/src/renderer/weatherUniformLayout.ts
@@ -62,9 +62,10 @@ export const WeatherParamIndex = {
     // 36-37
     sunrise: 36,
     anamorphicStreak: 37,
-    // 38-39: padding to reach 40 floats (160 bytes total)
-    _pad2: 38,
-    _pad3: 39,
+    // 38-39: cinematic camera FX (gated by quality >= high + reduced motion,
+    // see src/renderer/cinematicCameraFx.ts). Total stays 40 floats / 160 bytes.
+    dofStrength: 38,
+    motionBlurStrength: 39,
 } as const;
 
 export type WeatherParamName = keyof typeof WeatherParamIndex;

--- a/src/views/CarModeView.tsx
+++ b/src/views/CarModeView.tsx
@@ -7,6 +7,7 @@ import { usePanoInfoPanel } from '../hooks/usePanoInfoPanel';
 import { useCabinEnvironment } from '../hooks/useCabinEnvironment';
 import CarInputHandler from '../components/CarInputHandler';
 import { AudioAnalyzer } from '../audio/AudioAnalyzer';
+import { publishCameraSpeed, resetCameraSpeed } from '../renderer/cameraMotionSignal';
 import { getTopStationForLocation } from '../services/radioBrowserService';
 import {
   initCarMode,
@@ -369,6 +370,9 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
       carSpeedRef.current = telem.speedKmh;
       carRPMRef.current = telem.rpm;
       updateCarGauges(telem.speedKmh, telem.rpm);
+      // Feed the WebGPU post pass so speed-coupled motion blur can react
+      // without re-rendering the canvas at frame rate.
+      publishCameraSpeed(telem.speedKmh);
       // Throttle React state pushes for the compact HUD telemetry chip.
       if (now - lastTelemetryPushRef.current > 150) {
         lastTelemetryPushRef.current = now;
@@ -581,6 +585,7 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
   useEffect(() => {
     if (controlMode === 'freeLook') {
       dynamicsRef.current?.stop();
+      resetCameraSpeed();
       carSpeedRef.current = 0;
       pitchImpulseRef.current = 0;
       steeringInputRef.current = 0;


### PR DESCRIPTION
Implements all three phases of the weather-effects cohesion epic.

## Phase A — Preset cohesion

Atmospheric channels were independent sliders with no physical story between them. New `src/renderer/weatherCohesion.ts` derives them together on the CPU (cheap, testable, identical for every backend):

- **Precipitation implies cloud cover** — overcast now suppresses light shafts, lens flare and anamorphic streak together. A downpour no longer sits under a lens-flared sky.
- **Rain wets the air** — humidity haze follows rain; precipitation adds its own low ground mist even with the fog slider at zero.
- **Rain scrubs dust** — `dustIntensity` scales with `(1 − rain)`.
- **Fog is two quantities, not one** — `fogDensity` (Beer–Lambert extinction) and `fogIntensity` (flat aerial wash) previously received the *same* slider value, double-counting inside the shader.

Fog itself is rebuilt on a **view-depth proxy** (`viewHorizonY` / `viewDepthProxy` / `fogHeightFalloff`) reconstructed from screen Y and camera pitch, replacing a `smoothstep` band pinned to `uv.y 0.5`. Rain and snow now fade into the fog volume rather than punching through it, rain's scene darkening eases at night to protect the readable-night floor from #171, and `applySunrise` became camera-aware to match `sunsetHorizonGlow` (it previously ignored heading entirely, so dawn light stayed glued to one screen region while you turned).

Retuned across all three paths: fragment WGSL, compute WGSL, and the WebGL2 fallback's SDR approximation.

### Measured fog coverage, slider 40, level camera

| Pixel | Before | After |
|-------|--------|-------|
| Near ground (`uv.y` 0.9) | 0.06 | 0.38 |
| Horizon (`uv.y` 0.51) | 0.60 | 0.88 |
| Sky (`uv.y` 0.2) | 0.06 | 0.54 |

Before: a stripe across the middle of the frame that stayed put when the camera pitched, with the road in front of you *clearer* than the mid-distance. After: coverage grows monotonically with distance and tracks the horizon. Full before/after notes in `docs/GRAPHICS.md` §4.

## Phase B — Compute storage wired

Two `image_video_effects` surfaces stop being 1×1 dummies:

- **binding 6** `writeDepthTexture` — full-res `r32float` view-depth proxy, written every dispatch, driving height fog and DOF.
- **binding 12** `plasmaBuffer` — the real 64×64 WASM Perlin tile packed as 1024 `vec4`s, giving the compute path the same drifting dust turbulence the fragment path already had. The two paths visibly disagreed under `?weather=compute` before this.

`readDepthTexture` and `dataTextureA/B/C` remain dummies; status table in `docs/GRAPHICS.md` §5.

## Phase C — Cinematic camera FX

Depth of field and speed-coupled motion blur, in uniform slots 38/39 (reclaimed padding — the block stays 40 floats / 160 bytes). Gated in `src/renderer/cinematicCameraFx.ts` behind **both**:

- active quality preset enables it (High = DOF, Ultra = DOF + motion blur), overridable with `?quality=`
- `prefers-reduced-motion: reduce` is not set

Motion blur additionally scales with travel speed published through `src/renderer/cameraMotionSignal.ts`, which decays to zero ~400 ms after the publisher stops — a parked car gets none of it. Both effects share one 6-tap loop and early-out when both strengths are zero, so the default fragment path pays a single branch.

## Latent bug fixed: the compute path never compiled

`weather-post-compute.wgsl` called `applyVolumetricLightShafts` with four arguments against a three-parameter declaration. Tint rejected the whole module, so `?weather=compute` — and the Ultra preset's default — never produced a compute frame. WGSL is only compiled when a real GPU device exists, so no GPU-less CI run could catch it.

Both shaders now pass `naga --validate 31`, and `src/renderer/weatherShaderCallArity.test.ts` checks every local call's argument count statically (verified against the pre-fix shader: it flags the real regression).

## Acceptance criteria

- [x] Visible preset cohesion improvement with written before/after notes → `docs/GRAPHICS.md`
- [x] ≥1 compute dummy resource replaced by a real effect under `?weather=compute` → two (depth proxy + WASM noise tile)
- [x] DOF or motion blur ships behind quality + a11y gates → both
- [x] Fragment default path stable; parity tests extended where shared → parity guard grew from 3 to 15 cases
- [x] No billing impact — client GPU only, no new API calls
- [x] No new dependencies

## Testing

- `npm test` — 403 passed / 50 files (was 397/49)
- `npm run typecheck`, `npm run lint` — clean
- `naga --validate 31` — both weather shaders validate

Not verified visually: this container has no GPU, so the before/after numbers are computed analytically from the shader math rather than captured from screenshots. Worth an eyeball pass on the fog and sunrise presets, and a `?weather=compute` smoke test now that it compiles.

Unrelated pre-existing break noticed but not touched: `public/shaders/carview.wgsl:552` uses a C-style ternary, which is not valid WGSL. It is only referenced by service-worker precache lists, not loaded by the renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKRHDKrhmE9G2Y1zg2fTsv

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKRHDKrhmE9G2Y1zg2fTsv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cinematic depth-of-field and motion blur that respond to camera quality, movement, and reduced-motion preferences.
  * Improved weather atmosphere with camera-aware fog, depth, lighting, dust, rain, and snow effects.
  * Added quality selection through URL settings, saved preferences, and automatic hardware detection.
  * Improved visual consistency between accelerated and fallback rendering paths.

* **Documentation**
  * Added comprehensive graphics and rendering guidance, including visual targets and camera-effect behavior.

* **Tests**
  * Expanded coverage for weather cohesion, camera effects, rendering parity, and camera movement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->