### PR TITLE
Real rear imagery in the cabin rearview mirror (billing-aware Static feed)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,7 +174,8 @@ webgpu_streetview/
 │   │   ├── DashboardLayout.tsx      # Dashboard zone layout primitives
 │   │   ├── Gauges.tsx               # Speedometer / tachometer
 │   │   ├── Controls.tsx             # Dashboard buttons / sliders
-│   │   ├── RearviewMirror.ts        # Reflective mirror rendering
+│   │   ├── RearviewMirror.ts        # Rear-view glass (true Static feed, else honest unavailable)
+│   │   ├── rearViewFeed.ts          # Throttled/budgeted Street View Static rear imagery (billable)
 │   │   ├── SelectivePostProcessing.ts # Post-process settings manager
 │   │   ├── VehicleManager.ts        # Vehicle configs (sedan, convertible, science-lab, limousine)
 │   │   ├── theme.ts                 # Car interior theme tokens
@@ -411,7 +412,8 @@ Browser Output (top to bottom)
 
 - **`CarInterior.ts`** builds all geometry procedurally using `THREE.BoxGeometry`, `THREE.CylinderGeometry`, and custom `THREE.Shape` extrusions — no external GLTF/OBJ files.
 - **`DashboardUI.tsx`** is a React overlay; its buttons call functions exported from `src/car/index.ts` directly (not through React state).
-- **`RearviewMirror.ts`** renders a 180° behind view into the mirror surface using the Street View canvas.
+- **`RearviewMirror.ts`** renders the cabin rear-view glass. It never samples the forward Street View canvas (a forward *perspective* capture cannot be UV-shifted into a rear view). With a true rear sample bound via `setRearSample()` it shows that imagery, mirror-flipped and UV-registered against the car heading; with none it shows the honest "unavailable" glass.
+- **`rearViewFeed.ts`** is the only source of true rear imagery: a Street View **Static API** sample at `carHeading + 180`. The Static API is **billable per request**, so the feed is opt-in, throttled, deduped, session-budgeted, and killable — see `BILLING_SAFETY_CHECKLIST.md` § "Billable In-App Features" before changing any default. Driven by `useRearViewFeed`; toggled from the car dashboard's **Rear** button.
 - **Vehicles**: `sedan` | `convertible` | `science-lab` | `limousine`. Configs live in `VehicleManager.ts`. Vehicle switching is managed by the `VehicleManager` singleton.
 - **`car/interior/`** contains low-level builders: `GeometryFactory`, `MaterialFactory`, `LightingBuilder`, `LODManager`, `PostProcessingManager`, `RainSystem`, `ClockRenderer`, `InteractionHelper`, `PerformanceProfiler`.
 - **`car/ui/`** contains reusable dashboard primitives: `Button`, `IconButton`, `Slider`, `ToggleGroup`, `AudioVisualizer`, `ControlPanel`, `Icon`, and theme injection utilities.
@@ -570,6 +572,8 @@ The project uses Vitest + React Testing Library plus a side-by-side Playwright E
 - `src/renderer/RendererBackend.test.ts`, `src/renderer/createStreetViewRenderer*.test.ts` — Backend preference/debug-flag parsing and the WebGPU→WebGL2→raw fallback chain.
 - `src/app/sharedSessionSync.test.ts` — Pure host broadcast payload builder + guest teleport dedupe policy.
 - `src/app/historicalExperience.test.ts` — Historical comparison after-label derivation.
+- `src/car/__tests__/rearViewFeed.test.ts` — Static-API URL/cache-key builders and the cost-control policy: throttle, dedupe, blockers, session budget, failure circuit breaker, kill switch.
+- `src/car/__tests__/RearviewMirror.test.ts` — Honest-unavailable fallback plus the true-rear path (bind/clear, UV pan registration, coverage fade, head-pitch independence).
 - `e2e/*.spec.ts` — Playwright smoke + keyed critical paths (see above).
 
 ### Manual Testing Requirements
@@ -593,7 +597,7 @@ Run this after touching `WebGPUCanvas.tsx`, `Renderer.ts`, `useStreetView.tsx`, 
 5. Automated: `npm run test:e2e:keyed` (with `REACT_APP_MAPS_API_KEY`) covers hold-pause probe warnings over N hops; `npm run probe:hold-pause -- --hops=10` adds intra-hold pixel consistency. Non-zero exit / `FAIL` means a probe warning or sudden brightness jump.
 
 ### Car Spatial Correctness Manual Checklist
-Run this after touching `RearviewMirror.ts`, `CarInputHandler.tsx`, `CarInteriorAnimator.ts`, `carSpatialModel.ts`, `weather-post.wgsl`, `weather-post-compute.wgsl`, or `WebGLFallbackRenderer.ts` (epic #171):
+Run this after touching `RearviewMirror.ts`, `rearViewFeed.ts`, `useRearViewFeed.ts`, `CarInputHandler.tsx`, `CarInteriorAnimator.ts`, `carSpatialModel.ts`, `weather-post.wgsl`, `weather-post-compute.wgsl`, or `WebGLFallbackRenderer.ts` (epic #171):
 
 **World model** (`src/car/carSpatialModel.ts`): car body yaw = `carHeading`; head look = Street View `heading`/`pitch`. Free-look pans the head only. Chassis steers only in `carSteer`, temp-steer (steering-wheel grab), or explicit steer keys.
 
@@ -604,22 +608,33 @@ Run this after touching `RearviewMirror.ts`, `CarInputHandler.tsx`, `CarInterior
    - Grab the steering wheel and drag — chassis may yaw (temp-steer). Release — back to head-only look.
    - Press `H` into `carSteer`, drag — chassis yaws with mouse X. RMB/Shift in free-look must **not** steer.
 
-2. **Rearview mirror (honest unavailable until true rear feed)**
-   - Look up at the interior rearview glass.
+2. **Rearview mirror — feed OFF (default)**
+   - Look up at the interior rearview glass with the dashboard **Rear** button unlit.
    - **Pass**: dark glass with a dim center band (unavailable state). It must **not** show a UV-shifted crop of the forward Street View canvas.
-   - A future true-rear path (second panorama / Static API at `heading+180`, billing-aware) should call `setRearAvailable(true)` once a real feed is bound.
+   - **Billing gate**: open DevTools → Network, filter `maps/api/streetview`, and drive/cruise 10+ hops. **Zero** requests must appear while the toggle is off. Any request here is a release blocker.
 
-3. **Night exposure**
+3. **Rearview mirror — feed ON** (`rearViewFeed.ts`, **billable** — read `BILLING_SAFETY_CHECKLIST.md` first)
+   - Click **Rear** on the dashboard. The billing note under the light row should switch to `On — N requests this session`.
+   - **Pass**: the glass shows real imagery of the road *behind* the car, left/right reversed like a real mirror. Driving forward should push scenery away from you in the glass, not toward you.
+   - Steer left/right without hopping: the imagery should pan to stay world-locked, then fade back to the unavailable glass once you have turned roughly a full 90° FOV away — it must not smear clamped edge texels.
+   - Free-look around the cabin: the mirror must **not** move with your head (car-body space).
+   - **Throttle**: watch the Network panel while cruising. Requests must be spaced ≥3s apart and must stop entirely when parked.
+   - **Dedupe**: hop forward a few panoramas then back. Returning to a visited pose must be served from memory with no new request.
+   - **Blockers**: toggle DevTools offline → the note reads `Paused — offline` and requests stop. Restore the network and they resume. Reload with `?quality=low` → the note reads `Unavailable at Low quality` and the glass stays in the unavailable state.
+   - **Kill switch**: run `window.__REARVIEW_FEED__.kill()` in the console. Requests must stop permanently; re-clicking **Rear** must not resurrect the feed until reload.
+   - **No persistence**: Application → Cache Storage must contain no `maps.googleapis.com` entries (`swPolicy` forces `network-only` for Google hosts).
+
+4. **Night exposure**
    - Apply the Night time-of-day preset (or max night slider). Toggle headlights and dome light.
    - **Pass**: scene reads as night but road + cabin UI remain readable; headlights clearly lift the forward road; not crushed near-black.
    - Repeat with `?renderer=webgl&effect=night` and (WebGPU) default + `?weather=compute` — all three backends should stay in the same ballpark.
 
-4. **Snow / rain fall direction (`?effect=weather`)**
+5. **Snow / rain fall direction (`?effect=weather`)**
    - Set snow (and rain) above 0. WebGPU default: confirm flakes fall **downward**.
    - `?renderer=webgl&effect=weather`: same downward fall (top-origin UV; negative Y time term).
    - Optional: `?weather=compute` on WebGPU — same direction as fragment pass.
 
-5. **Wipers / quality gate**
+6. **Wipers / quality gate**
    - Medium or High quality: toggle wipers from the HUD (or stalk). Blades must sweep; HUD active state matches animator (`getWiperState().enabled`).
    - Low quality: toggle still flips HUD state and blades jump to a raised static "on" pose (no full sweep animation — documented tradeoff). Off returns to park.
 

--- a/BILLING_SAFETY_CHECKLIST.md
+++ b/BILLING_SAFETY_CHECKLIST.md
@@ -55,6 +55,45 @@
 
 ---
 
+## Billable In-App Features
+
+Most of the app runs on the Maps **JavaScript** API (one panorama session). These
+features spend *additional* per-request quota and each ships its own guard rails.
+
+### Rear-view mirror imagery (Street View **Static** API)
+
+`src/car/rearViewFeed.ts` fetches a rear-facing still at `carHeading + 180` so
+the cabin mirror can show what is actually behind the car.
+
+| Guard | Default | Where |
+|-------|---------|-------|
+| Opt-in toggle (persisted, **off** by default) | off | Car dashboard → **Rear**; `useRearViewFeed` |
+| Throttle between network requests | 3000 ms | `REAR_VIEW_DEFAULTS.minIntervalMs` |
+| Movement gate before a pose is even offered | 12 m / 20° / new pano | `useRearViewFeed` |
+| Session request budget (hard stop) | 200 | `REAR_VIEW_DEFAULTS.maxSessionRequests` |
+| Consecutive-failure circuit breaker | 5 | `REAR_VIEW_DEFAULTS.maxConsecutiveErrors` |
+| Blocked entirely | offline, Maps auth failure, Low quality, no key | `RearViewFeed.setBlocked()` |
+| Cache | session memory only, 48 entries, never persisted | `RearViewFeed` LRU |
+
+**Kill switch** — from DevTools on any page running car mode:
+
+```js
+window.__REARVIEW_FEED__.kill();   // aborts in-flight, drops cache, permanent
+window.__REARVIEW_FEED__.getStats(); // networkRequests, budgetRemaining, blockReason
+```
+
+`kill()` is permanent for the life of the page; re-enabling the toggle will not
+resurrect it. Reload after the underlying billing issue is resolved.
+
+**Checks before shipping a change to this feature**:
+
+- [ ] Toggle still defaults **off** for a fresh profile (`localStorage` cleared)
+- [ ] With the toggle off, DevTools → Network shows **zero** `maps/api/streetview` requests
+- [ ] Throttle/dedupe unit tests pass: `npx vitest run src/car/__tests__/rearViewFeed.test.ts`
+- [ ] Google imagery is still `network-only` in `src/offline/swPolicy.ts` (never SW-cached)
+
+---
+
 ## Emergency (Unexpected Costs)
 
 **DO THIS IMMEDIATELY** (within 5 minutes):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,13 @@ src/
   - Functional windshield wipers (animated sweep, toggle control)
   - Live dashboard gauges (speedometer 0-100 km/h, tachometer 0-8000 RPM)
   - Side mirrors (positioned for realistic viewing)
+  - Rearview mirror with optional **true rear imagery** (`car/rearViewFeed.ts`): a
+    Street View Static sample at `carHeading + 180`, bound via
+    `RearviewMirror.setRearSample()`. The Static API is **billable**, so the feed is
+    opt-in (dashboard **Rear** button), throttled, deduped, session-budgeted, and
+    killable via `window.__REARVIEW_FEED__.kill()`. With no sample bound the glass
+    shows an honest "unavailable" state — never a fake crop of the forward canvas.
+    Read `BILLING_SAFETY_CHECKLIST.md` § "Billable In-App Features" before changing it.
   - Toggleable headlights with spotlight effects
   - Dashboard UI in React (`DashboardUI.tsx`)
 - **Control Restrictions**: Only WASD/Arrow keys affect car heading; no mouse steering

--- a/src/car/Controls.tsx
+++ b/src/car/Controls.tsx
@@ -54,6 +54,7 @@ export {
   POWER_ICON,
   FAN_ICON,
   TEMP_ICON,
+  REAR_MIRROR_ICON,
 } from './ui/icons';
 
 const controlsUI = {

--- a/src/car/DashboardUI.module.css
+++ b/src/car/DashboardUI.module.css
@@ -232,6 +232,31 @@
 }
 
 /* --------------------------------------------------------------------------
+   Rear-view feed billing note
+   -------------------------------------------------------------------------- */
+.rearFeedNote {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: 6px;
+  padding: 6px 8px;
+  border: 1px solid rgba(255, 176, 0, 0.28);
+  border-radius: 8px;
+  background: rgba(255, 176, 0, 0.08);
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 10px;
+  line-height: 1.35;
+}
+
+.rearFeedNote strong {
+  color: rgba(255, 208, 120, 0.95);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+}
+
+/* --------------------------------------------------------------------------
    Responsive
    -------------------------------------------------------------------------- */
 @media (max-width: 640px) {

--- a/src/car/DashboardUI.tsx
+++ b/src/car/DashboardUI.tsx
@@ -37,6 +37,7 @@ import {
   HIGHBEAM_ICON,
   DOME_ICON,
   VEHICLE_ICON,
+  REAR_MIRROR_ICON,
 } from './Controls';
 
 // ============================================================================
@@ -61,6 +62,8 @@ export interface DashboardUIProps {
   onToggleHeadlights?: () => void;
   onToggleHighBeam?: () => void;
   onToggleDomeLight?: () => void;
+  /** Toggle the billable rear-view Static imagery feed. Omit to hide the row. */
+  onToggleRearFeed?: () => void;
   onWindowTint?: (value: number) => void;
   onSeatDistance?: (value: number) => void;
   isRoofOpen: boolean;
@@ -68,6 +71,10 @@ export interface DashboardUIProps {
   headlightsOn?: boolean;
   highBeam?: boolean;
   domeLightOn?: boolean;
+  /** Whether the rear-view Static imagery feed is opted in. */
+  rearFeedEnabled?: boolean;
+  /** Human-readable feed state (off / paused / request count) for the row. */
+  rearFeedStatus?: string;
   currentVehicle?: 'sedan' | 'convertible' | 'science-lab' | 'limousine';
   rainIntensity: number;
   snowIntensity?: number;
@@ -214,6 +221,7 @@ export const DashboardUI: React.FC<DashboardUIProps> = ({
   onToggleHeadlights,
   onToggleHighBeam,
   onToggleDomeLight,
+  onToggleRearFeed,
   onWindowTint,
   onSeatDistance,
   isRoofOpen,
@@ -221,6 +229,8 @@ export const DashboardUI: React.FC<DashboardUIProps> = ({
   headlightsOn = false,
   highBeam = false,
   domeLightOn = false,
+  rearFeedEnabled = false,
+  rearFeedStatus,
   currentVehicle = 'sedan',
   rainIntensity,
   snowIntensity = 0,
@@ -458,7 +468,37 @@ export const DashboardUI: React.FC<DashboardUIProps> = ({
                 <Label>Dome</Label>
               </ControlButton>
             )}
+            {onToggleRearFeed && (
+              <ControlButton
+                active={rearFeedEnabled}
+                onClick={onToggleRearFeed}
+                ariaLabel={
+                  'Toggle rear-view mirror imagery (uses billable Street View Static API requests)' +
+                  (rearFeedStatus ? ` — ${rearFeedStatus}` : '')
+                }
+              >
+                <IconSvg
+                  path={REAR_MIRROR_ICON}
+                  size={20}
+                  fill={rearFeedEnabled ? '#fff' : 'rgba(255,255,255,0.7)'}
+                />
+                <Label>Rear</Label>
+              </ControlButton>
+            )}
           </div>
+
+          {/* Billing note — the rear feed is the only control here that spends
+              Google API quota, so it says so rather than hiding the cost. */}
+          {onToggleRearFeed && (
+            <div className={styles.rearFeedNote} role="note">
+              <strong>Rear mirror imagery</strong>
+              <span>
+                {rearFeedStatus ??
+                  (rearFeedEnabled ? 'On' : 'Off — no Street View Static requests')}
+              </span>
+              <span>Uses billable Street View Static requests (throttled, cached in memory only).</span>
+            </div>
+          )}
 
           {/* Weather sliders */}
           <div className={styles.weatherSliders}>

--- a/src/car/RearviewMirror.ts
+++ b/src/car/RearviewMirror.ts
@@ -1,4 +1,6 @@
 import * as THREE from 'three';
+import type { RearViewSample } from './rearViewFeed';
+import { signedHeadingDelta } from './rearViewFeed';
 
 /**
  * RearviewMirror — cabin rear-view glass.
@@ -6,13 +8,23 @@ import * as THREE from 'three';
  * The live Google Maps canvas is a forward-facing *perspective* Street View
  * capture, not an equirectangular pano. UV-offsetting that canvas by +180°
  * therefore cannot show what is behind the car (it just crops the forward
- * view). Until a second rear-facing Street View / Static API sample is wired
- * (billing-aware, throttled), the glass shows an honest "unavailable" state
- * rather than a fake forward crop.
+ * view), so the forward canvas is never sampled here.
+ *
+ * A **true** rear feed comes from `rearViewFeed.ts`: a throttled, budgeted
+ * Street View Static API sample taken at `carHeading + 180`. When one is bound
+ * via `setRearSample()`, the glass shows that imagery, horizontally flipped the
+ * way a real mirror is. With no sample bound — feature off, offline, Low
+ * quality, no key, or no imagery at this pano — the glass falls back to an
+ * honest "unavailable" state rather than a fake forward crop.
+ *
+ * Because a Static sample is a still taken at one instant, `updateOrientation()`
+ * re-registers it as the car turns: the UV pan compensates for the heading
+ * delta since capture, and the imagery fades out once the car has rotated past
+ * what the sample's FOV can cover. That is registration of real imagery, not an
+ * invented crop.
  *
  * World model: the mirror mesh is parented in car-body space; head free-look
- * does not reorient it. `updateOrientation` remains a no-op by design until a
- * true rear feed exists.
+ * does not reorient it (head pitch is deliberately ignored).
  */
 export class RearviewMirror {
     private mirrorPlane: THREE.Mesh;
@@ -20,8 +32,14 @@ export class RearviewMirror {
     private isNightMode: boolean = false;
     private rearAvailable: boolean = false;
 
-    // Kept so a future true-rear feed can plug in without reshaping the API.
+    // Retained for API parity only — the forward canvas is never sampled.
     private streetViewCanvas: HTMLCanvasElement | null = null;
+
+    /** Currently bound true-rear Static sample, if any. */
+    private rearSample: RearViewSample | null = null;
+    private rearTexture: THREE.Texture | null = null;
+    /** Signed car-heading rotation since the bound sample was captured. */
+    private headingDeltaDeg: number = 0;
 
     constructor(
         scene: THREE.Scene,
@@ -34,6 +52,12 @@ export class RearviewMirror {
                 nightMode: { value: 0.0 },
                 rearAvailable: { value: 0.0 },
                 time: { value: 0.0 },
+                // True-rear Static sample, horizontally flipped at sample time.
+                rearTex: { value: null },
+                // UV pan (in texture units) compensating car rotation since capture.
+                rearPan: { value: 0.0 },
+                // 0..1 confidence — decays as the car rotates out of the sample's FOV.
+                rearFade: { value: 0.0 },
             },
             vertexShader: `
                 varying vec2 vUv;
@@ -46,6 +70,9 @@ export class RearviewMirror {
                 uniform float nightMode;
                 uniform float rearAvailable;
                 uniform float time;
+                uniform sampler2D rearTex;
+                uniform float rearPan;
+                uniform float rearFade;
                 varying vec2 vUv;
 
                 void main() {
@@ -74,10 +101,24 @@ export class RearviewMirror {
                         : vec3(0.35, 0.38, 0.42);
                     glass = mix(glass, labelColor, label * 0.85);
 
-                    // When a true rear feed is eventually attached, rearAvailable
-                    // flips and the glass brightens as a placeholder until textured.
+                    // True-rear Static sample. A real mirror reverses left/right,
+                    // hence the 1.0 - x; rearPan re-registers the still against how
+                    // far the car has turned since it was captured.
                     if (rearAvailable > 0.5) {
-                        glass = mix(glass, vec3(0.12, 0.13, 0.15), 0.5);
+                        vec2 rearUv = vec2(1.0 - vUv.x + rearPan, vUv.y);
+
+                        // Outside the sample's coverage there is no honest imagery
+                        // to show, so let the unavailable glass through instead of
+                        // smearing clamped edge texels.
+                        vec2 inside = step(vec2(0.0), rearUv) * step(rearUv, vec2(1.0));
+                        float coverage = inside.x * inside.y;
+
+                        vec3 rear = texture2D(rearTex, clamp(rearUv, 0.0, 1.0)).rgb;
+                        // Mirror glass: slightly dimmed, much dimmer at night.
+                        rear *= mix(0.92, 0.42, nightMode);
+                        rear *= mix(0.6, 1.0, vignette);
+
+                        glass = mix(glass, rear, clamp(rearFade, 0.0, 1.0) * coverage);
                     }
 
                     gl_FragColor = vec4(glass, 1.0);
@@ -110,25 +151,59 @@ export class RearviewMirror {
     }
 
     /**
-     * Optionally attach a Street View canvas. The current implementation does
-     * **not** sample it (forward perspective ≠ rear view). Reserved for a
-     * future true-rear feed (second panorama / Static API at heading+180).
+     * Attach the forward Street View canvas. The mirror does **not** sample it
+     * (forward perspective ≠ rear view); the hook exists so callers that track
+     * the scraped canvas keep a single place to notify. Detaching it does not
+     * disturb a bound rear sample, which comes from a separate source.
      */
     public setStreetViewCanvas(canvas: HTMLCanvasElement | null): void {
         this.streetViewCanvas = canvas;
-        // Keep unavailable until a real rear source is provided explicitly.
-        if (!canvas) {
+    }
+
+    /**
+     * Bind (or clear) a true rear-facing Static API sample. Passing null returns
+     * the glass to the honest unavailable state and releases the GPU texture.
+     */
+    public setRearSample(sample: RearViewSample | null): void {
+        if (sample === this.rearSample) return;
+
+        this.releaseRearTexture();
+        this.rearSample = sample;
+
+        if (!sample) {
+            this.headingDeltaDeg = 0;
+            this.applyRearRegistration();
             this.setRearAvailable(false);
+            return;
         }
+
+        const texture = new THREE.Texture(sample.image as TexImageSource);
+        // Static samples are non-power-of-two and never tiled — clamp + linear.
+        texture.wrapS = THREE.ClampToEdgeWrapping;
+        texture.wrapT = THREE.ClampToEdgeWrapping;
+        texture.minFilter = THREE.LinearFilter;
+        texture.magFilter = THREE.LinearFilter;
+        texture.generateMipmaps = false;
+        texture.colorSpace = THREE.SRGBColorSpace;
+        texture.needsUpdate = true;
+
+        this.rearTexture = texture;
+        this.mirrorMaterial.uniforms.rearTex!.value = texture;
+        this.headingDeltaDeg = 0;
+        this.applyRearRegistration();
+        this.setRearAvailable(true);
     }
 
     /**
      * Mark whether a true rear-facing feed is bound. Default is false so the
-     * glass stays in the honest unavailable state.
+     * glass stays in the honest unavailable state. Marking available without a
+     * bound sample is refused — an "available" mirror with nothing to show would
+     * render clamped garbage rather than an honest unavailable state.
      */
     public setRearAvailable(available: boolean): void {
-        this.rearAvailable = available;
-        this.mirrorMaterial.uniforms.rearAvailable!.value = available ? 1.0 : 0.0;
+        const effective = available && this.rearTexture !== null;
+        this.rearAvailable = effective;
+        this.mirrorMaterial.uniforms.rearAvailable!.value = effective ? 1.0 : 0.0;
     }
 
     public isRearAvailable(): boolean {
@@ -136,21 +211,69 @@ export class RearviewMirror {
     }
 
     /**
-     * Orientation hook for a future true-rear camera. No-op while the glass is
-     * in the unavailable state — rotating a fake crop would reintroduce the bug.
+     * Re-register the bound rear sample against the car's current heading.
+     *
+     * The sample is a still taken at one instant. As the car turns, the world it
+     * captured slides across the glass; panning the UVs by the heading delta
+     * over the sample FOV keeps it lined up. Head pitch is ignored on purpose —
+     * the mirror lives in car-body space, so free-look must not move it.
+     *
+     * No-op with no sample bound: rotating an absent feed is exactly the fake
+     * crop this class exists to avoid.
      */
-    public updateOrientation(_carHeading: number, _headPitch: number): void {
-        // Intentionally empty until a rear-facing source exists.
+    public updateOrientation(carHeading: number, _headPitch: number): void {
+        if (!this.rearSample) return;
+        this.headingDeltaDeg = signedHeadingDelta(carHeading, this.rearSample.carHeading);
+        this.applyRearRegistration();
+    }
+
+    /** Push `headingDeltaDeg` into the pan/fade uniforms. */
+    private applyRearRegistration(): void {
+        const sample = this.rearSample;
+        const uniforms = this.mirrorMaterial.uniforms;
+
+        if (!sample) {
+            uniforms.rearPan!.value = 0;
+            uniforms.rearFade!.value = 0;
+            return;
+        }
+
+        const fov = sample.fov > 0 ? sample.fov : 90;
+        uniforms.rearPan!.value = this.headingDeltaDeg / fov;
+
+        // Full confidence while the car is still inside the captured cone; fade
+        // to nothing by the time it has turned a full FOV away.
+        const turned = Math.abs(this.headingDeltaDeg);
+        const fadeStart = fov * 0.35;
+        const fadeEnd = fov;
+        const fade =
+            turned <= fadeStart
+                ? 1
+                : turned >= fadeEnd
+                  ? 0
+                  : 1 - (turned - fadeStart) / (fadeEnd - fadeStart);
+        uniforms.rearFade!.value = fade;
+    }
+
+    private releaseRearTexture(): void {
+        if (this.rearTexture) {
+            this.rearTexture.dispose();
+            this.rearTexture = null;
+        }
+        this.mirrorMaterial.uniforms.rearTex!.value = null;
     }
 
     /**
-     * Per-frame tick. Advances the subtle frost animation; does not sample the
-     * forward Street View canvas.
+     * Per-frame tick. Advances the frost animation and keeps a bound rear sample
+     * registered against the live car heading. Never samples the forward canvas.
      */
-    public update(_carHeading: number, _skipFrame: boolean = false): void {
+    public update(carHeading: number, _skipFrame: boolean = false): void {
         const u = this.mirrorMaterial.uniforms.time;
         if (u) {
             u.value = performance.now() * 0.001;
+        }
+        if (this.rearSample) {
+            this.updateOrientation(carHeading, 0);
         }
     }
 
@@ -164,14 +287,27 @@ export class RearviewMirror {
     }
 
     /** Test/diagnostic: whether the glass is currently sampling a rear feed. */
-    public getStatus(): { rearAvailable: boolean; hasCanvas: boolean } {
+    public getStatus(): {
+        rearAvailable: boolean;
+        hasCanvas: boolean;
+        hasRearSample: boolean;
+        headingDeltaDeg: number;
+        rearPan: number;
+        rearFade: number;
+    } {
         return {
             rearAvailable: this.rearAvailable,
             hasCanvas: this.streetViewCanvas !== null,
+            hasRearSample: this.rearSample !== null,
+            headingDeltaDeg: this.headingDeltaDeg,
+            rearPan: this.mirrorMaterial.uniforms.rearPan!.value as number,
+            rearFade: this.mirrorMaterial.uniforms.rearFade!.value as number,
         };
     }
 
     public dispose(): void {
+        this.releaseRearTexture();
+        this.rearSample = null;
         this.mirrorMaterial.dispose();
         this.mirrorPlane.geometry.dispose();
     }

--- a/src/car/__tests__/RearviewMirror.test.ts
+++ b/src/car/__tests__/RearviewMirror.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as THREE from 'three';
 import { RearviewMirror } from '../RearviewMirror';
+import type { RearViewSample } from '../rearViewFeed';
 
 // Minimal three.js surface used by RearviewMirror — avoid pulling a real WebGL context.
 vi.mock('three', () => {
@@ -46,11 +47,25 @@ vi.mock('three', () => {
     dispose() {}
   }
   class ShaderMaterial {
-    uniforms: Record<string, { value: number }>;
-    constructor(params: { uniforms: Record<string, { value: number }> }) {
+    uniforms: Record<string, { value: unknown }>;
+    constructor(params: { uniforms: Record<string, { value: unknown }> }) {
       this.uniforms = params.uniforms;
     }
     dispose() {}
+  }
+  class Texture {
+    needsUpdate = false;
+    wrapS = 0;
+    wrapT = 0;
+    minFilter = 0;
+    magFilter = 0;
+    generateMipmaps = true;
+    colorSpace = '';
+    disposed = false;
+    constructor(public image: unknown) {}
+    dispose() {
+      this.disposed = true;
+    }
   }
   class MeshStandardMaterial {
     // three.js material options accepted; unused in mock
@@ -70,10 +85,26 @@ vi.mock('three', () => {
     BoxGeometry,
     ShaderMaterial,
     MeshStandardMaterial,
+    Texture,
     Scene,
     WebGLRenderer,
+    ClampToEdgeWrapping: 1001,
+    LinearFilter: 1006,
+    SRGBColorSpace: 'srgb',
   };
 });
+
+function sample(overrides: Partial<RearViewSample> = {}): RearViewSample {
+  return {
+    image: { tag: 'rear' } as unknown as RearViewSample['image'],
+    imageHeading: 270,
+    carHeading: 90,
+    fov: 90,
+    cacheKey: 'pano:P|h18',
+    fetchedAt: 0,
+    ...overrides,
+  };
+}
 
 describe('RearviewMirror honest unavailable state', () => {
   let scene: THREE.Scene;
@@ -88,7 +119,11 @@ describe('RearviewMirror honest unavailable state', () => {
 
   it('defaults to rear-unavailable (no fake forward crop)', () => {
     expect(mirror.isRearAvailable()).toBe(false);
-    expect(mirror.getStatus()).toEqual({ rearAvailable: false, hasCanvas: false });
+    expect(mirror.getStatus()).toMatchObject({
+      rearAvailable: false,
+      hasCanvas: false,
+      hasRearSample: false,
+    });
   });
 
   it('does not mark rear available when only a forward Street View canvas is attached', () => {
@@ -99,14 +134,112 @@ describe('RearviewMirror honest unavailable state', () => {
     expect(mirror.getStatus().hasCanvas).toBe(true);
   });
 
-  it('exposes setRearAvailable for a future true-rear feed', () => {
+  it('refuses setRearAvailable(true) with no rear sample bound', () => {
     mirror.setRearAvailable(true);
-    expect(mirror.isRearAvailable()).toBe(true);
-    mirror.setRearAvailable(false);
+    // An "available" mirror with nothing to sample would render clamped
+    // garbage — the honest unavailable glass is the correct fallback.
     expect(mirror.isRearAvailable()).toBe(false);
   });
 
-  it('updateOrientation remains a no-op (does not invent a rear crop)', () => {
+  it('updateOrientation stays a no-op with no rear sample bound', () => {
     expect(() => mirror.updateOrientation(180, 10)).not.toThrow();
+    expect(mirror.getStatus().rearPan).toBe(0);
+    expect(mirror.getStatus().rearFade).toBe(0);
+  });
+});
+
+describe('RearviewMirror with a true rear feed', () => {
+  let mirror: RearviewMirror;
+
+  beforeEach(() => {
+    mirror = new RearviewMirror(new THREE.Scene(), new THREE.WebGLRenderer());
+  });
+
+  it('goes available once a rear sample is bound', () => {
+    mirror.setRearSample(sample());
+    expect(mirror.isRearAvailable()).toBe(true);
+    expect(mirror.getStatus()).toMatchObject({
+      rearAvailable: true,
+      hasRearSample: true,
+      rearPan: 0,
+      rearFade: 1,
+    });
+  });
+
+  it('returns to the honest unavailable glass when the sample is cleared', () => {
+    mirror.setRearSample(sample());
+    mirror.setRearSample(null);
+    expect(mirror.isRearAvailable()).toBe(false);
+    expect(mirror.getStatus()).toMatchObject({
+      hasRearSample: false,
+      rearPan: 0,
+      rearFade: 0,
+    });
+  });
+
+  it('disposes the previous texture when a newer sample replaces it', () => {
+    mirror.setRearSample(sample({ cacheKey: 'a' }));
+    const first = (
+      mirror.getMirrorMesh().material as unknown as {
+        uniforms: Record<string, { value: { disposed: boolean } | null }>;
+      }
+    ).uniforms.rearTex!.value;
+
+    mirror.setRearSample(sample({ cacheKey: 'b' }));
+    expect(first?.disposed).toBe(true);
+  });
+
+  it('pans the sample to compensate for car rotation since capture', () => {
+    mirror.setRearSample(sample({ carHeading: 90, fov: 90 }));
+
+    // Car has turned 22.5° right: a quarter of the 90° sample FOV.
+    mirror.updateOrientation(112.5, 0);
+    expect(mirror.getStatus().headingDeltaDeg).toBeCloseTo(22.5);
+    expect(mirror.getStatus().rearPan).toBeCloseTo(0.25);
+
+    // Turning the other way pans the other way.
+    mirror.updateOrientation(67.5, 0);
+    expect(mirror.getStatus().rearPan).toBeCloseTo(-0.25);
+  });
+
+  it('measures rotation across the 0/360 seam without a full-circle jump', () => {
+    mirror.setRearSample(sample({ carHeading: 350 }));
+    mirror.updateOrientation(10, 0);
+    expect(mirror.getStatus().headingDeltaDeg).toBeCloseTo(20);
+  });
+
+  it('fades the stale sample out once the car turns past its coverage', () => {
+    mirror.setRearSample(sample({ carHeading: 0, fov: 90 }));
+
+    mirror.updateOrientation(20, 0);
+    expect(mirror.getStatus().rearFade).toBe(1);
+
+    mirror.updateOrientation(65, 0);
+    const partial = mirror.getStatus().rearFade;
+    expect(partial).toBeGreaterThan(0);
+    expect(partial).toBeLessThan(1);
+
+    mirror.updateOrientation(95, 0);
+    expect(mirror.getStatus().rearFade).toBe(0);
+  });
+
+  it('ignores head pitch — the mirror lives in car-body space', () => {
+    mirror.setRearSample(sample({ carHeading: 90 }));
+    mirror.updateOrientation(90, 45);
+    expect(mirror.getStatus().rearPan).toBe(0);
+    mirror.updateOrientation(90, -45);
+    expect(mirror.getStatus().rearPan).toBe(0);
+  });
+
+  it('re-registers against the car heading on each frame tick', () => {
+    mirror.setRearSample(sample({ carHeading: 90, fov: 90 }));
+    mirror.update(112.5);
+    expect(mirror.getStatus().rearPan).toBeCloseTo(0.25);
+  });
+
+  it('releases the texture on dispose', () => {
+    mirror.setRearSample(sample());
+    expect(() => mirror.dispose()).not.toThrow();
+    expect(mirror.getStatus().hasRearSample).toBe(false);
   });
 });

--- a/src/car/__tests__/rearViewFeed.test.ts
+++ b/src/car/__tests__/rearViewFeed.test.ts
@@ -1,0 +1,365 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+    RearViewFeed,
+    buildRearViewUrl,
+    rearViewCacheKey,
+    normalizeDeg,
+    signedHeadingDelta,
+    REAR_VIEW_DEFAULTS,
+    type RearViewImageSource,
+    type RearViewFeedOptions,
+} from '../rearViewFeed';
+
+/** Stand-in for a decoded image; the feed never inspects its contents. */
+function fakeImage(): RearViewImageSource {
+    return { tag: 'fake-image' } as unknown as RearViewImageSource;
+}
+
+/**
+ * Feed wired to a manual clock and a counting loader, so throttle and dedupe
+ * behaviour is asserted on exact request counts rather than timing luck.
+ */
+function makeFeed(overrides: RearViewFeedOptions = {}) {
+    let clock = 100_000;
+    const urls: string[] = [];
+    let resolveWith: 'ok' | 'fail' = 'ok';
+
+    const feed = new RearViewFeed({
+        apiKey: 'test-key',
+        now: () => clock,
+        loadImage: async (url: string) => {
+            urls.push(url);
+            if (resolveWith === 'fail') throw new Error('404');
+            return fakeImage();
+        },
+        ...overrides,
+    });
+
+    return {
+        feed,
+        urls,
+        advance: (ms: number) => {
+            clock += ms;
+        },
+        failNext: () => {
+            resolveWith = 'fail';
+        },
+        succeedNext: () => {
+            resolveWith = 'ok';
+        },
+    };
+}
+
+const POSE = { lat: 40.7128, lng: -74.006, carHeading: 90 };
+
+describe('rearViewFeed helpers', () => {
+    it('normalizes headings into [0, 360)', () => {
+        expect(normalizeDeg(0)).toBe(0);
+        expect(normalizeDeg(370)).toBe(10);
+        expect(normalizeDeg(-10)).toBe(350);
+    });
+
+    it('computes signed shortest heading deltas across the 0/360 seam', () => {
+        expect(signedHeadingDelta(10, 350)).toBe(20);
+        expect(signedHeadingDelta(350, 10)).toBe(-20);
+        expect(signedHeadingDelta(90, 90)).toBe(0);
+    });
+});
+
+describe('buildRearViewUrl', () => {
+    it('targets the Street View Static endpoint at the requested heading', () => {
+        const url = new URL(
+            buildRearViewUrl({ apiKey: 'k', lat: 1.5, lng: 2.5, heading: 270 })
+        );
+        expect(url.host).toBe('maps.googleapis.com');
+        expect(url.pathname).toBe('/maps/api/streetview');
+        expect(url.searchParams.get('location')).toBe('1.5,2.5');
+        expect(url.searchParams.get('heading')).toBe('270.0');
+        expect(url.searchParams.get('fov')).toBe(String(REAR_VIEW_DEFAULTS.fov));
+        expect(url.searchParams.get('key')).toBe('k');
+    });
+
+    it('wraps out-of-range headings rather than sending them raw', () => {
+        const url = new URL(
+            buildRearViewUrl({ apiKey: 'k', lat: 0, lng: 0, heading: 400 })
+        );
+        expect(url.searchParams.get('heading')).toBe('40.0');
+    });
+
+    it('prefers pano id over location when known', () => {
+        const url = new URL(
+            buildRearViewUrl({ apiKey: 'k', lat: 1, lng: 2, panoId: 'PANO1', heading: 0 })
+        );
+        expect(url.searchParams.get('pano')).toBe('PANO1');
+        expect(url.searchParams.get('location')).toBeNull();
+    });
+
+    it('asks for error codes so missing imagery is not billed as a grey placeholder', () => {
+        const url = new URL(buildRearViewUrl({ apiKey: 'k', lat: 0, lng: 0, heading: 0 }));
+        expect(url.searchParams.get('return_error_code')).toBe('true');
+    });
+
+    it('refuses to build a URL without a key or a location', () => {
+        expect(() => buildRearViewUrl({ apiKey: '', lat: 0, lng: 0, heading: 0 })).toThrow();
+        expect(() => buildRearViewUrl({ apiKey: 'k', heading: 0 })).toThrow();
+    });
+});
+
+describe('rearViewCacheKey', () => {
+    it('collapses sub-metre jitter and small heading wobble onto one key', () => {
+        const a = rearViewCacheKey({ lat: 40.712812, lng: -74.006011, heading: 270 });
+        const b = rearViewCacheKey({ lat: 40.712813, lng: -74.006012, heading: 273 });
+        expect(a).toBe(b);
+    });
+
+    it('separates distinct positions and distinct heading buckets', () => {
+        const base = rearViewCacheKey({ lat: 40.7128, lng: -74.006, heading: 270 });
+        expect(rearViewCacheKey({ lat: 40.72, lng: -74.006, heading: 270 })).not.toBe(base);
+        expect(rearViewCacheKey({ lat: 40.7128, lng: -74.006, heading: 300 })).not.toBe(base);
+    });
+
+    it('keys on pano id when present, ignoring position drift within the pano', () => {
+        const a = rearViewCacheKey({ lat: 1, lng: 2, heading: 0, panoId: 'P' });
+        const b = rearViewCacheKey({ lat: 9, lng: 9, heading: 0, panoId: 'P' });
+        expect(a).toBe(b);
+        expect(a).toContain('pano:P');
+    });
+
+    it('never embeds the API key', () => {
+        expect(rearViewCacheKey({ lat: 1, lng: 2, heading: 0 })).not.toContain('key');
+    });
+
+    it('wraps the top heading bucket back onto zero', () => {
+        expect(rearViewCacheKey({ lat: 1, lng: 2, heading: 359 })).toBe(
+            rearViewCacheKey({ lat: 1, lng: 2, heading: 1 })
+        );
+    });
+});
+
+describe('RearViewFeed cost control', () => {
+    it('issues zero requests until explicitly enabled', async () => {
+        const { feed, urls } = makeFeed();
+        const result = await feed.request(POSE);
+        expect(result).toEqual({ status: 'blocked', reason: 'disabled' });
+        expect(urls).toHaveLength(0);
+    });
+
+    it('issues zero requests without an API key', async () => {
+        const { feed, urls } = makeFeed({ apiKey: '' });
+        feed.setEnabled(true);
+        const result = await feed.request(POSE);
+        expect(result.status).toBe('blocked');
+        expect(result.reason).toBe('no-key');
+        expect(urls).toHaveLength(0);
+    });
+
+    it.each(['offline', 'auth-failed', 'low-quality'] as const)(
+        'issues zero requests while blocked by %s',
+        async (blocker) => {
+            const { feed, urls } = makeFeed();
+            feed.setEnabled(true);
+            feed.setBlocked(blocker, true);
+
+            const result = await feed.request(POSE);
+            expect(result).toEqual({ status: 'blocked', reason: blocker });
+            expect(urls).toHaveLength(0);
+
+            // Clearing the blocker lets traffic resume.
+            feed.setBlocked(blocker, false);
+            expect((await feed.request(POSE)).status).toBe('fetched');
+            expect(urls).toHaveLength(1);
+        }
+    );
+
+    it('fetches once, then throttles further distinct poses inside the window', async () => {
+        const { feed, urls, advance } = makeFeed({ minIntervalMs: 3000 });
+        feed.setEnabled(true);
+
+        expect((await feed.request(POSE)).status).toBe('fetched');
+        expect(urls).toHaveLength(1);
+
+        advance(1000);
+        const throttled = await feed.request({ ...POSE, lat: POSE.lat + 0.01 });
+        expect(throttled.status).toBe('throttled');
+        expect(urls).toHaveLength(1);
+
+        advance(2500);
+        const allowed = await feed.request({ ...POSE, lat: POSE.lat + 0.02 });
+        expect(allowed.status).toBe('fetched');
+        expect(urls).toHaveLength(2);
+    });
+
+    it('serves a repeat pose from memory without a second request, even mid-throttle', async () => {
+        const { feed, urls, advance } = makeFeed();
+        feed.setEnabled(true);
+
+        expect((await feed.request(POSE)).status).toBe('fetched');
+        advance(60_000);
+
+        const second = await feed.request(POSE);
+        expect(second.status).toBe('cached');
+        expect(second.sample?.cacheKey).toBeDefined();
+        expect(urls).toHaveLength(1);
+        expect(feed.getStats().cacheHits).toBe(1);
+    });
+
+    it('dedupes concurrent requests for the same pose into one network call', async () => {
+        let release: (value: RearViewImageSource) => void = () => {};
+        const urls: string[] = [];
+        const feed = new RearViewFeed({
+            apiKey: 'k',
+            loadImage: (url: string) => {
+                urls.push(url);
+                return new Promise<RearViewImageSource>((resolve) => {
+                    release = resolve;
+                });
+            },
+        });
+        feed.setEnabled(true);
+
+        const first = feed.request(POSE);
+        const second = await feed.request(POSE);
+
+        expect(second.status).toBe('pending');
+        expect(urls).toHaveLength(1);
+
+        release(fakeImage());
+        expect((await first).status).toBe('fetched');
+        expect(urls).toHaveLength(1);
+    });
+
+    it('samples the view behind the car, not in front of it', async () => {
+        const { feed, urls } = makeFeed();
+        feed.setEnabled(true);
+
+        const result = await feed.request({ ...POSE, carHeading: 90 });
+        expect(result.sample?.imageHeading).toBe(270);
+        expect(result.sample?.carHeading).toBe(90);
+        expect(new URL(urls[0]!).searchParams.get('heading')).toBe('270.0');
+    });
+
+    it('stops permanently once the session request budget is spent', async () => {
+        const { feed, urls, advance } = makeFeed({ maxSessionRequests: 2, minIntervalMs: 0 });
+        feed.setEnabled(true);
+
+        for (let i = 0; i < 5; i++) {
+            advance(10);
+            await feed.request({ ...POSE, lat: POSE.lat + i * 0.01 });
+        }
+
+        expect(urls).toHaveLength(2);
+        expect(feed.getStats().blockReason).toBe('budget-exhausted');
+        expect(feed.getStats().budgetRemaining).toBe(0);
+    });
+
+    it('trips a circuit breaker after repeated failures instead of retrying forever', async () => {
+        const { feed, urls, advance, failNext } = makeFeed({
+            maxConsecutiveErrors: 3,
+            minIntervalMs: 0,
+        });
+        feed.setEnabled(true);
+        failNext();
+
+        for (let i = 0; i < 6; i++) {
+            advance(10);
+            await feed.request({ ...POSE, lat: POSE.lat + i * 0.01 });
+        }
+
+        expect(urls).toHaveLength(3);
+        expect(feed.getStats().blockReason).toBe('error-backoff');
+
+        feed.resetErrorStreak();
+        expect(feed.getStats().blockReason).toBeNull();
+    });
+
+    it('clears the error streak after a success', async () => {
+        const { feed, advance, failNext, succeedNext } = makeFeed({
+            maxConsecutiveErrors: 3,
+            minIntervalMs: 0,
+        });
+        feed.setEnabled(true);
+
+        failNext();
+        advance(10);
+        await feed.request(POSE);
+        expect(feed.getStats().consecutiveErrors).toBe(1);
+
+        succeedNext();
+        advance(10);
+        await feed.request({ ...POSE, lat: POSE.lat + 0.01 });
+        expect(feed.getStats().consecutiveErrors).toBe(0);
+    });
+
+    it('returns an error result rather than throwing when imagery is missing', async () => {
+        const { feed, failNext } = makeFeed();
+        feed.setEnabled(true);
+        failNext();
+
+        const result = await feed.request(POSE);
+        expect(result.status).toBe('error');
+        expect(result.error).toBeInstanceOf(Error);
+        expect(feed.getStats().errors).toBe(1);
+    });
+
+    it('kill() blocks everything afterwards and drops the cache', async () => {
+        const { feed, urls, advance } = makeFeed({ minIntervalMs: 0 });
+        feed.setEnabled(true);
+        await feed.request(POSE);
+        expect(feed.getStats().cacheSize).toBe(1);
+
+        feed.kill();
+        advance(10_000);
+        feed.setEnabled(true); // must not resurrect it
+
+        const result = await feed.request(POSE);
+        expect(result).toEqual({ status: 'blocked', reason: 'killed' });
+        expect(feed.isEnabled()).toBe(false);
+        expect(feed.isKilled()).toBe(true);
+        expect(feed.getStats().cacheSize).toBe(0);
+        expect(urls).toHaveLength(1);
+    });
+
+    it('drops cached imagery when the API key changes', async () => {
+        const { feed } = makeFeed();
+        feed.setEnabled(true);
+        await feed.request(POSE);
+        expect(feed.getStats().cacheSize).toBe(1);
+
+        feed.setApiKey('different-key');
+        expect(feed.getStats().cacheSize).toBe(0);
+    });
+
+    it('evicts oldest samples rather than growing without bound', async () => {
+        const { feed, advance } = makeFeed({ cacheLimit: 2, minIntervalMs: 0 });
+        feed.setEnabled(true);
+
+        for (let i = 0; i < 4; i++) {
+            advance(10);
+            await feed.request({ ...POSE, lat: POSE.lat + i * 0.01 });
+        }
+
+        expect(feed.getStats().cacheSize).toBe(2);
+    });
+
+    it('disposing aborts in-flight work and clears memory', async () => {
+        const abortSpy = vi.fn();
+        const feed = new RearViewFeed({
+            apiKey: 'k',
+            loadImage: (_url: string, signal: AbortSignal) =>
+                new Promise<RearViewImageSource>((_resolve, reject) => {
+                    signal.addEventListener('abort', () => {
+                        abortSpy();
+                        reject(new Error('aborted'));
+                    });
+                }),
+        });
+        feed.setEnabled(true);
+
+        const pending = feed.request(POSE);
+        feed.dispose();
+
+        expect(abortSpy).toHaveBeenCalled();
+        expect((await pending).status).toBe('error');
+        expect(feed.getStats().cacheSize).toBe(0);
+    });
+});

--- a/src/car/index.ts
+++ b/src/car/index.ts
@@ -1,5 +1,6 @@
 import { CarInterior } from './CarInterior';
 import { RearviewMirror } from './RearviewMirror';
+import type { RearViewSample } from './rearViewFeed';
 import { SelectivePostProcessing } from './SelectivePostProcessing';
 import { PanoLocationInfo } from '../utils/panoLocation';
 import {
@@ -20,6 +21,24 @@ import {
 
 export { CarInterior } from './CarInterior';
 export { RearviewMirror } from './RearviewMirror';
+export {
+    RearViewFeed,
+    REAR_VIEW_DEFAULTS,
+    buildRearViewUrl,
+    rearViewCacheKey,
+    normalizeDeg,
+    signedHeadingDelta,
+} from './rearViewFeed';
+export type {
+    RearViewSample,
+    RearViewRequest,
+    RearViewResult,
+    RearViewResultStatus,
+    RearViewBlockReason,
+    RearViewBlocker,
+    RearViewFeedOptions,
+    RearViewFeedStats,
+} from './rearViewFeed';
 export { SelectivePostProcessing } from './SelectivePostProcessing';
 export { createMaterials } from './interior/MaterialFactory';
 export type { MaterialSet } from './interior/MaterialFactory';
@@ -124,7 +143,8 @@ export {
     SNOW_ICON,
     RAIN_ICON,
     WIND_ICON,
-    VEHICLE_ICON
+    VEHICLE_ICON,
+    REAR_MIRROR_ICON
 } from './Controls';
 
 /**
@@ -260,6 +280,24 @@ export function setMirrorStreetViewCanvas(canvas: HTMLCanvasElement | null): voi
     carModeState.interior.setVanityStreetViewCanvas(canvas);
 }
 
+/**
+ * Bind a true rear-facing Street View Static sample to the rearview glass, or
+ * pass null to return it to the honest unavailable state.
+ *
+ * Sourced by `useRearViewFeed` from `rearViewFeed.ts` — see that module before
+ * calling this on any new path, the imagery is billable.
+ */
+export function setMirrorRearSample(sample: RearViewSample | null): void {
+    if (!carModeState) return;
+    carModeState.mirror.setRearSample(sample);
+}
+
+/** Diagnostic snapshot of the rearview glass (bound sample, pan, fade). */
+export function getMirrorStatus(): ReturnType<RearviewMirror['getStatus']> | null {
+    if (!carModeState) return null;
+    return carModeState.mirror.getStatus();
+}
+
 /** Sync Three.js camera FOV with WebGPU shader zoom for window alignment. */
 export function setCarZoomFOV(zoom: number): void {
     if (!carModeState) return;
@@ -393,9 +431,10 @@ export function updateCarMode(carHeading: number, headYawOffset: number, headPit
     // Head can look freely without affecting outside view
     carModeState.interior.setHeadOrientation(headYawOffset, headPitch);
 
-    // Update mirror with the rear view (180° behind car heading)
-    // The mirror shows what's actually behind the car based on Street View
-    carModeState.mirror.update(mirrorHeading ?? carHeading, true); // skipFrame = true for performance
+    // Re-register any bound rear sample against the *car body* heading — the
+    // mirror lives in car-body space, so the head's view heading must not move
+    // it (that was the epic #171 spatial bug).
+    carModeState.mirror.update(carHeading, true); // skipFrame = true for performance
 
     carModeState.interior.updateVanityMirror(mirrorHeading ?? carHeading, headPitch);
 

--- a/src/car/rearViewFeed.ts
+++ b/src/car/rearViewFeed.ts
@@ -1,0 +1,539 @@
+/**
+ * rearViewFeed — billing-aware rear imagery source for the cabin mirror.
+ *
+ * The live Google Maps canvas is a forward-facing *perspective* capture, so it
+ * can never be UV-shifted into a true rear view (see `RearviewMirror.ts`). The
+ * only way to show what is actually behind the car, without standing up a
+ * second live panorama + scraper, is a Street View **Static API** sample taken
+ * at `carHeading + 180`.
+ *
+ * The Static API is billable per request, so this module is built around cost
+ * control rather than freshness:
+ *
+ * - **Off by default.** Nothing is fetched until `setEnabled(true)`.
+ * - **Throttled.** At most one network request every `minIntervalMs`
+ *   (default 3s), regardless of how fast the car moves.
+ * - **Deduped.** Results are keyed by panorama id (or quantized lat/lng) plus a
+ *   coarse heading bucket, so re-entering a pano or jittering the heading
+ *   re-uses the sample already in memory.
+ * - **Budgeted.** A hard per-session request ceiling (`maxSessionRequests`)
+ *   acts as a runaway guard; once spent the feed blocks itself permanently.
+ * - **Kill switch.** `kill()` aborts in-flight work, drops the cache, and
+ *   refuses every subsequent request for the life of the page.
+ * - **Blockable.** Offline, Maps auth failure, and Low quality each pin the
+ *   feed to "blocked" so zero requests leave the page in those states.
+ *
+ * Caching is **session memory only** (a bounded `Map`). Google imagery is never
+ * written to Cache Storage / IndexedDB — `resolveSwFetchStrategy` in
+ * `src/offline/swPolicy.ts` independently forces `network-only` for Google
+ * hosts, and nothing here may weaken that.
+ *
+ * See `BILLING_SAFETY_CHECKLIST.md` before changing any default in this file.
+ */
+
+/** Street View Static API endpoint. Billable per successful request. */
+const STATIC_ENDPOINT = 'https://maps.googleapis.com/maps/api/streetview';
+
+export const REAR_VIEW_DEFAULTS = {
+    /** Small enough to stay cheap to decode; the mirror glass is ~280x100px. */
+    size: '320x180',
+    /** Roughly a real interior mirror's useful field. */
+    fov: 90,
+    pitch: 0,
+    /** Minimum spacing between *network* requests while driving. */
+    minIntervalMs: 3000,
+    /** Hard per-session ceiling — runaway guard, not a usage target. */
+    maxSessionRequests: 200,
+    /** Bounded LRU of decoded samples held in memory only. */
+    cacheLimit: 48,
+    /** Consecutive failures that trip the circuit breaker (e.g. a 403 storm). */
+    maxConsecutiveErrors: 5,
+    /** ~1.1m at the equator — finer than the gap between panoramas. */
+    positionPrecision: 5,
+    /** Heading quantization for cache keys; also the re-fetch trigger. */
+    headingBucketDeg: 15,
+} as const;
+
+/** Anything Three.js can turn into a texture. */
+export type RearViewImageSource = HTMLImageElement | ImageBitmap;
+
+export type RearViewBlockReason =
+    | 'disabled'
+    | 'no-key'
+    | 'offline'
+    | 'auth-failed'
+    | 'low-quality'
+    | 'budget-exhausted'
+    | 'error-backoff'
+    | 'killed';
+
+/** External conditions that pin the feed off. All of these mean zero fetches. */
+export type RearViewBlocker = Extract<
+    RearViewBlockReason,
+    'offline' | 'auth-failed' | 'low-quality'
+>;
+
+export interface RearViewRequest {
+    lat: number;
+    lng: number;
+    /** Car body heading in degrees; the sample is taken at heading + 180. */
+    carHeading: number;
+    /** Preferred when known — stable across tiny GPS jitter and cheaper to key. */
+    panoId?: string;
+}
+
+export interface RearViewSample {
+    image: RearViewImageSource;
+    /** Compass heading the imagery faces (`carHeading + 180`, normalized). */
+    imageHeading: number;
+    /** Car heading at capture time — the mirror registers UV drift against it. */
+    carHeading: number;
+    fov: number;
+    cacheKey: string;
+    fetchedAt: number;
+}
+
+export type RearViewResultStatus =
+    | 'blocked'
+    | 'throttled'
+    | 'pending'
+    | 'cached'
+    | 'fetched'
+    | 'error';
+
+export interface RearViewResult {
+    status: RearViewResultStatus;
+    sample?: RearViewSample;
+    reason?: RearViewBlockReason;
+    error?: Error;
+}
+
+export interface RearViewFeedStats {
+    /** Billable requests actually issued this session. */
+    networkRequests: number;
+    cacheHits: number;
+    throttledSkips: number;
+    blockedSkips: number;
+    errors: number;
+    consecutiveErrors: number;
+    cacheSize: number;
+    /** Remaining requests before the session budget blocks the feed. */
+    budgetRemaining: number;
+    blockReason: RearViewBlockReason | null;
+}
+
+export type RearViewImageLoader = (
+    url: string,
+    signal: AbortSignal
+) => Promise<RearViewImageSource>;
+
+export interface RearViewFeedOptions {
+    apiKey?: string;
+    size?: string;
+    fov?: number;
+    pitch?: number;
+    minIntervalMs?: number;
+    maxSessionRequests?: number;
+    cacheLimit?: number;
+    maxConsecutiveErrors?: number;
+    headingBucketDeg?: number;
+    positionPrecision?: number;
+    /** Injectable for tests; defaults to a crossOrigin <img> decode. */
+    loadImage?: RearViewImageLoader;
+    /** Injectable clock so throttle behaviour is deterministic in tests. */
+    now?: () => number;
+}
+
+/** Normalize any degree value into [0, 360). */
+export function normalizeDeg(deg: number): number {
+    const wrapped = deg % 360;
+    return wrapped < 0 ? wrapped + 360 : wrapped;
+}
+
+/** Signed shortest angular difference `a - b`, in (-180, 180]. */
+export function signedHeadingDelta(a: number, b: number): number {
+    return ((((a - b) % 360) + 540) % 360) - 180;
+}
+
+export interface RearViewUrlParams {
+    apiKey: string;
+    /** Compass heading the *camera* should face (already includes the +180). */
+    heading: number;
+    lat?: number;
+    lng?: number;
+    panoId?: string;
+    size?: string;
+    fov?: number;
+    pitch?: number;
+}
+
+/**
+ * Build a Street View Static API URL for a rear-facing sample.
+ *
+ * `pano` wins over `location` when available: it pins the sample to the exact
+ * panorama the driver is standing in, which both looks right and dedupes
+ * better. `return_error_code` makes missing imagery a 404 instead of a billed
+ * "no imagery available" grey placeholder.
+ */
+export function buildRearViewUrl(params: RearViewUrlParams): string {
+    const {
+        apiKey,
+        heading,
+        lat,
+        lng,
+        panoId,
+        size = REAR_VIEW_DEFAULTS.size,
+        fov = REAR_VIEW_DEFAULTS.fov,
+        pitch = REAR_VIEW_DEFAULTS.pitch,
+    } = params;
+
+    if (!apiKey) throw new Error('[rearViewFeed] API key required');
+    if (!panoId && (lat === undefined || lng === undefined)) {
+        throw new Error('[rearViewFeed] panoId or lat/lng required');
+    }
+
+    const query = new URLSearchParams();
+    query.set('size', size);
+    if (panoId) {
+        query.set('pano', panoId);
+    } else {
+        query.set('location', `${lat},${lng}`);
+    }
+    query.set('heading', normalizeDeg(heading).toFixed(1));
+    query.set('fov', String(fov));
+    query.set('pitch', String(pitch));
+    query.set('return_error_code', 'true');
+    query.set('key', apiKey);
+
+    return `${STATIC_ENDPOINT}?${query.toString()}`;
+}
+
+export interface RearViewCacheKeyParams {
+    lat: number;
+    lng: number;
+    /** Camera heading (rear-facing), not the car heading. */
+    heading: number;
+    panoId?: string;
+    headingBucketDeg?: number;
+    positionPrecision?: number;
+}
+
+/**
+ * Cache/dedupe key. Position is quantized to ~1m and heading into coarse
+ * buckets so ordinary driving jitter re-uses a sample instead of buying a new
+ * one. Deliberately excludes the API key — keys must never leak into logs or
+ * diagnostics that surface cache keys.
+ */
+export function rearViewCacheKey(params: RearViewCacheKeyParams): string {
+    const {
+        lat,
+        lng,
+        heading,
+        panoId,
+        headingBucketDeg = REAR_VIEW_DEFAULTS.headingBucketDeg,
+        positionPrecision = REAR_VIEW_DEFAULTS.positionPrecision,
+    } = params;
+
+    const bucket = Math.round(normalizeDeg(heading) / headingBucketDeg) %
+        Math.round(360 / headingBucketDeg);
+    const place = panoId
+        ? `pano:${panoId}`
+        : `loc:${lat.toFixed(positionPrecision)},${lng.toFixed(positionPrecision)}`;
+    return `${place}|h${bucket}`;
+}
+
+/** Default loader: a plain crossOrigin image decode, no Cache Storage writes. */
+function defaultLoadImage(url: string, signal: AbortSignal): Promise<RearViewImageSource> {
+    return new Promise<RearViewImageSource>((resolve, reject) => {
+        const img = new Image();
+        img.crossOrigin = 'anonymous';
+
+        const onAbort = () => {
+            img.onload = null;
+            img.onerror = null;
+            img.src = '';
+            reject(new Error('[rearViewFeed] request aborted'));
+        };
+
+        img.onload = () => {
+            signal.removeEventListener('abort', onAbort);
+            resolve(img);
+        };
+        img.onerror = () => {
+            signal.removeEventListener('abort', onAbort);
+            reject(new Error('[rearViewFeed] rear image failed to load'));
+        };
+
+        signal.addEventListener('abort', onAbort, { once: true });
+        img.src = url;
+    });
+}
+
+/**
+ * Throttled, budgeted rear-imagery fetcher.
+ *
+ * One instance per car-mode session. Call `request()` as often as you like —
+ * it is cheap and self-limiting; it only reaches the network when enabled,
+ * unblocked, past the throttle window, uncached, and inside budget.
+ */
+export class RearViewFeed {
+    private readonly opts: Required<Omit<RearViewFeedOptions, 'apiKey'>>;
+    private apiKey: string;
+
+    /** Session-memory LRU of decoded samples. Never persisted. */
+    private cache = new Map<string, RearViewSample>();
+    private inFlight = new Map<string, Promise<RearViewSample>>();
+    private controllers = new Set<AbortController>();
+
+    private enabled = false;
+    private killed = false;
+    private blockers = new Set<RearViewBlocker>();
+
+    private lastRequestAt = Number.NEGATIVE_INFINITY;
+    private networkRequests = 0;
+    private cacheHits = 0;
+    private throttledSkips = 0;
+    private blockedSkips = 0;
+    private errors = 0;
+    private consecutiveErrors = 0;
+
+    constructor(options: RearViewFeedOptions = {}) {
+        this.apiKey = (options.apiKey ?? '').trim();
+        this.opts = {
+            size: options.size ?? REAR_VIEW_DEFAULTS.size,
+            fov: options.fov ?? REAR_VIEW_DEFAULTS.fov,
+            pitch: options.pitch ?? REAR_VIEW_DEFAULTS.pitch,
+            minIntervalMs: options.minIntervalMs ?? REAR_VIEW_DEFAULTS.minIntervalMs,
+            maxSessionRequests:
+                options.maxSessionRequests ?? REAR_VIEW_DEFAULTS.maxSessionRequests,
+            cacheLimit: options.cacheLimit ?? REAR_VIEW_DEFAULTS.cacheLimit,
+            maxConsecutiveErrors:
+                options.maxConsecutiveErrors ?? REAR_VIEW_DEFAULTS.maxConsecutiveErrors,
+            headingBucketDeg: options.headingBucketDeg ?? REAR_VIEW_DEFAULTS.headingBucketDeg,
+            positionPrecision:
+                options.positionPrecision ?? REAR_VIEW_DEFAULTS.positionPrecision,
+            loadImage: options.loadImage ?? defaultLoadImage,
+            now: options.now ?? (() => Date.now()),
+        };
+    }
+
+    /** Master switch — the settings toggle. Off means zero network requests. */
+    setEnabled(enabled: boolean): void {
+        if (this.enabled === enabled) return;
+        this.enabled = enabled;
+        if (!enabled) this.abortInFlight();
+    }
+
+    isEnabled(): boolean {
+        return this.enabled && !this.killed;
+    }
+
+    setApiKey(key: string): void {
+        const next = (key ?? '').trim();
+        if (next === this.apiKey) return;
+        this.apiKey = next;
+        // Imagery is key-scoped; a key change invalidates what we hold.
+        this.clearCache();
+    }
+
+    /** Pin the feed off for an external condition (offline / auth / quality). */
+    setBlocked(blocker: RearViewBlocker, active: boolean): void {
+        const had = this.blockers.has(blocker);
+        if (active === had) return;
+        if (active) {
+            this.blockers.add(blocker);
+            this.abortInFlight();
+        } else {
+            this.blockers.delete(blocker);
+        }
+    }
+
+    /**
+     * Permanent kill switch. Aborts in-flight work, drops every cached sample,
+     * and refuses all further requests for the life of the page. Intended for
+     * the billing "stop everything now" path — there is no un-kill.
+     */
+    kill(): void {
+        this.killed = true;
+        this.enabled = false;
+        this.abortInFlight();
+        this.clearCache();
+    }
+
+    isKilled(): boolean {
+        return this.killed;
+    }
+
+    /** Why the next request would be refused, or null if it would proceed. */
+    getBlockReason(): RearViewBlockReason | null {
+        if (this.killed) return 'killed';
+        if (!this.enabled) return 'disabled';
+        if (!this.apiKey) return 'no-key';
+        if (this.blockers.has('offline')) return 'offline';
+        if (this.blockers.has('auth-failed')) return 'auth-failed';
+        if (this.blockers.has('low-quality')) return 'low-quality';
+        if (this.networkRequests >= this.opts.maxSessionRequests) return 'budget-exhausted';
+        // Circuit breaker: a referrer-blocked or unbilled key fails every
+        // request, and every failed request is still a request. Stop paying to
+        // rediscover that. Cleared by any success (see `resetErrorStreak`).
+        if (this.consecutiveErrors >= this.opts.maxConsecutiveErrors) return 'error-backoff';
+        return null;
+    }
+
+    /**
+     * Ask for rear imagery at the given pose.
+     *
+     * Never throws: transport failures come back as `status: 'error'` so the
+     * mirror can fall back to its honest unavailable glass.
+     */
+    async request(req: RearViewRequest): Promise<RearViewResult> {
+        const blockReason = this.getBlockReason();
+        if (blockReason) {
+            this.blockedSkips++;
+            return { status: 'blocked', reason: blockReason };
+        }
+
+        const imageHeading = normalizeDeg(req.carHeading + 180);
+        const cacheKey = rearViewCacheKey({
+            lat: req.lat,
+            lng: req.lng,
+            heading: imageHeading,
+            ...(req.panoId ? { panoId: req.panoId } : {}),
+            headingBucketDeg: this.opts.headingBucketDeg,
+            positionPrecision: this.opts.positionPrecision,
+        });
+
+        const cached = this.cache.get(cacheKey);
+        if (cached) {
+            // Refresh LRU recency.
+            this.cache.delete(cacheKey);
+            this.cache.set(cacheKey, cached);
+            this.cacheHits++;
+            return { status: 'cached', sample: cached };
+        }
+
+        if (this.inFlight.has(cacheKey)) {
+            return { status: 'pending' };
+        }
+
+        const now = this.opts.now();
+        if (now - this.lastRequestAt < this.opts.minIntervalMs) {
+            this.throttledSkips++;
+            return { status: 'throttled' };
+        }
+
+        this.lastRequestAt = now;
+        this.networkRequests++;
+
+        const url = buildRearViewUrl({
+            apiKey: this.apiKey,
+            heading: imageHeading,
+            lat: req.lat,
+            lng: req.lng,
+            ...(req.panoId ? { panoId: req.panoId } : {}),
+            size: this.opts.size,
+            fov: this.opts.fov,
+            pitch: this.opts.pitch,
+        });
+
+        const controller = new AbortController();
+        this.controllers.add(controller);
+
+        const pending = this.opts
+            .loadImage(url, controller.signal)
+            .then((image): RearViewSample => {
+                const sample: RearViewSample = {
+                    image,
+                    imageHeading,
+                    carHeading: normalizeDeg(req.carHeading),
+                    fov: this.opts.fov,
+                    cacheKey,
+                    fetchedAt: this.opts.now(),
+                };
+                this.storeSample(sample);
+                this.consecutiveErrors = 0;
+                return sample;
+            })
+            .finally(() => {
+                this.controllers.delete(controller);
+                this.inFlight.delete(cacheKey);
+            });
+
+        this.inFlight.set(cacheKey, pending);
+
+        try {
+            const sample = await pending;
+            return { status: 'fetched', sample };
+        } catch (err) {
+            this.errors++;
+            this.consecutiveErrors++;
+            return {
+                status: 'error',
+                error: err instanceof Error ? err : new Error(String(err)),
+            };
+        }
+    }
+
+    getStats(): RearViewFeedStats {
+        return {
+            networkRequests: this.networkRequests,
+            cacheHits: this.cacheHits,
+            throttledSkips: this.throttledSkips,
+            blockedSkips: this.blockedSkips,
+            errors: this.errors,
+            consecutiveErrors: this.consecutiveErrors,
+            cacheSize: this.cache.size,
+            budgetRemaining: Math.max(0, this.opts.maxSessionRequests - this.networkRequests),
+            blockReason: this.getBlockReason(),
+        };
+    }
+
+    /**
+     * Clear a tripped error circuit breaker — e.g. after the driver fixes the
+     * key or explicitly re-enables the feature. Does not refund the budget.
+     */
+    resetErrorStreak(): void {
+        this.consecutiveErrors = 0;
+    }
+
+    /** Drop every in-memory sample. Called on key change, kill, and dispose. */
+    clearCache(): void {
+        for (const sample of this.cache.values()) {
+            if (typeof ImageBitmap !== 'undefined' && sample.image instanceof ImageBitmap) {
+                sample.image.close();
+            }
+        }
+        this.cache.clear();
+    }
+
+    dispose(): void {
+        this.enabled = false;
+        this.abortInFlight();
+        this.clearCache();
+    }
+
+    private storeSample(sample: RearViewSample): void {
+        this.cache.set(sample.cacheKey, sample);
+        while (this.cache.size > this.opts.cacheLimit) {
+            const oldest = this.cache.keys().next();
+            if (oldest.done) break;
+            const evicted = this.cache.get(oldest.value);
+            if (
+                evicted &&
+                typeof ImageBitmap !== 'undefined' &&
+                evicted.image instanceof ImageBitmap
+            ) {
+                evicted.image.close();
+            }
+            this.cache.delete(oldest.value);
+        }
+    }
+
+    private abortInFlight(): void {
+        for (const controller of this.controllers) {
+            controller.abort();
+        }
+        this.controllers.clear();
+        this.inFlight.clear();
+    }
+}

--- a/src/car/ui/icons.ts
+++ b/src/car/ui/icons.ts
@@ -15,3 +15,5 @@ export const VOLUME_ICON = 'M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.
 export const POWER_ICON = 'M16.56 13.66a8 8 0 0 1-11.32 0L7.3 11.6a5.33 5.33 0 0 0 7.54 0l1.72 2.06zM13.5 5.5v6h-3v-6h3z';
 export const FAN_ICON = 'M12 12c0-3 2.5-5.5 5.5-5.5S23 9 23 12H12zm0 0c0 3-2.5 5.5-5.5 5.5S1 15 1 12h11zm0 0c-3 0-5.5-2.5-5.5-5.5S9 1 12 1v11zm0 0c3 0 5.5 2.5 5.5 5.5S15 23 12 23V12z';
 export const TEMP_ICON = 'M15 13V5c0-1.66-1.34-3-3-3S9 3.34 9 5v8c-1.21.91-2 2.37-2 4 0 2.76 2.24 5 5 5s5-2.24 5-5c0-1.63-.79-3.09-2-4zm-4-2V5c0-.55.45-1 1-1s1 .45 1 1v1h-1v1h1v2h-1v1h1v1h-2z';
+/** Rearview mirror glass — used by the rear-imagery feed toggle. */
+export const REAR_MIRROR_ICON = 'M4 7c0-.9.6-1.7 1.5-1.9l6-1.3c.3-.1.7-.1 1 0l6 1.3c.9.2 1.5 1 1.5 1.9v6c0 1.1-.9 2-2 2H6c-1.1 0-2-.9-2-2V7zm2 0v6h12V7l-6-1.3L6 7zm1 10h10v2H7v-2z';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -12,6 +12,12 @@ export { useLocationHistory } from './useLocationHistory';
 export { useSnapshots } from './useSnapshots';
 export { useVehicleSettings } from './useVehicleSettings';
 export {
+  useRearViewFeed,
+  type UseRearViewFeedParams,
+  type UseRearViewFeedResult,
+  type RearViewFeedPose,
+} from './useRearViewFeed';
+export {
   useTours,
   type Tour,
   type TourWaypoint,

--- a/src/hooks/useRearViewFeed.ts
+++ b/src/hooks/useRearViewFeed.ts
@@ -1,0 +1,262 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { RearViewFeed, type RearViewFeedStats, type RearViewSample } from '../car/rearViewFeed';
+import { setMirrorRearSample } from '../car';
+import { getActiveQualityLevel } from '../config/visualPresets';
+import { onMapsAuthFailure } from '../services/maps/loader';
+
+/**
+ * useRearViewFeed — drives the cabin mirror's true rear imagery.
+ *
+ * Owns one `RearViewFeed` for the lifetime of car mode and pokes it whenever
+ * the car's pose changes materially. The feed itself does the cost control
+ * (throttle, dedupe, session budget); this hook supplies the *policy*:
+ *
+ * - **Opt-in, persisted off.** The toggle defaults to disabled because Street
+ *   View Static requests are billable. Nothing is fetched until the driver
+ *   turns it on, and the choice survives reloads in localStorage.
+ * - **Blockers.** Offline, Maps auth failure, and Low quality each pin the feed
+ *   off, so those states issue exactly zero requests.
+ * - **Kill switch.** `window.__REARVIEW_FEED__.kill()` from DevTools (or the
+ *   returned `kill()`) permanently stops the feed and clears its cache for the
+ *   rest of the page's life. See `BILLING_SAFETY_CHECKLIST.md`.
+ */
+
+const STORAGE_KEY = 'webgpu_streetview_rear_view_feed';
+
+/** Movement that justifies spending a new request, in metres. */
+const REFETCH_DISTANCE_M = 12;
+/** Car rotation that justifies spending a new request, in degrees. */
+const REFETCH_HEADING_DEG = 20;
+
+export interface RearViewFeedPose {
+    lat: number;
+    lng: number;
+    carHeading: number;
+    panoId?: string;
+}
+
+export interface UseRearViewFeedParams {
+    /** Effective Maps key; empty disables the feed with reason `no-key`. */
+    apiKey: string;
+    /** Whether car mode is currently mounted/active. */
+    active: boolean;
+    /** Maps auth failure from `useMapsBootstrap`; blocks all requests. */
+    authFailed?: boolean;
+}
+
+export interface UseRearViewFeedResult {
+    enabled: boolean;
+    setEnabled: (value: boolean) => void;
+    toggle: () => void;
+    /** Push the current car pose; safe (and cheap) to call every frame. */
+    notifyPose: (pose: RearViewFeedPose) => void;
+    /** Human-readable state for the settings row. */
+    status: string;
+    stats: RearViewFeedStats | null;
+    /** Permanent stop — no un-kill for the life of the page. */
+    kill: () => void;
+}
+
+function readStoredEnabled(): boolean {
+    if (typeof window === 'undefined') return false;
+    try {
+        return window.localStorage.getItem(STORAGE_KEY) === 'true';
+    } catch {
+        return false;
+    }
+}
+
+/** Equirectangular metres between two lat/lng pairs — plenty at this scale. */
+function metresBetween(aLat: number, aLng: number, bLat: number, bLng: number): number {
+    const toRad = Math.PI / 180;
+    const x = (bLng - aLng) * toRad * Math.cos(((aLat + bLat) / 2) * toRad);
+    const y = (bLat - aLat) * toRad;
+    return Math.sqrt(x * x + y * y) * 6371000;
+}
+
+export function useRearViewFeed({
+    apiKey,
+    active,
+    authFailed = false,
+}: UseRearViewFeedParams): UseRearViewFeedResult {
+    const [enabled, setEnabledState] = useState<boolean>(readStoredEnabled);
+    const [stats, setStats] = useState<RearViewFeedStats | null>(null);
+
+    const feedRef = useRef<RearViewFeed | null>(null);
+    const lastPoseRef = useRef<RearViewFeedPose | null>(null);
+    const boundKeyRef = useRef<string | null>(null);
+    const requestingRef = useRef(false);
+
+    if (!feedRef.current) {
+        feedRef.current = new RearViewFeed({ apiKey });
+    }
+
+    // Expose the kill switch for DevTools / incident response.
+    useEffect(() => {
+        const feed = feedRef.current;
+        if (!feed || typeof window === 'undefined') return;
+        (window as unknown as Record<string, unknown>).__REARVIEW_FEED__ = feed;
+        return () => {
+            delete (window as unknown as Record<string, unknown>).__REARVIEW_FEED__;
+        };
+    }, []);
+
+    useEffect(() => {
+        feedRef.current?.setApiKey(apiKey);
+    }, [apiKey]);
+
+    // Master switch: off unless the driver opted in *and* car mode is running.
+    useEffect(() => {
+        const feed = feedRef.current;
+        if (!feed) return;
+        feed.setEnabled(enabled && active);
+        if (!(enabled && active)) {
+            lastPoseRef.current = null;
+            boundKeyRef.current = null;
+            setMirrorRearSample(null);
+        }
+        setStats(feed.getStats());
+    }, [enabled, active]);
+
+    // Offline blocker — zero requests while the network is down.
+    useEffect(() => {
+        const feed = feedRef.current;
+        if (!feed) return;
+        const sync = () => feed.setBlocked('offline', !navigator.onLine);
+        sync();
+        window.addEventListener('online', sync);
+        window.addEventListener('offline', sync);
+        return () => {
+            window.removeEventListener('online', sync);
+            window.removeEventListener('offline', sync);
+        };
+    }, []);
+
+    useEffect(() => {
+        feedRef.current?.setBlocked('auth-failed', authFailed);
+    }, [authFailed]);
+
+    // A referrer-blocked or unbilled key fails Static requests too, and each
+    // failure is still billable-shaped traffic. Stop the moment Maps says so.
+    useEffect(() => {
+        return onMapsAuthFailure(() => {
+            feedRef.current?.setBlocked('auth-failed', true);
+            setMirrorRearSample(null);
+            setStats(feedRef.current?.getStats() ?? null);
+        });
+    }, []);
+
+    // Low quality opts out entirely: the extra texture is not worth the spend
+    // on a machine already struggling to hold frame rate.
+    useEffect(() => {
+        feedRef.current?.setBlocked('low-quality', getActiveQualityLevel() === 'low');
+    }, [active]);
+
+    useEffect(() => {
+        return () => {
+            feedRef.current?.dispose();
+            setMirrorRearSample(null);
+        };
+    }, []);
+
+    const persist = useCallback((value: boolean) => {
+        try {
+            window.localStorage.setItem(STORAGE_KEY, value ? 'true' : 'false');
+        } catch {
+            // Private-mode storage failure must not break the toggle.
+        }
+    }, []);
+
+    const setEnabled = useCallback(
+        (value: boolean) => {
+            setEnabledState(value);
+            persist(value);
+        },
+        [persist]
+    );
+
+    const toggle = useCallback(() => {
+        setEnabledState((prev) => {
+            persist(!prev);
+            return !prev;
+        });
+    }, [persist]);
+
+    const kill = useCallback(() => {
+        feedRef.current?.kill();
+        setMirrorRearSample(null);
+        setEnabled(false);
+        setStats(feedRef.current?.getStats() ?? null);
+    }, [setEnabled]);
+
+    /**
+     * Pose gate. The feed throttles by time; this gates by *movement*, so a
+     * parked car sitting at a red light never spends a request. A pose only
+     * reaches the feed after the car has moved `REFETCH_DISTANCE_M` metres,
+     * turned `REFETCH_HEADING_DEG` degrees, or hopped to a new panorama.
+     */
+    const notifyPose = useCallback((pose: RearViewFeedPose) => {
+        const feed = feedRef.current;
+        if (!feed || !feed.isEnabled() || requestingRef.current) return;
+
+        const previous = lastPoseRef.current;
+        if (previous) {
+            const movedFar =
+                metresBetween(previous.lat, previous.lng, pose.lat, pose.lng) >=
+                REFETCH_DISTANCE_M;
+            const turnedFar =
+                Math.abs(
+                    ((((pose.carHeading - previous.carHeading) % 360) + 540) % 360) - 180
+                ) >= REFETCH_HEADING_DEG;
+            const newPano = Boolean(pose.panoId) && pose.panoId !== previous.panoId;
+            if (!movedFar && !turnedFar && !newPano) return;
+        }
+
+        requestingRef.current = true;
+        void feed
+            .request(pose)
+            .then((result) => {
+                if (result.status === 'fetched' || result.status === 'cached') {
+                    lastPoseRef.current = pose;
+                    const sample = result.sample as RearViewSample;
+                    if (sample.cacheKey !== boundKeyRef.current) {
+                        boundKeyRef.current = sample.cacheKey;
+                        setMirrorRearSample(sample);
+                    }
+                } else if (result.status === 'error') {
+                    // No imagery here (or transport failed) — fall back to the
+                    // honest unavailable glass rather than a stale rear view.
+                    lastPoseRef.current = pose;
+                    boundKeyRef.current = null;
+                    setMirrorRearSample(null);
+                }
+                setStats(feed.getStats());
+            })
+            .finally(() => {
+                requestingRef.current = false;
+            });
+    }, []);
+
+    const blockReason = stats?.blockReason ?? null;
+    const status = !enabled
+        ? 'Off — no Street View Static requests'
+        : blockReason === 'killed'
+          ? 'Stopped by kill switch'
+          : blockReason === 'no-key'
+            ? 'Unavailable — no Maps API key'
+            : blockReason === 'offline'
+              ? 'Paused — offline'
+              : blockReason === 'auth-failed'
+                ? 'Paused — Maps auth failed'
+                : blockReason === 'low-quality'
+                  ? 'Unavailable at Low quality'
+                  : blockReason === 'budget-exhausted'
+                    ? 'Paused — session request budget spent'
+                    : blockReason === 'error-backoff'
+                      ? 'Paused — repeated request failures'
+                      : blockReason === 'disabled'
+                        ? 'Off'
+                        : `On — ${stats?.networkRequests ?? 0} requests this session`;
+
+    return { enabled, setEnabled, toggle, notifyPose, status, stats, kill };
+}

--- a/src/views/CarModeView.tsx
+++ b/src/views/CarModeView.tsx
@@ -5,6 +5,7 @@ import { useEnvironmentSettings } from '../hooks/useEnvironmentSettings';
 import { useVehicleSettings, MAX_SEAT_DISTANCE } from '../hooks/useVehicleSettings';
 import { usePanoInfoPanel } from '../hooks/usePanoInfoPanel';
 import { useCabinEnvironment } from '../hooks/useCabinEnvironment';
+import { useRearViewFeed } from '../hooks/useRearViewFeed';
 import CarInputHandler from '../components/CarInputHandler';
 import { AudioAnalyzer } from '../audio/AudioAnalyzer';
 import { publishCameraSpeed, resetCameraSpeed } from '../renderer/cameraMotionSignal';
@@ -66,7 +67,7 @@ const GEAR_HOP_INTERVAL_MS = 550;
  * - Dashboard UI with gauges, wipers, lights controls
  * - Head look independent of car steering
  */
-const CarModeView: React.FC<CarModeViewProps> = () => {
+const CarModeView: React.FC<CarModeViewProps> = ({ mapsApiKey }) => {
   const { heading, pitch, panorama, advance, canvas, zoom, position } = useStreetView();
   const {
     controlMode,
@@ -113,6 +114,10 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
 
   // Cabin lighting from the surrounding panorama (IBL) + the real sun.
   useCabinEnvironment(panorama, position);
+
+  // True rear-view imagery for the mirror. Opt-in and billable — see
+  // `rearViewFeed.ts` and BILLING_SAFETY_CHECKLIST.md before touching this.
+  const rearFeed = useRearViewFeed({ apiKey: mapsApiKey, active: true });
   
   const containerRef = useRef<HTMLDivElement>(null);
   const carModeStateRef = useRef<CarModeState | null>(null);
@@ -300,11 +305,28 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
     setCarMediaInfo(stationName, stationTags, isRadioPlaying);
   }, [stationName, stationTags, isRadioPlaying]);
 
-  // Keep rearview mirror fed from the scraped Street View canvas
+  // Keep rearview mirror fed from the scraped Street View canvas. The mirror
+  // does not sample it (forward perspective ≠ rear view) — this only keeps the
+  // canvas-tracking hook and the vanity mirror in step.
   useEffect(() => {
     setMirrorStreetViewCanvas(canvas);
     return () => setMirrorStreetViewCanvas(null);
   }, [canvas]);
+
+  // Offer the current pose to the rear-view feed. Fires only on panorama hops
+  // and heading changes, and the feed itself throttles/dedupes on top of that,
+  // so a stationary car spends nothing.
+  const { enabled: rearFeedEnabled, notifyPose: notifyRearPose } = rearFeed;
+  useEffect(() => {
+    if (!rearFeedEnabled || !position) return;
+    const panoId = panorama?.getPano?.();
+    notifyRearPose({
+      lat: position.lat(),
+      lng: position.lng(),
+      carHeading,
+      ...(panoId ? { panoId } : {}),
+    });
+  }, [rearFeedEnabled, notifyRearPose, position, panorama, carHeading]);
 
   // Sync Three.js camera FOV with WebGPU zoom so window frames line up with the panorama
   useEffect(() => {
@@ -688,6 +710,9 @@ const CarModeView: React.FC<CarModeViewProps> = () => {
         onToggleHeadlights={toggleHeadlights}
         onToggleHighBeam={toggleHighBeam}
         onToggleDomeLight={toggleDomeLight}
+        onToggleRearFeed={rearFeed.toggle}
+        rearFeedEnabled={rearFeed.enabled}
+        rearFeedStatus={rearFeed.status}
         isRoofOpen={isRoofOpen}
         wipersEnabled={wipersEnabled}
         headlightsOn={headlightsOn}


### PR DESCRIPTION
## Problem

Since epic #171 the cabin rearview glass shows an honest "unavailable" state: the scraped Google Maps canvas is a forward *perspective* capture, so no UV shift of it can produce a true rear view. `setStreetViewCanvas()` / `setRearAvailable()` existed but were no-ops for real imagery, and driving/cruise had no way to look behind.

This wires the true rear path (MVP from the issue): a Street View **Static API** sample at `carHeading + 180`.

## What changed

### `src/car/rearViewFeed.ts` (new)

The Static API is billable per request, so the module is built around cost control rather than freshness:

| Guard | Default |
|---|---|
| Opt-in toggle, persisted **off** | off |
| Throttle between network requests | 3000 ms |
| Movement gate before a pose is even offered | 12 m / 20° / new pano |
| Session request budget (hard stop) | 200 |
| Consecutive-failure circuit breaker | 5 |
| Blocked entirely | offline, Maps auth failure, Low quality, no key |
| Cache | session memory only, 48-entry LRU |

- Deduped by pano id (or ~1 m quantized lat/lng) plus a coarse heading bucket, so driving jitter and revisits re-use what is already in memory. Concurrent requests for the same key collapse to one network call.
- `return_error_code=true` so missing imagery 404s instead of being billed as a grey placeholder.
- Nothing is persisted. `resolveSwFetchStrategy` already forces `network-only` for Google hosts and this change does not touch it.
- Kill switch: `window.__REARVIEW_FEED__.kill()` aborts in-flight work, drops the cache, and refuses everything afterwards for the life of the page. `getStats()` exposes `networkRequests` / `budgetRemaining` / `blockReason`.
- Cache keys deliberately never embed the API key.

### `RearviewMirror.ts`

- `setRearSample()` binds a sample to a Three.js texture; the shader samples it horizontally flipped, the way real mirror glass reverses left/right.
- `updateOrientation()` is no longer a no-op: it re-registers the still against the car heading, panning UVs by `Δheading / fov` and fading back to the unavailable glass once the car has rotated past the sample's coverage (rather than smearing clamped edge texels). Head pitch is still ignored — the mirror lives in car-body space, so free-look cannot move it.
- No regression to the honest fallback: the forward canvas is still never sampled, and `setRearAvailable(true)` is refused with no sample bound.
- `updateCarMode` now passes the **car body** heading to `mirror.update()` instead of the view heading, which is what the car-body-space world model requires.

### Wiring & UI

- `useRearViewFeed` hook owns the feed, the persisted toggle, the blockers (including a `onMapsAuthFailure` subscription), and the pose gate.
- `CarModeView` offers the pose on pano/heading change; `DashboardUI` gains a **Rear** toggle plus a billing note showing live feed state (`Off — no Street View Static requests`, `On — N requests this session`, `Paused — offline`, …).

## Testing

- `src/car/__tests__/rearViewFeed.test.ts` (new, 29 tests) — URL/cache-key builders, throttle, dedupe (sequential + concurrent), each blocker, budget exhaustion, failure circuit breaker, key-change invalidation, LRU eviction, kill switch, abort-on-dispose.
- `src/car/__tests__/RearviewMirror.test.ts` — extended for the true-rear path: bind/clear, `setRearAvailable` refusal without a sample, pan registration (incl. across the 0/360 seam), coverage fade, head-pitch independence, texture disposal.
- `npm run typecheck`, `npm run lint`, `npx vitest run` (53 files / 496 tests) and `vite build` all pass.
- Manual steps added to the AGENTS "Car Spatial Correctness" checklist: feed-OFF billing gate (zero `maps/api/streetview` requests over 10+ hops), feed-ON registration/throttle/dedupe/blocker/kill-switch verification, and a Cache Storage check.
- `BILLING_SAFETY_CHECKLIST.md` gains a "Billable In-App Features" section documenting every guard, the kill switch, and pre-ship checks.

## Notes

- Defaults are conservative on purpose; anything that raises request volume should be weighed against `BILLING_SAFETY_CHECKLIST.md` first.
- The dual-hidden-panorama option from the issue is deliberately not attempted here — it needs hold-pause coordination and a second scraper.

Closes the MVP scope of the rear-view imagery issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_015qX9VR5AbGL6enE8soXQDx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional rear-view mirror feed using Street View imagery.
  * Added controls showing feed status, billing information, and enablement options.
  * Added safeguards including throttling, deduplication, session budgets, caching limits, offline blocking, and a permanent kill switch.
  * Rear imagery now adjusts to vehicle heading and gracefully indicates when unavailable.

* **Documentation**
  * Added billing-safety guidance, testing coverage details, and rear-feed behavior documentation.

* **Tests**
  * Added coverage for rear imagery, caching, request limits, failures, orientation, and lifecycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->