### PR TITLE
Fix bundle budget: lazy-load car mode out of main chunk

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -16,7 +16,7 @@ import { useSnapshots } from '../hooks/useSnapshots';
 import { useGlobeMode } from '../hooks/useGlobeMode';
 import { useKeyboardShortcuts, useAnnouncer, SkipLink } from '../hooks/useKeyboardShortcuts';
 import { useCruiseMode } from '../hooks/useCruiseMode';
-import { getGearHopCount } from '../car';
+import { loadCarRuntime } from '../car/carRuntimeLoader';
 import { useAutopilot } from '../hooks/useAutopilot';
 import { buildAppKeyboardShortcuts } from '../hooks/useAppKeyboardShortcuts';
 import { useGlobeTeleport } from '../hooks/useGlobeTeleport';
@@ -36,6 +36,12 @@ import { ConnectedChrome } from './shell/ConnectedChrome';
 import { MapsAuthModal } from './shell/MapsAuthModal';
 import { OfflineStatusToast } from './shell/OfflineStatusToast';
 import { StreetViewStage } from './shell/StreetViewStage';
+
+/** Cached car runtime for sync cruise gear hops once car mode has loaded. */
+let carRuntimeModule: typeof import('../car/carModeRuntime') | null = null;
+void loadCarRuntime().then((module) => {
+  carRuntimeModule = module;
+});
 
 /** Main app layout: composition shell for feature controllers + chrome. */
 export function AppShell() {
@@ -152,7 +158,7 @@ export function AppShell() {
     // In car mode the gearshift is the speed selector: P/N park cruise, D
     // keeps the classic single hop, 2/3 chain extra hops per tick. Free-look
     // has no gearbox, so it always cruises one hop at a time.
-    hopsPerTick: () => (viewModeRef.current === 'car' ? getGearHopCount() : 1),
+    hopsPerTick: () => (viewModeRef.current === 'car' ? (carRuntimeModule?.getGearHopCount() ?? 1) : 1),
   });
   onAuthFailureRef.current = () => setIsCruiseMode(false);
 

--- a/src/car/carRuntimeLoader.ts
+++ b/src/car/carRuntimeLoader.ts
@@ -1,0 +1,17 @@
+/**
+ * Lazy loader for the heavy car-mode runtime (Three.js interior stack).
+ * Import this from providers/hooks that must not pull `car/index.ts` into main.
+ */
+import type { CarModeState } from './carModeRuntime';
+
+export type { CarModeState };
+
+let runtimePromise: Promise<typeof import('./carModeRuntime')> | null = null;
+
+/** Load carModeRuntime once; shared across toggles and teardown. */
+export function loadCarRuntime(): Promise<typeof import('./carModeRuntime')> {
+  if (!runtimePromise) {
+    runtimePromise = import('./carModeRuntime');
+  }
+  return runtimePromise;
+}

--- a/src/hooks/useEnvironmentSettings.tsx
+++ b/src/hooks/useEnvironmentSettings.tsx
@@ -1,12 +1,5 @@
 import React, { createContext, useContext, useState, useCallback, useMemo } from 'react';
-import {
-  toggleWipers,
-  setCarWipers,
-  toggleCarHeadlights,
-  toggleCarDomeLight,
-  setCarHeadlights,
-  setCarDomeLight,
-} from '../car';
+import { loadCarRuntime } from '../car/carRuntimeLoader';
 
 // Types
 export type TimeOfDay = 'day' | 'sunrise' | 'sunset' | 'night';
@@ -141,26 +134,29 @@ export const EnvironmentSettingsProvider: React.FC<EnvironmentSettingsProviderPr
   
   // Wipers
   const toggleWipersCallback = useCallback(() => {
-    const newState = toggleWipers();
-    setWipersEnabledState(newState);
-    setCarWipers(newState);
+    void loadCarRuntime().then(({ toggleWipers, setCarWipers }) => {
+      const newState = toggleWipers();
+      setWipersEnabledState(newState);
+      setCarWipers(newState);
+    });
   }, []);
-  
+
   const setWipers = useCallback((enabled: boolean) => {
     setWipersEnabledState(enabled);
-    setCarWipers(enabled);
+    void loadCarRuntime().then(({ setCarWipers }) => setCarWipers(enabled));
   }, []);
-  
+
   // Headlights
   const toggleHeadlights = useCallback((): boolean => {
-    const newState = toggleCarHeadlights();
+    const newState = !headlightsOn;
     setHeadlightsOnState(newState);
+    void loadCarRuntime().then(({ setCarHeadlights }) => setCarHeadlights(newState));
     return newState;
-  }, []);
-  
+  }, [headlightsOn]);
+
   const setHeadlights = useCallback((enabled: boolean) => {
     setHeadlightsOnState(enabled);
-    setCarHeadlights(enabled);
+    void loadCarRuntime().then(({ setCarHeadlights }) => setCarHeadlights(enabled));
   }, []);
   
   // High beam
@@ -170,14 +166,15 @@ export const EnvironmentSettingsProvider: React.FC<EnvironmentSettingsProviderPr
   
   // Dome light
   const toggleDomeLightCallback = useCallback((): boolean => {
-    const newState = toggleCarDomeLight();
+    const newState = !domeLightOn;
     setDomeLightOnState(newState);
+    void loadCarRuntime().then(({ setCarDomeLight }) => setCarDomeLight(newState));
     return newState;
-  }, []);
-  
+  }, [domeLightOn]);
+
   const setDomeLight = useCallback((enabled: boolean) => {
     setDomeLightOnState(enabled);
-    setCarDomeLight(enabled);
+    void loadCarRuntime().then(({ setCarDomeLight }) => setCarDomeLight(enabled));
   }, []);
   
   // Roof

--- a/src/hooks/useViewMode.tsx
+++ b/src/hooks/useViewMode.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useCallback, useRef, useEffect } from 'react';
-import { initCarMode, toggleCarMode, disposeCarMode, CarModeState } from '../car';
+import { loadCarRuntime, type CarModeState } from '../car/carRuntimeLoader';
 
 // Types
 export type ViewMode = 'freelook' | 'car';
@@ -109,11 +109,15 @@ export const ViewModeProvider: React.FC<ViewModeProviderProps> = ({
   const initCarModeForContainer = useCallback((container: HTMLElement) => {
     if (!carModeStateRef.current && container) {
       containerRef.current = container;
-      try {
-        carModeStateRef.current = initCarMode(container);
-      } catch (err) {
-        console.error('[ViewModeProvider] Failed to initialize car mode:', err);
-      }
+      void loadCarRuntime()
+        .then(({ initCarMode }) => {
+          if (!carModeStateRef.current && containerRef.current === container) {
+            carModeStateRef.current = initCarMode(container);
+          }
+        })
+        .catch((err) => {
+          console.error('[ViewModeProvider] Failed to initialize car mode:', err);
+        });
     }
   }, []);
 
@@ -126,31 +130,30 @@ export const ViewModeProvider: React.FC<ViewModeProviderProps> = ({
   // Handle mode switching side effects
   useEffect(() => {
     if (prevViewMode === viewMode) return;
-    
+
     console.log(`[ViewMode] Switching: ${prevViewMode} → ${viewMode}`);
-    
-    // Cleanup previous mode
-    if (prevViewMode === 'car') {
-      toggleCarMode(false);
-    }
-    
-    // Initialize new mode
-    if (viewMode === 'car') {
-      if (carModeStateRef.current && containerRef.current) {
+
+    void loadCarRuntime().then(({ toggleCarMode }) => {
+      if (prevViewMode === 'car') {
+        toggleCarMode(false);
+      }
+
+      if (viewMode === 'car' && carModeStateRef.current && containerRef.current) {
         toggleCarMode(true);
-        // Reset car control mode to default when entering car mode
         setControlMode('freeLook');
         previousControlModeRef.current = 'freeLook';
       }
-    }
+    });
   }, [viewMode, prevViewMode]);
-  
+
   // Cleanup on unmount
   useEffect(() => {
     return () => {
       if (carModeStateRef.current) {
-        disposeCarMode();
-        carModeStateRef.current = null;
+        void loadCarRuntime().then(({ disposeCarMode }) => {
+          disposeCarMode();
+          carModeStateRef.current = null;
+        });
       }
     };
   }, []);

--- a/src/views/MainView.tsx
+++ b/src/views/MainView.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import { useViewMode } from '../hooks/useViewMode';
 import FreeLookView from './FreeLookView';
-import CarModeView from './CarModeView';
+
+const CarModeView = lazy(() => import('./CarModeView'));
 
 interface MainViewProps {
   mapsApiKey: string;
@@ -19,7 +20,11 @@ const MainView: React.FC<MainViewProps> = ({ mapsApiKey }) => {
   return (
     <>
       {viewMode === 'freelook' && <FreeLookView mapsApiKey={mapsApiKey} />}
-      {viewMode === 'car' && <CarModeView mapsApiKey={mapsApiKey} />}
+      {viewMode === 'car' && (
+        <Suspense fallback={null}>
+          <CarModeView mapsApiKey={mapsApiKey} />
+        </Suspense>
+      )}
     </>
   );
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`npm run build` failed verification because `main.*.js` gzip size was **434,407 bytes**, exceeding the **409,600 byte (400 KiB)** budget by ~25 KB.

Root cause: the car-mode barrel (`src/car/index.ts`) — which pulls in the full Three.js interior stack — was eagerly imported by always-mounted providers (`useViewMode`, `useEnvironmentSettings`) and `AppShell`, even on the default free-look route.

## Solution

Code-split the car stack so free-look first paint stays lean:

- **`src/car/carRuntimeLoader.ts`** — shared dynamic `import('./carModeRuntime')` helper
- **`MainView.tsx`** — `React.lazy()` + `Suspense` for `CarModeView`
- **`useViewMode.tsx`** / **`useEnvironmentSettings.tsx`** — defer car API calls via `loadCarRuntime()` instead of static `../car` imports
- **`AppShell.tsx`** — resolve cruise gear hops through the cached runtime module (defaults to 1 hop until car mode loads)

## Results

| Bundle | Before | After |
|--------|--------|-------|
| `main.*.js` gzip | 434,407 B ❌ | 348,454 B ✅ |
| `carModeRuntime.*.chunk.js` gzip | (in main) | 74,868 B |
| `CarModeView.*.chunk.js` gzip | (in main) | 14,589 B |

Cesium-in-main check still passes (1 hit). All lazy chunks within budget.

## Verification

- `npm run build` — bundle budget ✅
- `npm run lint` — ✅
- `npm run typecheck` — ✅
- `npm test` — 490/496 pass; 6 `App.test.tsx` failures are pre-existing on `main` (loading-gate timing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad9b4fb4-76fe-4d69-9b5b-0d193b3557e2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad9b4fb4-76fe-4d69-9b5b-0d193b3557e2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved application startup by loading car-mode functionality only when needed.
  * Added lazy loading for the car-mode view to reduce initial loading overhead.

* **Bug Fixes**
  * Improved reliability of car controls, including wipers, headlights, dome lights, and cruise-mode gear changes.
  * Preserved responsive control updates while background runtime operations complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->