### PR TITLE
Fix car mode bootstrap crash on WebGL-only hosts

### DIFF
--- a/src/car/CarInterior.ts
+++ b/src/car/CarInterior.ts
@@ -420,6 +420,9 @@ export class CarInterior implements CarInteriorAssemblyHost {
     }
 
     public applySeatPosition(): void {
+        if (!this.driverSeatGroup || !this.vehicleConfig?.cameraPosition) {
+            return;
+        }
         const { x, y, z } = this.vehicleConfig.cameraPosition;
         this.driverSeatGroup.position.set(x, y, z + this.seatOffset);
     }

--- a/src/car/interior/CarInteriorBootstrap.ts
+++ b/src/car/interior/CarInteriorBootstrap.ts
@@ -149,6 +149,9 @@ export function bootstrapCarInterior(
     scene.add(roofGroup);
 
     const driverSeatGroup = new THREE.Group();
+    // Host must know driverSeatGroup before applySeatPosition() — CarInterior reads
+    // this.driverSeatGroup.position during the bootstrap callback.
+    host.driverSeatGroup = driverSeatGroup;
     applySeatPosition();
     interiorGroup.add(driverSeatGroup);
     driverSeatGroup.add(camera);

--- a/src/hooks/useGlobeTeleport.ts
+++ b/src/hooks/useGlobeTeleport.ts
@@ -40,7 +40,11 @@ export function useGlobeTeleport({
 
     getTopStationForLocation(lat, lng).then(station => {
       if (station && audioRef.current) {
-        audioRef.current.src = station.urlResolved || station.url;
+        let streamUrl = station.urlResolved || station.url;
+        if (streamUrl.startsWith('http://')) {
+          streamUrl = `https://${streamUrl.slice(7)}`;
+        }
+        audioRef.current.src = streamUrl;
         audioRef.current.play().catch(() => {});
         setIsRadioPlaying(true);
         console.log(`[GlobeTeleport] Tuned to: ${station.name} (${station.country})`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Car mode fails to initialize on production (`test.1ink.us`) with:

```
TypeError: Cannot read properties of undefined (reading 'position')
```

The minified stack often points at `RearviewMirror.ts`, but the root cause is `CarInteriorBootstrap` calling `applySeatPosition()` before `CarInterior.driverSeatGroup` is assigned.

## Fix

1. **Bootstrap order** — Set `host.driverSeatGroup` on the assembly host before invoking the seat-position callback in `CarInteriorBootstrap.ts`.
2. **Defensive guard** — `CarInterior.applySeatPosition()` returns early if `driverSeatGroup` or `vehicleConfig.cameraPosition` is not ready.
3. **Globe radio mixed content** — `useGlobeTeleport` upgrades `http://` stream URLs to `https://` so Radio Browser stations play on HTTPS deployments.

## Testing

- `npm run typecheck` — clean
- `npm test -- src/car` — 70 tests pass

## Notes

- Geocoding API warnings on production are a Google Cloud Console configuration issue (enable Geocoding API on the Maps key), not addressed in this PR.
- Globe orbital drop, bookmark waypoints, and POI layers are already on `main` in `GlobeView.tsx`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86bdab69-61d6-45c2-b026-8a99017b4b98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86bdab69-61d6-45c2-b026-8a99017b4b98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vehicle interior positioning when seat or camera data is unavailable.
  * Fixed driver seat positioning during interior setup.
  * Improved auto-radio playback by using secure HTTPS stream connections where available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->