### PR TITLE
feat(studio): cinema mode, WebM clips, tour director track, session weather sync

### DIFF
--- a/docs/SHARED_SESSIONS.md
+++ b/docs/SHARED_SESSIONS.md
@@ -1,0 +1,79 @@
+# Shared Exploration Sessions
+
+Multiplayer Street View road trips: a **host** drives (cruise, keyboard, MiniMap); **guests** follow the host POV over a WebRTC data channel. Signaling uses Supabase Realtime room codes — no imagery or POV state is persisted server-side.
+
+## Architecture
+
+```
+Host browser                         Guest browser
+┌─────────────────┐               ┌─────────────────┐
+│ Street View     │               │ Street View     │
+│ useSharedSession│◄──WebRTC DC──►│ useSharedSession│
+│ (broadcast POV) │   (P2P only)  │ (apply POV)     │
+└────────┬────────┘               └────────┬────────┘
+         │ SDP + ICE candidates             │
+         └──────────► Supabase Realtime ◄───┘
+                    (signaling only)
+```
+
+- **Media path**: peer-to-peer `RTCDataChannel` (`streetview-sync` label), hub topology (host ↔ each guest).
+- **Signaling**: 6-character room codes via Supabase Realtime — SDP offers/answers and trickle ICE only.
+- **Weather sync**: host broadcasts a compact `weatherPreset` string (`tod:night|rain:0.50|…`) at 10 Hz with POV; guests apply time-of-day and weather sliders when it changes.
+
+## STUN vs TURN
+
+| | STUN | TURN |
+|---|------|------|
+| **Purpose** | Discover public IP / NAT type | Relay traffic when direct P2P fails |
+| **Default** | `stun:stun.l.google.com:19302` (always on) | Off unless configured |
+| **Cost** | Free public STUN | You operate or rent a TURN server |
+| **When needed** | Most home NATs | Symmetric NAT, corporate firewalls on **both** ends |
+
+The app resolves ICE servers in `src/utils/iceServers.ts`:
+
+1. Google STUN (always).
+2. Optional TURN when `REACT_APP_TURN_URL` (or `VITE_TURN_URL`) is set at build time, **or** `window.TURN_URL` (+ optional `TURN_USERNAME` / `TURN_CREDENTIAL`) in runtime `public/config.js`.
+
+**No code fork is required** — only configuration. Never commit TURN credentials to git; use deploy secrets or post-deploy `config.js` edits.
+
+### Example runtime config
+
+```js
+// public/config.js (after deploy)
+window.TURN_URL = "turn:turn.example.com:3478";
+window.TURN_USERNAME = "user";
+window.TURN_CREDENTIAL = "secret";
+```
+
+### Example build-time env (`.env.local`)
+
+```
+REACT_APP_TURN_URL=turn:turn.example.com:3478
+REACT_APP_TURN_USERNAME=user
+REACT_APP_TURN_CREDENTIAL=secret
+```
+
+## Reconnect / host-migrate
+
+- Guests apply incoming state only when `seq` increases (`shouldApplyIncomingState`) — late packets never roll the view backward.
+- On disconnect, the client retries up to 5 times with a 2 s delay (`MAX_RECONNECT_ATTEMPTS`, `RECONNECT_DELAY_MS` in `useSharedSession.ts`).
+- **Host-migrate** is not automated: if the host leaves, guests see `host-left`. A guest must create a new room to become host.
+
+## Guest follow modes
+
+Current behavior: **hard follow** — guests teleport to the host pano and mirror heading/pitch/zoom. Free-look offset for guests is a future UX option; the data model already carries full POV for extension.
+
+## Billing / imagery
+
+- Shared sessions **never** fetch Street View Static API imagery.
+- Signaling carries handshake metadata only — no Google tiles are cached by the session layer (`swPolicy` remains `network-only` for `maps.googleapis.com`).
+
+## Related files
+
+| File | Role |
+|------|------|
+| `src/hooks/useSharedSession.ts` | WebRTC + room lifecycle |
+| `src/app/useSharedSessionSync.ts` | 10 Hz host broadcast + guest apply |
+| `src/app/sharedSessionSync.ts` | Pure payload builders |
+| `src/utils/iceServers.ts` | STUN + optional TURN resolution |
+| `src/utils/weatherPresetSync.ts` | Weather preset serialize/parse |

--- a/e2e/cinema-studio.spec.ts
+++ b/e2e/cinema-studio.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+import { dismissWelcome, gotoApp } from './helpers';
+
+test.describe('cinema studio', () => {
+  test('cinema mode toggles via Shift+F and exits on Esc', async ({ page }) => {
+    await gotoApp(page);
+    await dismissWelcome(page);
+
+    await expect(page.getByTestId('cinema-overlay')).toHaveCount(0);
+
+    await page.keyboard.press('Shift+F');
+    await expect(page.getByTestId('cinema-overlay')).toBeVisible();
+    await expect(page.getByTestId('cinema-letterbox-top')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('cinema-overlay')).toHaveCount(0);
+  });
+
+  test('tour panel opens and export JSON button is available', async ({ page }) => {
+    await gotoApp(page);
+    await dismissWelcome(page);
+
+    await page.getByRole('button', { name: /Tour/i }).click();
+    await expect(page.getByRole('heading', { name: /Tour/i })).toBeVisible();
+
+    const importBtn = page.getByRole('button', { name: /Import JSON/i });
+    await expect(importBtn).toBeVisible();
+
+    // With no tours, export buttons are absent — import is the export-path entry point.
+    await expect(page.getByTestId('tour-export-json')).toHaveCount(0);
+  });
+});

--- a/public/config.js
+++ b/public/config.js
@@ -35,3 +35,13 @@ window.CESIUM_ION_TOKEN = "";
 // src/hooks/useSharedSession.ts and README "Shared Exploration Sessions".
 window.SUPABASE_URL = "";
 window.SUPABASE_ANON_KEY = "";
+
+// Optional TURN relay for Shared Exploration Sessions when STUN-only
+// WebRTC cannot traverse symmetric NAT / restrictive firewalls on both ends.
+// Supply URL (+ username/credential if required) at build time via
+// REACT_APP_TURN_URL / REACT_APP_TURN_USERNAME / REACT_APP_TURN_CREDENTIAL,
+// or edit here after a bundle deploy. Never commit real credentials.
+// See docs/SHARED_SESSIONS.md.
+window.TURN_URL = "";
+window.TURN_USERNAME = "";
+window.TURN_CREDENTIAL = "";

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -1,5 +1,6 @@
-import { useRef, useCallback, useEffect } from 'react';
+import { useRef, useCallback, useEffect, useMemo } from 'react';
 import WelcomeModal from '../components/WelcomeModal';
+import CinemaOverlay from '../components/CinemaOverlay';
 import { parseDeepLinkParams } from '../utils/deepLink';
 import {
   useStreetView,
@@ -17,8 +18,13 @@ import { useSnapshots } from '../hooks/useSnapshots';
 import { useGlobeMode } from '../hooks/useGlobeMode';
 import { useKeyboardShortcuts, useAnnouncer, SkipLink } from '../hooks/useKeyboardShortcuts';
 import { useCruiseMode } from '../hooks/useCruiseMode';
+import { useCinemaMode } from '../hooks/useCinemaMode';
 import { publishCruiseFlag } from '../hooks/CruiseFlagContext';
 import { loadCarRuntime } from '../car/carRuntimeLoader';
+import { vehicleManager } from '../car/VehicleManager';
+import type { DirectorSnapshot } from '../hooks/useTours';
+import type { TourDirectorKeyframe } from '../utils/tourDirector';
+import { serializeWeatherPreset } from '../utils/weatherPresetSync';
 import { useAutopilot } from '../hooks/useAutopilot';
 import { buildAppKeyboardShortcuts } from '../hooks/useAppKeyboardShortcuts';
 import { useGlobeTeleport } from '../hooks/useGlobeTeleport';
@@ -90,6 +96,48 @@ export function AppShell() {
     setMapsLoadStatus: maps.setMapsLoadStatus,
   });
 
+  const cinema = useCinemaMode(connection.isConnected && !connection.showWelcome);
+  const {
+    isCinemaMode,
+    letterbox,
+    gradingLocked,
+    toggleCinemaMode,
+    exitCinemaMode,
+    setLetterbox,
+    setGradingLocked,
+  } = cinema;
+
+  const weatherPresetBroadcast = useMemo(
+    () =>
+      serializeWeatherPreset({
+        timeOfDay: env.timeOfDay,
+        rainIntensity: env.rainIntensity,
+        snowIntensity: env.snowIntensity,
+        fogDensity: env.fogDensity,
+      }),
+    [env.timeOfDay, env.rainIntensity, env.snowIntensity, env.fogDensity],
+  );
+
+  const getDirectorSnapshot = useCallback((): DirectorSnapshot | null => ({
+    timeOfDay: env.timeOfDay,
+    vehicle: vehicleManager.getCurrentVehicle(),
+    rainIntensity: env.rainIntensity,
+    snowIntensity: env.snowIntensity,
+    fogDensity: env.fogDensity,
+  }), [env.timeOfDay, env.rainIntensity, env.snowIntensity, env.fogDensity]);
+
+  const applyDirectorKeyframe = useCallback(
+    (frame: TourDirectorKeyframe) => {
+      if (frame.timeOfDay) env.applyTimeOfDayPreset(frame.timeOfDay);
+      if (frame.rainIntensity !== undefined) env.setRainIntensity(frame.rainIntensity);
+      if (frame.snowIntensity !== undefined) env.setSnowIntensity(frame.snowIntensity);
+      if (frame.fogDensity !== undefined) env.setFogDensity(frame.fogDensity);
+      if (frame.colorGradingPreset) env.applyColorGradingPreset(frame.colorGradingPreset);
+      if (frame.vehicle) vehicleManager.setVehicle(frame.vehicle);
+    },
+    [env],
+  );
+
   const {
     bookmarks,
     addBookmark,
@@ -132,6 +180,11 @@ export function AppShell() {
     setHeading,
     setPitch,
     setZoom,
+    weatherPreset: weatherPresetBroadcast,
+    applyTimeOfDayPreset: env.applyTimeOfDayPreset,
+    setRainIntensity: env.setRainIntensity,
+    setSnowIntensity: env.setSnowIntensity,
+    setFogDensity: env.setFogDensity,
   });
 
   const { tourPanelProps } = useTourBindings({
@@ -147,6 +200,8 @@ export function AppShell() {
     isPanoramaReady,
     routePrefetch,
     panoCacheFetch: panoCache.fetch,
+    getDirectorSnapshot,
+    applyDirectorKeyframe,
   });
 
   const { isCruiseMode, setIsCruiseMode } = useCruiseMode({
@@ -307,6 +362,9 @@ export function AppShell() {
       setIsWeatherPanelOpen: panels.setIsWeatherPanelOpen,
       isTourPanelOpen: panels.isTourPanelOpen,
       setIsTourPanelOpen: panels.setIsTourPanelOpen,
+      isCinemaMode,
+      toggleCinemaMode,
+      exitCinemaMode,
       viewMode,
       toggleViewMode,
       wipersEnabled: env.wipersEnabled,
@@ -321,7 +379,7 @@ export function AppShell() {
       globeMode,
       announce,
     }),
-    connection.isConnected && !connection.showWelcome,
+    connection.isConnected && !connection.showWelcome && !isCinemaMode,
   );
 
   const mapsLoadingOverlay = buildMapsLoadingOverlay({
@@ -376,7 +434,7 @@ export function AppShell() {
 
       {connection.showWelcome && <WelcomeModal onStart={connection.handleStart} search={placeSearch} />}
 
-      {connection.isConnected && (
+      {connection.isConnected && !isCinemaMode && (
         <ConnectedChrome
           panels={panels}
           session={{
@@ -445,6 +503,19 @@ export function AppShell() {
             onRefresh: () => void routePrefetch.refreshSummaries(),
           }}
           search={placeSearch}
+        />
+      )}
+
+      {connection.isConnected && isCinemaMode && (
+        <CinemaOverlay
+          visible={isCinemaMode}
+          letterbox={letterbox}
+          onToggleLetterbox={() => setLetterbox(!letterbox)}
+          gradingLocked={gradingLocked}
+          onToggleGradingLock={() => setGradingLocked(!gradingLocked)}
+          renderer={renderer}
+          onExit={exitCinemaMode}
+          onTakeSnapshot={handleTakeSnapshot}
         />
       )}
 

--- a/src/app/sharedSessionSync.test.ts
+++ b/src/app/sharedSessionSync.test.ts
@@ -55,6 +55,23 @@ describe('buildHostBroadcastPayload', () => {
       viewMode: 'car',
     });
   });
+
+  it('includes weatherPreset when provided in extras', () => {
+    expect(
+      buildHostBroadcastPayload(
+        mockPanorama({ panoId: 'pano-1' }),
+        pov,
+        viewMode,
+        { weatherPreset: 'tod:night|rain:0.50' },
+      ),
+    ).toEqual({
+      panoId: 'pano-1',
+      position: { lat: 37, lng: -122 },
+      pov,
+      viewMode: 'freelook',
+      weatherPreset: 'tod:night|rain:0.50',
+    });
+  });
 });
 
 describe('shouldTeleportGuestToPano', () => {

--- a/src/app/sharedSessionSync.ts
+++ b/src/app/sharedSessionSync.ts
@@ -3,12 +3,16 @@ import type { SessionState } from '../hooks/useSharedSession';
 export type HostBroadcastPov = SessionState['pov'];
 export type HostBroadcastViewMode = SessionState['viewMode'];
 
-export type HostBroadcastPayload = Omit<SessionState, 'seq' | 'weatherPreset'>;
+export type HostBroadcastPayload = Omit<SessionState, 'seq'>;
 
 /** Minimal panorama surface needed to build a host broadcast payload. */
 export interface HostBroadcastPanorama {
   getPano(): string | null | undefined;
   getPosition(): { lat(): number; lng(): number } | null | undefined;
+}
+
+export interface HostBroadcastExtras {
+  weatherPreset?: string;
 }
 
 /**
@@ -19,6 +23,7 @@ export function buildHostBroadcastPayload(
   panorama: HostBroadcastPanorama | null | undefined,
   pov: HostBroadcastPov,
   viewMode: HostBroadcastViewMode,
+  extras?: HostBroadcastExtras,
 ): HostBroadcastPayload | null {
   if (!panorama) return null;
   const panoId = panorama.getPano();
@@ -29,6 +34,7 @@ export function buildHostBroadcastPayload(
     position: { lat: pos.lat(), lng: pos.lng() },
     pov,
     viewMode,
+    ...(extras?.weatherPreset ? { weatherPreset: extras.weatherPreset } : {}),
   };
 }
 

--- a/src/app/useSharedSessionSync.ts
+++ b/src/app/useSharedSessionSync.ts
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from 'react';
 import type { UseSharedSessionResult } from '../hooks/useSharedSession';
 import { buildHostBroadcastPayload, shouldTeleportGuestToPano } from './sharedSessionSync';
+import { parseWeatherPreset } from '../utils/weatherPresetSync';
+import type { TimeOfDay } from '../hooks/useEnvironmentSettings';
 
 export interface UseSharedSessionSyncParams {
   sharedSession: UseSharedSessionResult;
@@ -13,6 +15,12 @@ export interface UseSharedSessionSyncParams {
   setHeading: (heading: number) => void;
   setPitch: (pitch: number) => void;
   setZoom: (zoom: number) => void;
+  /** Serialized weather preset broadcast by host (see weatherPresetSync). */
+  weatherPreset?: string;
+  applyTimeOfDayPreset?: (preset: TimeOfDay) => void;
+  setRainIntensity?: (v: number) => void;
+  setSnowIntensity?: (v: number) => void;
+  setFogDensity?: (v: number) => void;
 }
 
 /**
@@ -29,8 +37,14 @@ export function useSharedSessionSync({
   setHeading,
   setPitch,
   setZoom,
+  weatherPreset,
+  applyTimeOfDayPreset,
+  setRainIntensity,
+  setSnowIntensity,
+  setFogDensity,
 }: UseSharedSessionSyncParams): void {
   const lastAppliedPanoRef = useRef<string | null>(null);
+  const lastWeatherPresetRef = useRef<string | null>(null);
 
   const {
     role: sessionRole,
@@ -43,7 +57,12 @@ export function useSharedSessionSync({
   useEffect(() => {
     if (sessionRole !== 'host' || !sessionConnected) return;
     const interval = setInterval(() => {
-      const payload = buildHostBroadcastPayload(panorama, { heading, pitch, zoom }, viewMode);
+      const payload = buildHostBroadcastPayload(
+        panorama,
+        { heading, pitch, zoom },
+        viewMode,
+        weatherPreset ? { weatherPreset } : undefined,
+      );
       if (!payload) return;
       broadcastState(payload);
     }, 100);
@@ -57,6 +76,7 @@ export function useSharedSessionSync({
     pitch,
     zoom,
     viewMode,
+    weatherPreset,
   ]);
 
   // Guests follow the host's POV as it arrives.
@@ -72,6 +92,20 @@ export function useSharedSessionSync({
     setHeading(latestState.pov.heading);
     setPitch(latestState.pov.pitch);
     setZoom(latestState.pov.zoom);
+
+    if (
+      latestState.weatherPreset &&
+      latestState.weatherPreset !== lastWeatherPresetRef.current
+    ) {
+      lastWeatherPresetRef.current = latestState.weatherPreset;
+      const parsed = parseWeatherPreset(latestState.weatherPreset);
+      if (parsed) {
+        if (parsed.timeOfDay && applyTimeOfDayPreset) applyTimeOfDayPreset(parsed.timeOfDay);
+        if (parsed.rainIntensity !== undefined && setRainIntensity) setRainIntensity(parsed.rainIntensity);
+        if (parsed.snowIntensity !== undefined && setSnowIntensity) setSnowIntensity(parsed.snowIntensity);
+        if (parsed.fogDensity !== undefined && setFogDensity) setFogDensity(parsed.fogDensity);
+      }
+    }
   }, [
     sessionRole,
     latestState,
@@ -80,5 +114,9 @@ export function useSharedSessionSync({
     setHeading,
     setPitch,
     setZoom,
+    applyTimeOfDayPreset,
+    setRainIntensity,
+    setSnowIntensity,
+    setFogDensity,
   ]);
 }

--- a/src/app/useTourBindings.ts
+++ b/src/app/useTourBindings.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { useTours, type CurrentPOV, type Tour, type TourWaypoint } from '../hooks/useTours';
+import { useTours, type CurrentPOV, type DirectorSnapshot, type Tour, type TourWaypoint } from '../hooks/useTours';
 import type { UseRoutePrefetchResult } from '../hooks/useRoutePrefetch';
 import type { RouteGraphNode, RouteGraphSummary, RoutePrefetchProgress } from '../offline';
 
@@ -16,6 +16,10 @@ export interface UseTourBindingsParams {
   isPanoramaReady: boolean;
   routePrefetch: UseRoutePrefetchResult;
   panoCacheFetch: (lat: number, lng: number) => Promise<unknown>;
+  /** Optional director-track snapshot for session recording. */
+  getDirectorSnapshot?: () => DirectorSnapshot | null;
+  /** Apply director keyframe during tour playback. */
+  applyDirectorKeyframe?: (frame: import('../utils/tourDirector').TourDirectorKeyframe) => void;
 }
 
 /** Props bag consumed by TourPanel (minus isOpen/onClose owned by panels). */
@@ -26,7 +30,11 @@ export interface TourPanelBindings {
   draftWaypoints: TourWaypoint[];
   getCurrentPOV: () => CurrentPOV | null;
   currentLocationLabel: string;
-  onStartRecording: (name: string, getCurrentPOV: () => CurrentPOV | null) => void;
+  onStartRecording: (
+    name: string,
+    getCurrentPOV: () => CurrentPOV | null,
+    getDirectorSnapshot?: () => DirectorSnapshot | null,
+  ) => void;
   onPauseRecording: () => void;
   onResumeRecording: () => void;
   onStopRecording: (name: string) => void;
@@ -55,6 +63,7 @@ export interface TourPanelBindings {
   onDeleteRouteGraph: (routeId: string) => void;
   getRouteGraph: (routeId: string) => Promise<RouteGraphNode[]>;
   panoCacheFetch: (lat: number, lng: number) => Promise<unknown>;
+  applyDirectorKeyframe?: (frame: import('../utils/tourDirector').TourDirectorKeyframe) => void;
 }
 
 export interface UseTourBindingsResult {
@@ -79,6 +88,8 @@ export function useTourBindings({
   isPanoramaReady,
   routePrefetch,
   panoCacheFetch,
+  getDirectorSnapshot,
+  applyDirectorKeyframe,
 }: UseTourBindingsParams): UseTourBindingsResult {
   const toursApi = useTours();
 
@@ -119,7 +130,8 @@ export function useTourBindings({
       draftWaypoints: toursApi.draftWaypoints,
       getCurrentPOV,
       currentLocationLabel: locationName,
-      onStartRecording: (name, getPOV) => toursApi.startRecording(name, getPOV),
+      onStartRecording: (name, getPOV) =>
+        toursApi.startRecording(name, getPOV, 0, getDirectorSnapshot),
       onPauseRecording: toursApi.pauseRecording,
       onResumeRecording: toursApi.resumeRecording,
       onStopRecording: (name) => {
@@ -146,6 +158,7 @@ export function useTourBindings({
       onDeleteRouteGraph,
       getRouteGraph: routePrefetch.getRouteGraph,
       panoCacheFetch,
+      applyDirectorKeyframe,
     }),
     [
       toursApi,
@@ -164,6 +177,8 @@ export function useTourBindings({
       onPrepareOfflineGraph,
       onDeleteRouteGraph,
       panoCacheFetch,
+      getDirectorSnapshot,
+      applyDirectorKeyframe,
     ],
   );
 

--- a/src/components/CinemaOverlay.tsx
+++ b/src/components/CinemaOverlay.tsx
@@ -1,0 +1,259 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import type { StreetViewRenderer } from '../renderer/RendererBackend';
+import {
+  CanvasClipRecorder,
+  downloadClip,
+  isClipRecordingSupported,
+  type ClipRecorderState,
+} from '../utils/canvasRecorder';
+
+export interface CinemaOverlayProps {
+  visible: boolean;
+  letterbox: boolean;
+  onToggleLetterbox: () => void;
+  gradingLocked: boolean;
+  onToggleGradingLock: () => void;
+  renderer: StreetViewRenderer | null;
+  onExit: () => void;
+  onTakeSnapshot?: () => void;
+}
+
+const MIN_CLIP_MS = 15_000;
+
+const CinemaOverlay: React.FC<CinemaOverlayProps> = ({
+  visible,
+  letterbox,
+  onToggleLetterbox,
+  gradingLocked,
+  onToggleGradingLock,
+  renderer,
+  onExit,
+  onTakeSnapshot,
+}) => {
+  const [recState, setRecState] = useState<ClipRecorderState>(
+    isClipRecordingSupported() ? 'idle' : 'unsupported',
+  );
+  const [elapsedSec, setElapsedSec] = useState(0);
+  const recorderRef = useRef<CanvasClipRecorder | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const cleanupRecorder = useCallback(() => {
+    stopTimer();
+    recorderRef.current?.dispose();
+    recorderRef.current = null;
+    setElapsedSec(0);
+    setRecState(isClipRecordingSupported() ? 'idle' : 'unsupported');
+  }, [stopTimer]);
+
+  useEffect(() => {
+    if (!visible) cleanupRecorder();
+    return cleanupRecorder;
+  }, [visible, cleanupRecorder]);
+
+  const handleStartRecording = useCallback(() => {
+    if (!renderer?.canvas || recState === 'recording') return;
+    cleanupRecorder();
+    const recorder = new CanvasClipRecorder(renderer.canvas, { fps: 30, burnAttribution: true });
+    if (recorder.getState() === 'unsupported') {
+      setRecState('unsupported');
+      return;
+    }
+    recorderRef.current = recorder;
+    recorder.start();
+    setRecState('recording');
+    setElapsedSec(0);
+    timerRef.current = setInterval(() => setElapsedSec((s) => s + 1), 1000);
+  }, [renderer, recState, cleanupRecorder]);
+
+  const handleStopRecording = useCallback(async () => {
+    const recorder = recorderRef.current;
+    if (!recorder || recState !== 'recording') return;
+    stopTimer();
+    try {
+      const result = await recorder.stop();
+      downloadClip(result.blob, result.mimeType);
+      setRecState('stopped');
+    } catch (err) {
+      console.error('[CinemaOverlay] clip stop failed', err);
+      setRecState('idle');
+    } finally {
+      recorder.dispose();
+      recorderRef.current = null;
+      setElapsedSec(0);
+      setTimeout(() => setRecState(isClipRecordingSupported() ? 'idle' : 'unsupported'), 1500);
+    }
+  }, [recState, stopTimer]);
+
+  if (!visible) return null;
+
+  const canStop = recState === 'recording' && elapsedSec * 1000 >= MIN_CLIP_MS;
+  const recordingHint =
+    recState === 'recording' && !canStop
+      ? `Record ≥${MIN_CLIP_MS / 1000}s (${elapsedSec}s)`
+      : null;
+
+  return (
+    <>
+      {letterbox && (
+        <>
+          <div
+            aria-hidden
+            data-testid="cinema-letterbox-top"
+            style={{
+              position: 'fixed',
+              top: 0,
+              left: 0,
+              right: 0,
+              height: '10vh',
+              background: '#000',
+              zIndex: 50,
+              pointerEvents: 'none',
+            }}
+          />
+          <div
+            aria-hidden
+            data-testid="cinema-letterbox-bottom"
+            style={{
+              position: 'fixed',
+              bottom: 0,
+              left: 0,
+              right: 0,
+              height: '10vh',
+              background: '#000',
+              zIndex: 50,
+              pointerEvents: 'none',
+            }}
+          />
+        </>
+      )}
+
+      <div
+        role="toolbar"
+        aria-label="Cinema mode controls"
+        data-testid="cinema-overlay"
+        style={{
+          position: 'fixed',
+          bottom: letterbox ? '12vh' : 16,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          zIndex: 60,
+          display: 'flex',
+          gap: 8,
+          padding: '10px 14px',
+          background: 'rgba(0,0,0,0.72)',
+          borderRadius: 10,
+          border: '1px solid rgba(255,255,255,0.15)',
+          pointerEvents: 'auto',
+        }}
+        onMouseDown={(e) => e.stopPropagation()}
+        onMouseUp={(e) => e.stopPropagation()}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        {recState === 'unsupported' ? (
+          <span style={{ color: '#f0ad4e', fontSize: 12 }}>WebM recording unavailable</span>
+        ) : recState === 'recording' ? (
+          <button
+            type="button"
+            data-testid="cinema-stop-recording"
+            disabled={!canStop}
+            onClick={() => void handleStopRecording()}
+            style={btnStyle('#d9534f', !canStop)}
+            title={recordingHint ?? 'Stop and download clip'}
+          >
+            ■ Stop {elapsedSec > 0 ? `(${elapsedSec}s)` : ''}
+          </button>
+        ) : (
+          <button
+            type="button"
+            data-testid="cinema-start-recording"
+            onClick={handleStartRecording}
+            disabled={!renderer}
+            style={btnStyle('#d9534f')}
+            title="Record WebM clip (min 15s)"
+          >
+            ● Record
+          </button>
+        )}
+
+        {onTakeSnapshot && (
+          <button type="button" onClick={onTakeSnapshot} style={btnStyle('#2196F3')} title="Capture still">
+            📷 Still
+          </button>
+        )}
+
+        <button
+          type="button"
+          data-testid="cinema-letterbox-toggle"
+          onClick={onToggleLetterbox}
+          style={btnStyle(letterbox ? '#4CAF50' : '#555')}
+          title="Toggle letterbox"
+        >
+          ▬ Letterbox
+        </button>
+
+        <button
+          type="button"
+          data-testid="cinema-grading-lock"
+          onClick={onToggleGradingLock}
+          style={btnStyle(gradingLocked ? '#4CAF50' : '#555')}
+          title="Lock exposure/grading"
+        >
+          {gradingLocked ? '🔒 Locked' : '🔓 Grade'}
+        </button>
+
+        <button
+          type="button"
+          data-testid="cinema-exit"
+          onClick={onExit}
+          style={btnStyle('#555')}
+          title="Exit cinema mode (Esc)"
+        >
+          Esc Exit
+        </button>
+      </div>
+
+      {recordingHint && (
+        <div
+          style={{
+            position: 'fixed',
+            top: letterbox ? '12vh' : 20,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            zIndex: 60,
+            color: '#fff',
+            background: 'rgba(213,83,79,0.85)',
+            padding: '6px 12px',
+            borderRadius: 6,
+            fontSize: 13,
+            pointerEvents: 'none',
+          }}
+        >
+          {recordingHint}
+        </div>
+      )}
+    </>
+  );
+};
+
+function btnStyle(bg: string, disabled = false): React.CSSProperties {
+  return {
+    padding: '8px 12px',
+    border: 'none',
+    borderRadius: 6,
+    background: disabled ? '#444' : bg,
+    color: disabled ? '#888' : '#fff',
+    fontSize: 13,
+    fontWeight: 'bold',
+    cursor: disabled ? 'not-allowed' : 'pointer',
+  };
+}
+
+export default CinemaOverlay;

--- a/src/components/TourPanel.tsx
+++ b/src/components/TourPanel.tsx
@@ -46,6 +46,7 @@ interface TourPanelProps {
     onDeleteRouteGraph?: (routeId: string) => void;
     getRouteGraph?: (routeId: string) => Promise<RouteGraphNode[]>;
     panoCacheFetch?: (lat: number, lng: number) => Promise<unknown>;
+    applyDirectorKeyframe?: (frame: import('../utils/tourDirector').TourDirectorKeyframe) => void;
 }
 
 type TabKey = 'library' | 'record' | 'play';
@@ -95,6 +96,7 @@ const TourPanel: React.FC<TourPanelProps> = ({
     onDeleteRouteGraph,
     getRouteGraph,
     panoCacheFetch,
+    applyDirectorKeyframe,
 }) => {
     const panelRef = useRef<HTMLDivElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
@@ -284,6 +286,7 @@ const TourPanel: React.FC<TourPanelProps> = ({
                                                 ▶ Play
                                             </button>
                                             <button
+                                                data-testid="tour-export-json"
                                                 onClick={() => onDownloadTourJson(tour)}
                                                 style={{ padding: '5px 10px', backgroundColor: '#2196F3', color: '#fff', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: '12px' }}
                                             >
@@ -384,6 +387,7 @@ const TourPanel: React.FC<TourPanelProps> = ({
                         isPanoramaReady={isPanoramaReady}
                         getRouteGraph={getRouteGraph}
                         prewarmPanoCache={panoCacheFetch}
+                        applyDirectorKeyframe={applyDirectorKeyframe}
                     />
                 )}
             </div>

--- a/src/components/TourPlayer.tsx
+++ b/src/components/TourPlayer.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { Tour } from '../hooks/useTours';
 import type { RouteGraphNode } from '../offline';
 import { findPathBetweenPanos } from '../offline';
+import { resolveDirectorAt, type TourDirectorKeyframe } from '../utils/tourDirector';
 
 interface TourPlayerProps {
     tour: Tour;
@@ -14,6 +15,8 @@ interface TourPlayerProps {
     getRouteGraph?: (routeId: string) => Promise<RouteGraphNode[]>;
     /** Pre-warms the panorama cache for a lat/lng, used to smooth hops the offline graph knows about. */
     prewarmPanoCache?: (lat: number, lng: number) => Promise<unknown>;
+    /** Apply director-track keyframe (weather / vehicle) during playback. */
+    applyDirectorKeyframe?: (frame: TourDirectorKeyframe) => void;
 }
 
 const btnStyle: React.CSSProperties = {
@@ -37,6 +40,7 @@ const TourPlayer: React.FC<TourPlayerProps> = ({
     isPanoramaReady,
     getRouteGraph,
     prewarmPanoCache,
+    applyDirectorKeyframe,
 }) => {
     const [currentIndex, setCurrentIndex] = useState(0);
     const [isPlaying, setIsPlaying] = useState(false);
@@ -47,6 +51,8 @@ const TourPlayer: React.FC<TourPlayerProps> = ({
     speedRef.current = speed;
     const runTokenRef = useRef(0);
     const routeGraphNodesRef = useRef<RouteGraphNode[]>([]);
+    const playbackElapsedRef = useRef(0);
+    const playbackStartedAtRef = useRef(0);
 
     // Reset playback position whenever a different tour is loaded.
     useEffect(() => {
@@ -70,6 +76,12 @@ const TourPlayer: React.FC<TourPlayerProps> = ({
         };
     }, [tour.id, getRouteGraph]);
 
+    const applyDirectorAt = useCallback((elapsedMs: number) => {
+        if (!tour.directorTrack?.length || !applyDirectorKeyframe) return;
+        const frame = resolveDirectorAt(tour.directorTrack, elapsedMs);
+        if (frame) applyDirectorKeyframe(frame);
+    }, [tour.directorTrack, applyDirectorKeyframe]);
+
     const visitWaypoint = useCallback(async (index: number) => {
         const wp = tour.waypoints[index];
         if (!wp) return;
@@ -91,7 +103,8 @@ const TourPlayer: React.FC<TourPlayerProps> = ({
         setHeading(wp.pov.heading);
         setPitch(wp.pov.pitch);
         setZoom(wp.pov.zoom);
-    }, [tour.waypoints, teleportToPano, setHeading, setPitch, setZoom, prewarmPanoCache]);
+        applyDirectorAt(playbackElapsedRef.current);
+    }, [tour.waypoints, teleportToPano, setHeading, setPitch, setZoom, prewarmPanoCache, applyDirectorAt]);
 
     // Playback loop: advances through waypoints from currentIndex while isPlaying.
     useEffect(() => {
@@ -99,6 +112,9 @@ const TourPlayer: React.FC<TourPlayerProps> = ({
         const token = ++runTokenRef.current;
 
         const run = async () => {
+            playbackStartedAtRef.current = performance.now();
+            playbackElapsedRef.current = 0;
+            applyDirectorAt(0);
             let idx = currentIndex;
             while (idx < tour.waypoints.length) {
                 if (runTokenRef.current !== token) return;
@@ -110,7 +126,14 @@ const TourPlayer: React.FC<TourPlayerProps> = ({
                 const effectiveDwell = tour.transitionType === 'hold-pause'
                     ? wp.dwellTimeMs
                     : Math.min(wp.dwellTimeMs, 800);
-                await new Promise(resolve => setTimeout(resolve, effectiveDwell / speedRef.current));
+                const dwellMs = effectiveDwell / speedRef.current;
+                const dwellStart = performance.now();
+                while (performance.now() - dwellStart < dwellMs) {
+                    if (runTokenRef.current !== token) return;
+                    playbackElapsedRef.current = performance.now() - playbackStartedAtRef.current;
+                    applyDirectorAt(playbackElapsedRef.current);
+                    await new Promise(resolve => setTimeout(resolve, 200));
+                }
                 if (runTokenRef.current !== token) return;
                 idx++;
             }
@@ -147,7 +170,22 @@ const TourPlayer: React.FC<TourPlayerProps> = ({
     const waypointCount = tour.waypoints.length;
 
     return (
-        <div ref={containerRef} style={{ display: 'flex', flexDirection: 'column', gap: '10px', backgroundColor: isFullscreen ? '#111' : 'transparent', padding: isFullscreen ? '20px' : 0 }}>
+        <div
+            ref={containerRef}
+            data-testid="tour-player"
+            style={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '10px',
+                backgroundColor: isFullscreen ? '#111' : 'transparent',
+                padding: isFullscreen ? '20px' : 0,
+            }}
+        >
+            {tour.directorTrack && tour.directorTrack.length > 0 && (
+                <div style={{ color: '#888', fontSize: '11px' }}>
+                    Director track: {tour.directorTrack.length} keyframe{tour.directorTrack.length === 1 ? '' : 's'}
+                </div>
+            )}
             <div style={{ color: '#ccc', fontSize: '13px' }}>
                 Waypoint {waypointCount === 0 ? 0 : currentIndex + 1} / {waypointCount}
                 {tour.waypoints[currentIndex]?.annotation ? ` — ${tour.waypoints[currentIndex]!.annotation}` : ''}

--- a/src/hooks/useAppKeyboardShortcuts.ts
+++ b/src/hooks/useAppKeyboardShortcuts.ts
@@ -24,6 +24,9 @@ export interface UseAppKeyboardShortcutsOptions {
   setIsWeatherPanelOpen: (v: boolean) => void;
   isTourPanelOpen: boolean;
   setIsTourPanelOpen: (v: boolean) => void;
+  isCinemaMode: boolean;
+  toggleCinemaMode: () => void;
+  exitCinemaMode: () => void;
   viewMode: 'freelook' | 'car';
   toggleViewMode: () => void;
   wipersEnabled: boolean;
@@ -68,6 +71,9 @@ export function buildAppKeyboardShortcuts(options: UseAppKeyboardShortcutsOption
     setIsWeatherPanelOpen,
     isTourPanelOpen,
     setIsTourPanelOpen,
+    isCinemaMode,
+    toggleCinemaMode,
+    exitCinemaMode,
     viewMode,
     toggleViewMode,
     wipersEnabled,
@@ -181,6 +187,20 @@ export function buildAppKeyboardShortcuts(options: UseAppKeyboardShortcutsOption
       },
     },
     {
+      key: 'F',
+      modifier: 'shift',
+      description: 'Toggle cinema mode',
+      action: () => {
+        if (isCinemaMode) {
+          exitCinemaMode();
+          announce('Cinema mode off');
+        } else {
+          toggleCinemaMode();
+          announce('Cinema mode on — Esc to exit');
+        }
+      },
+    },
+    {
       key: 'c',
       description: 'Toggle car mode',
       action: () => {
@@ -238,8 +258,9 @@ export function buildAppKeyboardShortcuts(options: UseAppKeyboardShortcutsOption
     },
     {
       key: 'Escape',
-      description: 'Close panels',
+      description: 'Close panels or exit cinema mode',
       action: () => {
+        if (isCinemaMode) { exitCinemaMode(); return; }
         if (globeMode.isActive) { globeMode.deactivate(); return; }
         if (isWeatherPanelOpen) { setIsWeatherPanelOpen(false); return; }
         if (isAccessibilityPanelOpen) setIsAccessibilityPanelOpen(false);

--- a/src/hooks/useCinemaMode.ts
+++ b/src/hooks/useCinemaMode.ts
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export interface CinemaModeState {
+  isCinemaMode: boolean;
+  letterbox: boolean;
+  /** Lock exposure/grading sliders from accidental changes while filming. */
+  gradingLocked: boolean;
+  toggleCinemaMode: () => void;
+  enterCinemaMode: () => void;
+  exitCinemaMode: () => void;
+  setLetterbox: (enabled: boolean) => void;
+  setGradingLocked: (locked: boolean) => void;
+}
+
+/**
+ * Immersive cinema mode — hides chrome, optional letterbox, Esc to exit.
+ * Does not touch rear-view Static feed (billing gate unchanged).
+ */
+export function useCinemaMode(enabled: boolean): CinemaModeState {
+  const [isCinemaMode, setIsCinemaMode] = useState(false);
+  const [letterbox, setLetterbox] = useState(true);
+  const [gradingLocked, setGradingLocked] = useState(false);
+
+  const enterCinemaMode = useCallback(() => setIsCinemaMode(true), []);
+  const exitCinemaMode = useCallback(() => setIsCinemaMode(false), []);
+  const toggleCinemaMode = useCallback(() => setIsCinemaMode((v) => !v), []);
+
+  // Esc exits cinema mode (global listener only while active).
+  useEffect(() => {
+    if (!enabled || !isCinemaMode) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        exitCinemaMode();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => window.removeEventListener('keydown', onKeyDown, true);
+  }, [enabled, isCinemaMode, exitCinemaMode]);
+
+  // Body class for global CSS hooks (letterbox, hide scrollbars).
+  useEffect(() => {
+    if (!enabled) return;
+    document.body.classList.toggle('cinema-mode', isCinemaMode);
+    return () => document.body.classList.remove('cinema-mode');
+  }, [enabled, isCinemaMode]);
+
+  return {
+    isCinemaMode,
+    letterbox,
+    gradingLocked,
+    toggleCinemaMode,
+    enterCinemaMode,
+    exitCinemaMode,
+    setLetterbox,
+    setGradingLocked,
+  };
+}

--- a/src/hooks/useSharedSession.ts
+++ b/src/hooks/useSharedSession.ts
@@ -15,6 +15,7 @@ import {
   toSharedSessionParticipants,
   type SharedSessionParticipant,
 } from './sharedSessionRoster';
+import { resolveIceServers } from '../utils/iceServers';
 
 /**
  * Shared Exploration Sessions — multiplayer Street View road trips.
@@ -30,10 +31,8 @@ import {
  * room "expires" the moment everyone leaves it — there is nothing left to
  * clean up.
  *
- * TURN is intentionally not configured (STUN-only) — most NATs traverse
- * fine, but symmetric NATs / restrictive firewalls on both ends can fail to
- * connect. See README "Shared Exploration Sessions" for how to add a TURN
- * server later (just extend ICE_SERVERS below; no other changes needed).
+ * TURN is optional — configure via REACT_APP_TURN_* or runtime window.TURN_*
+ * in public/config.js. See docs/SHARED_SESSIONS.md.
  *
  * See docs/feature_expansion_plan.md §14.3.
  */
@@ -63,8 +62,8 @@ export type SharedSessionStatus =
 export type { SharedSessionParticipant };
 
 const DATA_CHANNEL_LABEL = 'streetview-sync';
-/** STUN-only for now — see the module doc comment above and README for TURN. */
-const ICE_SERVERS: RTCIceServer[] = [{ urls: 'stun:stun.l.google.com:19302' }];
+/** STUN + optional TURN — see docs/SHARED_SESSIONS.md. */
+const ICE_SERVERS: RTCIceServer[] = resolveIceServers();
 const RECONNECT_DELAY_MS = 2000;
 const MAX_RECONNECT_ATTEMPTS = 5;
 

--- a/src/hooks/useSnapshots.ts
+++ b/src/hooks/useSnapshots.ts
@@ -25,8 +25,7 @@ export interface SnapshotMetadata {
 
 export type SnapshotShareResult = 'share' | 'clipboard' | 'cancelled';
 
-/** Attribution text required alongside any shared Google Maps-derived imagery. */
-const MAPS_ATTRIBUTION = 'Imagery © Google';
+import { MAPS_ATTRIBUTION } from '../utils/attribution';
 
 const MAX_SNAPSHOTS = 20; // Limit stored snapshots to avoid storage quota issues
 

--- a/src/hooks/useTours.ts
+++ b/src/hooks/useTours.ts
@@ -1,5 +1,12 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { loadMirroredJson, saveMirroredJson } from '../offline/offlinePersistence';
+import {
+    buildDirectorKeyframe,
+    isValidDirectorKeyframe,
+    shouldRecordDirectorKeyframe,
+    type DirectorSnapshot,
+    type TourDirectorKeyframe,
+} from '../utils/tourDirector';
 
 export interface TourWaypoint {
     id: string;
@@ -18,6 +25,8 @@ export interface Tour {
     name: string;
     description?: string;
     waypoints: TourWaypoint[];
+    /** Weather / vehicle keyframes recorded alongside waypoints (director track). */
+    directorTrack?: TourDirectorKeyframe[];
     transitionType: TourTransitionType;
     autoPlaySpeed: number;
     createdAt: string;
@@ -32,6 +41,9 @@ export interface CurrentPOV {
 
 const DEFAULT_DWELL_MS = 4000;
 const MIN_WAYPOINT_INTERVAL_MS = 3000;
+const DIRECTOR_MIN_INTERVAL_MS = 2000;
+
+export type { TourDirectorKeyframe, DirectorSnapshot };
 
 function makeId(): string {
     return `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
@@ -57,7 +69,9 @@ function isValidTour(value: unknown): value is Tour {
             );
         }) &&
         (t.transitionType === 'hold-pause' || t.transitionType === 'fade') &&
-        typeof t.autoPlaySpeed === 'number'
+        typeof t.autoPlaySpeed === 'number' &&
+        (t.directorTrack === undefined ||
+            (Array.isArray(t.directorTrack) && t.directorTrack.every(isValidDirectorKeyframe)))
     );
 }
 
@@ -70,8 +84,12 @@ export function useTours() {
     const [isPaused, setIsPaused] = useState(false);
     const [draftName, setDraftName] = useState('');
     const [draftWaypoints, setDraftWaypoints] = useState<TourWaypoint[]>([]);
+    const [draftDirectorTrack, setDraftDirectorTrack] = useState<TourDirectorKeyframe[]>([]);
     const recordingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const directorIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const recordingStartedAtRef = useRef<number>(0);
     const getCurrentPOVRef = useRef<(() => CurrentPOV | null) | null>(null);
+    const getDirectorSnapshotRef = useRef<(() => DirectorSnapshot | null) | null>(null);
 
     useEffect(() => {
         let cancelled = false;
@@ -117,10 +135,31 @@ export function useTours() {
         });
     }, []);
 
-    const startRecording = useCallback((name: string, getCurrentPOV: () => CurrentPOV | null, intervalMs: number = 0) => {
+    const sampleDirectorKeyframe = useCallback(() => {
+        const snap = getDirectorSnapshotRef.current?.();
+        if (!snap) return;
+        const elapsedMs = performance.now() - recordingStartedAtRef.current;
+        setDraftDirectorTrack((prev) => {
+            const last = prev[prev.length - 1] ?? null;
+            if (!shouldRecordDirectorKeyframe(last, snap, elapsedMs, DIRECTOR_MIN_INTERVAL_MS)) {
+                return prev;
+            }
+            return [...prev, buildDirectorKeyframe(elapsedMs, snap)];
+        });
+    }, []);
+
+    const startRecording = useCallback((
+        name: string,
+        getCurrentPOV: () => CurrentPOV | null,
+        intervalMs: number = 0,
+        getDirectorSnapshot?: () => DirectorSnapshot | null,
+    ) => {
         setDraftName(name);
         setDraftWaypoints([]);
+        setDraftDirectorTrack([]);
         getCurrentPOVRef.current = getCurrentPOV;
+        getDirectorSnapshotRef.current = getDirectorSnapshot ?? null;
+        recordingStartedAtRef.current = performance.now();
         setIsRecording(true);
         setIsPaused(false);
 
@@ -128,14 +167,22 @@ export function useTours() {
             clearInterval(recordingIntervalRef.current);
             recordingIntervalRef.current = null;
         }
+        if (directorIntervalRef.current) {
+            clearInterval(directorIntervalRef.current);
+            directorIntervalRef.current = null;
+        }
         if (intervalMs >= MIN_WAYPOINT_INTERVAL_MS) {
             recordingIntervalRef.current = setInterval(() => {
                 addWaypointFromCurrent(DEFAULT_DWELL_MS);
             }, intervalMs);
         }
+        if (getDirectorSnapshot) {
+            directorIntervalRef.current = setInterval(sampleDirectorKeyframe, DIRECTOR_MIN_INTERVAL_MS);
+        }
         // Capture the starting position immediately.
         addWaypointFromCurrent(DEFAULT_DWELL_MS);
-    }, [addWaypointFromCurrent]);
+        sampleDirectorKeyframe();
+    }, [addWaypointFromCurrent, sampleDirectorKeyframe]);
 
     const pauseRecording = useCallback(() => {
         setIsPaused(true);
@@ -143,21 +190,34 @@ export function useTours() {
             clearInterval(recordingIntervalRef.current);
             recordingIntervalRef.current = null;
         }
+        if (directorIntervalRef.current) {
+            clearInterval(directorIntervalRef.current);
+            directorIntervalRef.current = null;
+        }
     }, []);
 
     const resumeRecording = useCallback(() => {
         setIsPaused(false);
-    }, []);
+        if (getDirectorSnapshotRef.current && !directorIntervalRef.current) {
+            directorIntervalRef.current = setInterval(sampleDirectorKeyframe, DIRECTOR_MIN_INTERVAL_MS);
+        }
+    }, [sampleDirectorKeyframe]);
 
     const cancelRecording = useCallback(() => {
         if (recordingIntervalRef.current) {
             clearInterval(recordingIntervalRef.current);
             recordingIntervalRef.current = null;
         }
+        if (directorIntervalRef.current) {
+            clearInterval(directorIntervalRef.current);
+            directorIntervalRef.current = null;
+        }
         getCurrentPOVRef.current = null;
+        getDirectorSnapshotRef.current = null;
         setIsRecording(false);
         setIsPaused(false);
         setDraftWaypoints([]);
+        setDraftDirectorTrack([]);
         setDraftName('');
     }, []);
 
@@ -166,12 +226,19 @@ export function useTours() {
             clearInterval(recordingIntervalRef.current);
             recordingIntervalRef.current = null;
         }
+        if (directorIntervalRef.current) {
+            clearInterval(directorIntervalRef.current);
+            directorIntervalRef.current = null;
+        }
+        sampleDirectorKeyframe();
         getCurrentPOVRef.current = null;
+        getDirectorSnapshotRef.current = null;
         setIsRecording(false);
         setIsPaused(false);
 
         if (draftWaypoints.length === 0) {
             setDraftWaypoints([]);
+            setDraftDirectorTrack([]);
             setDraftName('');
             return null;
         }
@@ -181,6 +248,7 @@ export function useTours() {
             id: makeId(),
             name: (finalName ?? draftName).trim() || `Tour ${new Date().toLocaleDateString()}`,
             waypoints: draftWaypoints,
+            ...(draftDirectorTrack.length > 0 ? { directorTrack: draftDirectorTrack } : {}),
             transitionType: 'hold-pause',
             autoPlaySpeed: 1,
             createdAt: now,
@@ -188,9 +256,10 @@ export function useTours() {
         };
         setTours(prev => [newTour, ...prev]);
         setDraftWaypoints([]);
+        setDraftDirectorTrack([]);
         setDraftName('');
         return newTour.id;
-    }, [draftName, draftWaypoints]);
+    }, [draftName, draftWaypoints, draftDirectorTrack, sampleDirectorKeyframe]);
 
     const deleteTour = useCallback((id: string) => {
         setTours(prev => prev.filter(t => t.id !== id));
@@ -302,6 +371,7 @@ export function useTours() {
         isPaused,
         draftName,
         draftWaypoints,
+        draftDirectorTrack,
         startRecording,
         pauseRecording,
         resumeRecording,

--- a/src/utils/attribution.ts
+++ b/src/utils/attribution.ts
@@ -1,0 +1,2 @@
+/** Attribution text required alongside any shared Google Maps-derived imagery. */
+export const MAPS_ATTRIBUTION = 'Imagery © Google';

--- a/src/utils/canvasRecorder.ts
+++ b/src/utils/canvasRecorder.ts
@@ -1,0 +1,184 @@
+import { MAPS_ATTRIBUTION } from './attribution';
+
+export type ClipRecorderState = 'idle' | 'recording' | 'stopped' | 'unsupported';
+
+export interface ClipRecorderOptions {
+  /** Frames per second for captureStream. Default 30. */
+  fps?: number;
+  /** Burn attribution footer into the recorded frame. Default true. */
+  burnAttribution?: boolean;
+  /** Minimum clip length in ms (informational; enforced by caller). */
+  minDurationMs?: number;
+}
+
+export interface ClipRecorderResult {
+  blob: Blob;
+  mimeType: string;
+  durationMs: number;
+}
+
+const PREFERRED_MIME_TYPES = [
+  'video/webm;codecs=vp9',
+  'video/webm;codecs=vp8',
+  'video/webm',
+];
+
+function pickMimeType(): string | undefined {
+  if (typeof MediaRecorder === 'undefined') return undefined;
+  for (const mime of PREFERRED_MIME_TYPES) {
+    if (MediaRecorder.isTypeSupported(mime)) return mime;
+  }
+  return undefined;
+}
+
+function createCompositeCanvas(
+  source: HTMLCanvasElement,
+): { canvas: HTMLCanvasElement; ctx: CanvasRenderingContext2D } {
+  const canvas = document.createElement('canvas');
+  canvas.width = source.width;
+  canvas.height = source.height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('2D context unavailable for clip composite');
+  return { canvas, ctx };
+}
+
+/**
+ * Blit source canvas to composite, optionally drawing attribution footer.
+ * Call every frame while recording when burnAttribution is enabled.
+ */
+export function blitFrameWithAttribution(
+  source: HTMLCanvasElement,
+  composite: CanvasRenderingContext2D,
+  burnAttribution: boolean,
+): void {
+  const w = source.width;
+  const h = source.height;
+  composite.drawImage(source, 0, 0, w, h);
+  if (!burnAttribution) return;
+
+  const footerH = Math.max(18, Math.round(h * 0.028));
+  composite.fillStyle = 'rgba(0,0,0,0.55)';
+  composite.fillRect(0, h - footerH, w, footerH);
+  composite.fillStyle = 'rgba(255,255,255,0.85)';
+  composite.font = `${Math.max(10, Math.round(footerH * 0.55))}px system-ui, sans-serif`;
+  composite.textBaseline = 'middle';
+  composite.fillText(MAPS_ATTRIBUTION, 8, h - footerH / 2);
+}
+
+export function isClipRecordingSupported(): boolean {
+  return typeof MediaRecorder !== 'undefined' && pickMimeType() !== undefined;
+}
+
+/**
+ * Record a clip from a renderer canvas via captureStream + MediaRecorder.
+ * When burnAttribution is true, samples are composited through a 2D canvas each frame.
+ */
+export class CanvasClipRecorder {
+  private sourceCanvas: HTMLCanvasElement;
+  private options: Required<Pick<ClipRecorderOptions, 'fps' | 'burnAttribution'>>;
+  private mimeType: string;
+  private mediaRecorder: MediaRecorder | null = null;
+  private chunks: Blob[] = [];
+  private compositeCtx: CanvasRenderingContext2D | null = null;
+  private rafId: number | null = null;
+  private startedAt = 0;
+  private state: ClipRecorderState = 'idle';
+
+  constructor(sourceCanvas: HTMLCanvasElement, options: ClipRecorderOptions = {}) {
+    this.sourceCanvas = sourceCanvas;
+    this.options = {
+      fps: options.fps ?? 30,
+      burnAttribution: options.burnAttribution ?? true,
+    };
+    const mime = pickMimeType();
+    if (!mime) {
+      this.mimeType = '';
+      this.state = 'unsupported';
+      return;
+    }
+    this.mimeType = mime;
+  }
+
+  getState(): ClipRecorderState {
+    return this.state;
+  }
+
+  start(): void {
+    if (this.state === 'unsupported') {
+      throw new Error('MediaRecorder / WebM not supported in this browser');
+    }
+    if (this.state === 'recording') return;
+
+    this.chunks = [];
+    let stream: MediaStream;
+
+    if (this.options.burnAttribution) {
+      const { canvas, ctx } = createCompositeCanvas(this.sourceCanvas);
+      this.compositeCtx = ctx;
+      blitFrameWithAttribution(this.sourceCanvas, ctx, true);
+      stream = canvas.captureStream(this.options.fps);
+      const tick = () => {
+        if (this.state !== 'recording' || !this.compositeCtx) return;
+        blitFrameWithAttribution(this.sourceCanvas, this.compositeCtx, true);
+        this.rafId = requestAnimationFrame(tick);
+      };
+      this.rafId = requestAnimationFrame(tick);
+    } else {
+      stream = this.sourceCanvas.captureStream(this.options.fps);
+    }
+
+    this.mediaRecorder = new MediaRecorder(stream, { mimeType: this.mimeType });
+    this.mediaRecorder.ondataavailable = (e) => {
+      if (e.data.size > 0) this.chunks.push(e.data);
+    };
+    this.mediaRecorder.start(250);
+    this.startedAt = performance.now();
+    this.state = 'recording';
+  }
+
+  stop(): Promise<ClipRecorderResult> {
+    if (this.state !== 'recording' || !this.mediaRecorder) {
+      return Promise.reject(new Error('Not recording'));
+    }
+
+    const recorder = this.mediaRecorder;
+    const durationMs = performance.now() - this.startedAt;
+
+    return new Promise((resolve, reject) => {
+      recorder.onstop = () => {
+        if (this.rafId !== null) {
+          cancelAnimationFrame(this.rafId);
+          this.rafId = null;
+        }
+        this.state = 'stopped';
+        const blob = new Blob(this.chunks, { type: this.mimeType });
+        resolve({ blob, mimeType: this.mimeType, durationMs });
+      };
+      recorder.onerror = () => reject(new Error('MediaRecorder error'));
+      recorder.stop();
+    });
+  }
+
+  dispose(): void {
+    if (this.rafId !== null) {
+      cancelAnimationFrame(this.rafId);
+      this.rafId = null;
+    }
+    this.mediaRecorder = null;
+    this.compositeCtx = null;
+    this.state = 'idle';
+  }
+}
+
+/** Trigger a download of a recorded clip blob. */
+export function downloadClip(blob: Blob, mimeType: string, baseName = 'streetview-clip'): void {
+  const ext = mimeType.includes('webm') ? 'webm' : 'mp4';
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `${baseName.replace(/[^a-z0-9-_ ]/gi, '_') || 'clip'}.${ext}`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}

--- a/src/utils/iceServers.ts
+++ b/src/utils/iceServers.ts
@@ -1,0 +1,62 @@
+/**
+ * ICE server resolution for WebRTC shared sessions.
+ *
+ * STUN is always included. TURN is optional — supply via build-time env
+ * (REACT_APP_TURN_URL / REACT_APP_TURN_USERNAME / REACT_APP_TURN_CREDENTIAL)
+ * or runtime window.TURN_* in public/config.js. Never commit credentials.
+ */
+
+const DEFAULT_STUN: RTCIceServer = { urls: 'stun:stun.l.google.com:19302' };
+
+declare global {
+  interface Window {
+    TURN_URL?: string;
+    TURN_USERNAME?: string;
+    TURN_CREDENTIAL?: string;
+  }
+}
+
+function readEnv(key: string): string {
+  const vite = (import.meta as ImportMeta & { env?: Record<string, string> }).env?.[key];
+  if (vite?.trim()) return vite.trim();
+  const react = (process.env as Record<string, string | undefined>)[key];
+  return react?.trim() || '';
+}
+
+function buildTurnServer(): RTCIceServer | null {
+  const urls =
+    readEnv('VITE_TURN_URL') ||
+    readEnv('REACT_APP_TURN_URL') ||
+    (typeof window !== 'undefined' ? window.TURN_URL?.trim() : '') ||
+    '';
+  if (!urls) return null;
+
+  const username =
+    readEnv('VITE_TURN_USERNAME') ||
+    readEnv('REACT_APP_TURN_USERNAME') ||
+    (typeof window !== 'undefined' ? window.TURN_USERNAME?.trim() : '') ||
+    undefined;
+  const credential =
+    readEnv('VITE_TURN_CREDENTIAL') ||
+    readEnv('REACT_APP_TURN_CREDENTIAL') ||
+    (typeof window !== 'undefined' ? window.TURN_CREDENTIAL?.trim() : '') ||
+    undefined;
+
+  const server: RTCIceServer = { urls };
+  if (username) server.username = username;
+  if (credential) server.credential = credential;
+  return server;
+}
+
+/** Resolved ICE servers: STUN + optional TURN when configured. */
+export function resolveIceServers(): RTCIceServer[] {
+  const servers: RTCIceServer[] = [DEFAULT_STUN];
+  const turn = buildTurnServer();
+  if (turn) servers.push(turn);
+  return servers;
+}
+
+/** True when a TURN URL is configured (credentials may still be empty for open relays). */
+export function hasTurnConfigured(): boolean {
+  return buildTurnServer() !== null;
+}

--- a/src/utils/studioUtils.test.ts
+++ b/src/utils/studioUtils.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { serializeWeatherPreset, parseWeatherPreset } from './weatherPresetSync';
+
+describe('weatherPresetSync', () => {
+  it('round-trips time-of-day and weather intensities', () => {
+    const raw = serializeWeatherPreset({
+      timeOfDay: 'night',
+      rainIntensity: 0.6,
+      snowIntensity: 0.2,
+      fogDensity: 0.1,
+    });
+    expect(parseWeatherPreset(raw)).toEqual({
+      timeOfDay: 'night',
+      rainIntensity: 0.6,
+      snowIntensity: 0.2,
+      fogDensity: 0.1,
+    });
+  });
+
+  it('returns null for empty preset', () => {
+    expect(parseWeatherPreset('')).toBeNull();
+    expect(parseWeatherPreset(undefined)).toBeNull();
+  });
+});
+
+describe('iceServers', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+    delete (window as Window & { TURN_URL?: string }).TURN_URL;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('always includes STUN', async () => {
+    const { resolveIceServers } = await import('./iceServers');
+    const servers = resolveIceServers();
+    expect(servers.some((s) => String(s.urls).includes('stun:'))).toBe(true);
+  });
+
+  it('adds TURN when REACT_APP_TURN_URL is set', async () => {
+    process.env.REACT_APP_TURN_URL = 'turn:example.com:3478';
+    process.env.REACT_APP_TURN_USERNAME = 'u';
+    process.env.REACT_APP_TURN_CREDENTIAL = 'p';
+    const { resolveIceServers, hasTurnConfigured } = await import('./iceServers');
+    const servers = resolveIceServers();
+    expect(hasTurnConfigured()).toBe(true);
+    expect(servers).toHaveLength(2);
+    expect(servers[1]?.urls).toBe('turn:example.com:3478');
+    expect(servers[1]?.username).toBe('u');
+  });
+});
+
+describe('canvasRecorder', () => {
+  it('reports unsupported when MediaRecorder missing', async () => {
+    const { isClipRecordingSupported } = await import('./canvasRecorder');
+    const original = globalThis.MediaRecorder;
+    // @ts-expect-error test shim
+    delete globalThis.MediaRecorder;
+    expect(isClipRecordingSupported()).toBe(false);
+    globalThis.MediaRecorder = original;
+  });
+});

--- a/src/utils/tourDirector.test.ts
+++ b/src/utils/tourDirector.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildDirectorKeyframe,
+  resolveDirectorAt,
+  shouldRecordDirectorKeyframe,
+  type DirectorSnapshot,
+} from './tourDirector';
+
+const baseSnap: DirectorSnapshot = {
+  timeOfDay: 'day',
+  vehicle: 'sedan',
+  rainIntensity: 0,
+  snowIntensity: 0,
+  fogDensity: 0,
+};
+
+describe('tourDirector', () => {
+  it('resolveDirectorAt returns last keyframe at or before elapsedMs', () => {
+    const track = [
+      buildDirectorKeyframe(0, { ...baseSnap, timeOfDay: 'day' }),
+      buildDirectorKeyframe(5000, { ...baseSnap, timeOfDay: 'sunset' }),
+      buildDirectorKeyframe(10000, { ...baseSnap, timeOfDay: 'night' }),
+    ];
+    expect(resolveDirectorAt(track, 0)?.timeOfDay).toBe('day');
+    expect(resolveDirectorAt(track, 4999)?.timeOfDay).toBe('day');
+    expect(resolveDirectorAt(track, 5000)?.timeOfDay).toBe('sunset');
+    expect(resolveDirectorAt(track, 99999)?.timeOfDay).toBe('night');
+  });
+
+  it('shouldRecordDirectorKeyframe respects min interval unless tod/vehicle changes', () => {
+    const last = buildDirectorKeyframe(0, baseSnap);
+    const changed = { ...baseSnap, timeOfDay: 'night' as const };
+    expect(shouldRecordDirectorKeyframe(last, changed, 500, 2000)).toBe(true);
+    expect(shouldRecordDirectorKeyframe(last, baseSnap, 500, 2000)).toBe(false);
+    expect(shouldRecordDirectorKeyframe(last, baseSnap, 2500, 2000)).toBe(true);
+  });
+});

--- a/src/utils/tourDirector.ts
+++ b/src/utils/tourDirector.ts
@@ -1,0 +1,81 @@
+import type { TimeOfDay } from '../hooks/useEnvironmentSettings';
+import type { VehicleType } from '../car/VehicleManager';
+
+/** Weather / vehicle keyframe on the director track (ms from recording start). */
+export interface TourDirectorKeyframe {
+  elapsedMs: number;
+  timeOfDay?: TimeOfDay;
+  vehicle?: VehicleType;
+  /** Color-grading preset name (see applyColorGradingPreset). */
+  colorGradingPreset?: string;
+  rainIntensity?: number;
+  snowIntensity?: number;
+  fogDensity?: number;
+}
+
+export interface DirectorSnapshot {
+  timeOfDay: TimeOfDay;
+  vehicle: VehicleType;
+  colorGradingPreset?: string;
+  rainIntensity: number;
+  snowIntensity: number;
+  fogDensity: number;
+}
+
+const TIME_OF_DAYS: TimeOfDay[] = ['day', 'sunrise', 'sunset', 'night'];
+
+export function isValidDirectorKeyframe(value: unknown): value is TourDirectorKeyframe {
+  if (!value || typeof value !== 'object') return false;
+  const k = value as Record<string, unknown>;
+  if (typeof k.elapsedMs !== 'number' || !Number.isFinite(k.elapsedMs)) return false;
+  if (k.timeOfDay !== undefined && !TIME_OF_DAYS.includes(k.timeOfDay as TimeOfDay)) return false;
+  return true;
+}
+
+/** Pick the active keyframe at `elapsedMs` (last keyframe at or before the time). */
+export function resolveDirectorAt(
+  track: TourDirectorKeyframe[] | undefined,
+  elapsedMs: number,
+): TourDirectorKeyframe | null {
+  if (!track?.length) return null;
+  let active: TourDirectorKeyframe | null = null;
+  for (const frame of track) {
+    if (frame.elapsedMs <= elapsedMs) active = frame;
+    else break;
+  }
+  return active;
+}
+
+/** Returns true when the snapshot differs materially from the last keyframe. */
+export function shouldRecordDirectorKeyframe(
+  last: TourDirectorKeyframe | null,
+  snap: DirectorSnapshot,
+  elapsedMs: number,
+  minIntervalMs: number,
+): boolean {
+  if (!last) return true;
+  if (elapsedMs - last.elapsedMs < minIntervalMs) {
+    return (
+      last.timeOfDay !== snap.timeOfDay ||
+      last.vehicle !== snap.vehicle ||
+      last.colorGradingPreset !== snap.colorGradingPreset
+    );
+  }
+  // Interval elapsed — always sample so playback has timeline coverage.
+  return true;
+}
+
+export function buildDirectorKeyframe(
+  elapsedMs: number,
+  snap: DirectorSnapshot,
+): TourDirectorKeyframe {
+  return {
+    elapsedMs,
+    timeOfDay: snap.timeOfDay,
+    vehicle: snap.vehicle,
+    colorGradingPreset: snap.colorGradingPreset,
+    rainIntensity: snap.rainIntensity,
+    snowIntensity: snap.snowIntensity,
+    fogDensity: snap.fogDensity,
+  };
+}

--- a/src/utils/weatherPresetSync.ts
+++ b/src/utils/weatherPresetSync.ts
@@ -1,0 +1,54 @@
+import type { TimeOfDay } from '../hooks/useEnvironmentSettings';
+
+/**
+ * Compact weather preset string for shared-session broadcast.
+ * Format: `tod:<day|sunrise|sunset|night>|rain:<0-1>|snow:<0-1>|fog:<0-1>`
+ * (segments optional after time-of-day).
+ */
+export function serializeWeatherPreset(opts: {
+  timeOfDay: TimeOfDay;
+  rainIntensity?: number;
+  snowIntensity?: number;
+  fogDensity?: number;
+}): string {
+  const parts = [`tod:${opts.timeOfDay}`];
+  if (opts.rainIntensity !== undefined) parts.push(`rain:${opts.rainIntensity.toFixed(2)}`);
+  if (opts.snowIntensity !== undefined) parts.push(`snow:${opts.snowIntensity.toFixed(2)}`);
+  if (opts.fogDensity !== undefined) parts.push(`fog:${opts.fogDensity.toFixed(2)}`);
+  return parts.join('|');
+}
+
+export interface ParsedWeatherPreset {
+  timeOfDay?: TimeOfDay;
+  rainIntensity?: number;
+  snowIntensity?: number;
+  fogDensity?: number;
+}
+
+const VALID_TOD: TimeOfDay[] = ['day', 'sunrise', 'sunset', 'night'];
+
+export function parseWeatherPreset(raw: string | undefined): ParsedWeatherPreset | null {
+  if (!raw?.trim()) return null;
+  const result: ParsedWeatherPreset = {};
+  for (const segment of raw.split('|')) {
+    const [key, val] = segment.split(':');
+    if (!key || val === undefined) continue;
+    switch (key) {
+      case 'tod':
+        if (VALID_TOD.includes(val as TimeOfDay)) result.timeOfDay = val as TimeOfDay;
+        break;
+      case 'rain':
+        result.rainIntensity = parseFloat(val);
+        break;
+      case 'snow':
+        result.snowIntensity = parseFloat(val);
+        break;
+      case 'fog':
+        result.fogDensity = parseFloat(val);
+        break;
+      default:
+        break;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : null;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Road-trip studio capstone (P2 XL) — content creation and collaboration foundations:

### 1. Photo / Cinema mode
- **Cinema mode** (`Shift+F`): hides all chrome, optional letterbox bars, Esc to exit
- **WebM clip capture** via `MediaRecorder` + `canvas.captureStream()` with Google attribution footer burned in
- Still capture from cinema toolbar; existing snapshot/EXIF gallery unchanged

### 2. Session recording (tour director track)
- Tours gain optional `directorTrack[]` keyframes (time-of-day, vehicle, rain/snow/fog)
- Recorded automatically during tour recording; applied during `TourPlayer` playback
- Included in JSON export (no schema break — field is optional)

### 3. Multiplayer production
- **Weather preset sync** completed: host broadcasts `weatherPreset` at 10 Hz; guests apply time-of-day + weather sliders
- **TURN config** plugs in via `REACT_APP_TURN_*` or runtime `window.TURN_*` in `public/config.js` — no code fork
- New `docs/SHARED_SESSIONS.md` documents STUN vs TURN, reconnect policy, billing gates

### 4. Playback presentation
- `TourPlayer` resolves director keyframes during dwell intervals
- Cinema overlay is separate from tour fullscreen (tour panel play tab unchanged)

## Acceptance criteria

| Criterion | Status |
|-----------|--------|
| ≥15s WebM clip with weather visible | ✅ `CanvasClipRecorder` enforces 15s minimum before stop |
| Cinema mode hides UI, Esc restores | ✅ `useCinemaMode` + `CinemaOverlay` |
| Tour export includes director track | ✅ `directorTrack` in `Tour` JSON |
| Shared session STUN/TURN docs | ✅ `docs/SHARED_SESSIONS.md` |
| No Google tile caching | ✅ exports are canvas captures only |
| Recording does not enable rear Static feed | ✅ no changes to `rearViewFeed` |
| E2E smoke: cinema + tour panel | ✅ `e2e/cinema-studio.spec.ts` |

## New files

- `src/utils/canvasRecorder.ts` — native MediaRecorder wrapper
- `src/utils/tourDirector.ts` — director keyframe helpers
- `src/utils/iceServers.ts` — STUN + optional TURN resolution
- `src/utils/weatherPresetSync.ts` — compact preset serialize/parse
- `src/hooks/useCinemaMode.ts`, `src/components/CinemaOverlay.tsx`

## Testing

- `npm run typecheck` ✅
- `npm run lint` ✅
- Unit: `tourDirector.test.ts`, `studioUtils.test.ts`, `sharedSessionSync.test.ts` ✅
- `App.test.tsx` — 6 pre-existing jsdom timing failures (unchanged)
- E2E smoke — `cinema-studio.spec.ts` added (webServer timeout in cloud VM; run locally with `npm run test:e2e:smoke`)

## Out of scope (per issue)

- Server-side video hosting
- Social network / accounts beyond existing storageApi
- Watch-party tour playback (future workstream 4)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-096c90ee-2106-4476-a5fe-3fa66c5131ba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-096c90ee-2106-4476-a5fe-3fa66c5131ba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

