### PR TITLE
Named look packs, shareable look URLs, and WebGL atmosphere parity

### DIFF
--- a/docs/GRAPHICS.md
+++ b/docs/GRAPHICS.md
@@ -244,13 +244,77 @@ The WebGL2 fallback does not implement either — it ignores slots 38/39.
 
 ---
 
-## 7. Editing checklist
+## 8. Artistic looks (scene packs)
+
+Named looks live in `src/config/lookPacks.ts` and apply **weather + grading +
+time-of-day + vehicle lights** in one click. They are piecewise curves over the
+existing 6 grading uniforms (vibrance → saturation → contrast → temperature/tint
+→ exposure) with **ACES still last**. No 3D LUT texture, no extra uniform slots,
+no billable APIs.
+
+The look bible (before/after notes, curve stops, palette cards) is
+[`docs/looks/README.md`](./looks/README.md).
+
+| Id | Intent |
+|----|--------|
+| `clear` | Reset — daylight, no weather, neutral grade |
+| `noir` | Ink-black night, wet streets, headlights |
+| `teal-orange` | Travel-poster split tone at sunset |
+| `bleach-bypass` | Silver-retention newsreel, overcast sun kill |
+| `golden-hour` | Honey sunrise, soft haze |
+| `storm` | GRAPHICS.md §3 storm sliders + cool underexpose |
+| `arctic` | High-key snow, cold air |
+| `neon-rain` | Wet night, magenta/cyan, high beam |
+
+Share with location deep links:
+
+```text
+?look=noir
+?look=noir&rain=40
+?tod=night&sat=0.4&con=1.55
+```
+
+`src/utils/lookLink.ts` round-trips `look` + overrides. Reduced motion still
+applies the grade/weather; it only zeroes cinematic slots 38/39.
+
+Creator UX: **Looks** toolbar button (shortcut `K`) or the Looks strip inside
+the Weather panel. **Copy look as URL** writes the current pack + diffs.
+
+---
+
+## 9. WebGL parity budget
+
+The WebGL2 fallback is SDR and skips DOF, motion blur, fBm dust, and the 4-tap
+haze blur. Isolation flags (`?effect=weather|night|fog`) exist so look targets
+can be compared directionally.
+
+| Effect | Must match | Best effort | Skip |
+|--------|------------|-------------|------|
+| Night floor (`NIGHT_BASE_FLOOR`) | ✓ | | |
+| Precip fall Y sign (`WEATHER_FALL_Y_SIGN = −1`) | ✓ | | |
+| Overcast sun kill (CPU `weatherCohesion`) | ✓ | | |
+| Rain darken `mix(0.22, 0.10, night)` | ✓ | | |
+| Humidity haze distance + color mix | ✓ | | |
+| Humidity haze 4-tap blur | | | ✓ (WebGPU) |
+| fBm / WASM dust | | | ✓ (WebGPU) |
+| DOF / motion blur (slots 38/39) | | | ✓ (WebGPU High/Ultra) |
+| GPU particles (`?weather=compute`) | | | ✓ (compute only) |
+| Fog coverage along view-depth proxy | | ✓ SDR approx | |
+| Color grade + ACES-style tonemap | | ✓ Reinhard SDR | |
+
+Guarded by `src/renderer/webglLookParity.test.ts` and
+`src/renderer/weatherCohesion.test.ts`.
+
+---
+
+## 10. Editing checklist
 
 - Shared WGSL helper changed? Update **both** `weather-post.wgsl` and
   `weather-post-compute.wgsl`; `weatherShaderParity.test.ts` will fail otherwise.
 - New uniform? It must fit the existing 40 floats or every consumer in
   `weatherUniformLayout.ts`'s header comment changes in lockstep.
 - Preset retune? Put the intended look in §3 above and the measured delta in §4.
+  Named artistic looks go in `src/config/lookPacks.ts` + `docs/looks/README.md`.
 - Coupling between channels belongs in `weatherCohesion.ts` (CPU, testable),
   not duplicated into three shaders.
 - Changing what the CPU noise tile contains? The fragment path is the default

--- a/docs/RENDERER_FALLBACK.md
+++ b/docs/RENDERER_FALLBACK.md
@@ -168,14 +168,20 @@ Known differences:
 
 ### Backend parity checklist (debug matrix)
 
-| Effect | WebGPU fragment | WebGPU compute | WebGL fallback |
-| --- | --- | --- | --- |
-| Rain direction | Downward | Downward | Downward |
-| Snow direction | Downward | Downward | Downward |
-| Night readability | Road/UI readable with headlights | Same target as fragment | Approximate, same readability target |
-| Fog/headlights controls | Full | Full | Approximate |
+| Effect | Budget | WebGPU fragment | WebGPU compute | WebGL fallback |
+| --- | --- | --- | --- | --- |
+| Rain direction | **must match** | Downward | Downward | Downward |
+| Snow direction | **must match** | Downward | Downward | Downward |
+| Night readability | **must match** | Road/UI readable with headlights | Same target as fragment | Approximate, same readability target |
+| Overcast sun kill | **must match** | CPU `weatherCohesion` | Same CPU pack | Same CPU pack (shaft/flare uniforms) |
+| Rain darken `mix(0.22, 0.10)` | **must match** | Yes | Yes | Yes (was 0.045/0.020) |
+| Humidity haze mix | **must match** | Distance + color + 4-tap blur | Same mix, `textureSampleLevel` blur | Distance + color mix, no blur |
+| Fog/headlights controls | best effort | Full | Full | Approximate |
+| fBm / WASM dust | skip | Fragment Perlin tile | fBm tile | None |
+| DOF / motion blur | skip | High / Ultra, reduced-motion gated | Same | Ignores slots 38/39 |
+| GPU particles | skip | No | High/Ultra compute | No |
 
-`src/renderer/weatherShaderParity.test.ts` is a CI guard for WGSL drift: it compares `applyNight` and normalized `snow(...)` math between `weather-post.wgsl` and `weather-post-compute.wgsl` and fails if they diverge.
+`src/renderer/weatherShaderParity.test.ts` is a CI guard for WGSL drift: it compares `applyNight` and normalized `snow(...)` math between `weather-post.wgsl` and `weather-post-compute.wgsl` and fails if they diverge. `src/renderer/webglLookParity.test.ts` locks the must-match GLSL literals (rain darken, haze color, fall Y).
 
 ## WebGL to WebGPU Porting Notes
 

--- a/docs/looks/README.md
+++ b/docs/looks/README.md
@@ -1,0 +1,142 @@
+# Look bible
+
+Named artistic looks for the Street View weather/grading stack. Each look is a
+**scene pack**: weather sliders + color grade + time of day + optional vehicle
+lights, applied in one click from the Looks panel or `?look=<id>`.
+
+Grading is the existing 6-knob chain (vibrance → saturation → contrast →
+temperature/tint → exposure). ACES filmic tonemap stays last. No 3D LUT
+textures, no extra weather uniforms (layout remains 40 floats), no billable
+APIs.
+
+Source of truth: `src/config/lookPacks.ts`. Palette cards below are committed
+fixtures for the piecewise curves. GPU reference frames (`<id>-webgpu.png`)
+should be captured on WebGPU Chrome against a known pano (see Capture).
+
+Related: `docs/GRAPHICS.md` §3 (weather presets) and §8 (looks), 
+`docs/RENDERER_FALLBACK.md` (must-match vs best-effort).
+
+---
+
+## Capture (WebGPU Chrome)
+
+This cloud/CI environment has no WebGPU adapter, so live panorama screenshots
+cannot be produced here. On a WebGPU-capable Chrome/Edge:
+
+1. Open a stable pano (deep-link lat/lng/heading) at default day, `?look=clear`.
+2. Snapshot the WebGPU canvas → `docs/looks/clear-webgpu.png` (the **before**).
+3. For each look: `?look=<id>` with the same pano/heading → `<id>-webgpu.png`.
+4. Optional A/B: `?renderer=webgl&effect=weather|night|fog&look=<id>` for
+   directional parity (night floor, precip fall, overcast sun kill).
+
+Until those PNGs land, the SVG palette cards are the committed reference.
+
+---
+
+## Looks
+
+### ☀️ Clear (`clear`) — reset / before
+
+- **Weather:** rain 0 / snow 0 / fog 0 / wind 0 · TOD day
+- **Grade:** all knobs neutral (1 / 1 / 1 / 0 / 0 / 0)
+- **Curve:** untouched shadows/mids; ACES only on highlights
+- **Before:** whatever look was on
+- **After:** stock Street View color, sun FX at the cohesion floor
+
+![clear palette](./clear.svg)
+
+### 🎬 Noir (`noir`)
+
+- **Weather:** rain 25 / fog 18 / wind 12 · TOD night · headlights · wipers
+- **Grade:** vib 0.45 · sat 0.35 · con 1.55 · exp −0.25 · temp −0.45 · tint +0.15
+- **Curve:** cool crushed shadows, thin desaturated mids, hard headlight specular then ACES
+- **Before:** daylight panorama, Google-saturated signs, flat exposure
+- **After:** silver pavement, crushed sky, sparse rain, headlight pools. Color almost gone except cool lamps. Night floor from #171 keeps the road readable.
+
+![noir palette](./noir.svg)
+
+### 🧡 Teal & Orange (`teal-orange`) — travel poster
+
+- **Weather:** fog 8 · TOD sunset
+- **Grade:** vib 1.35 · sat 1.25 · con 1.18 · exp +0.12 · temp +0.42 · tint −0.28
+- **Curve:** teal shadows, lifted mids, orange sun highlights into ACES
+- **Before:** generic afternoon, mixed white balance, no sky drama
+- **After:** sun side honey/orange; shade and asphalt pick up teal. Horizon glow agrees with camera heading.
+
+![teal-orange palette](./teal-orange.svg)
+
+### 📰 Bleach Bypass (`bleach-bypass`)
+
+- **Weather:** fog 22 (overcast sun kill) · TOD day
+- **Grade:** vib 0.55 · sat 0.50 · con 1.65 · exp +0.15 · temp −0.05
+- **Curve:** hard shadow floor, silver-retention mids, slight overexposure compressed by ACES (not clipped)
+- **Before:** colorful storefronts and sky, soft Google contrast
+- **After:** harsh metallic mids, retained highlight texture, almost no chroma. Sky goes newsreel grey.
+
+![bleach-bypass palette](./bleach-bypass.svg)
+
+### 🌅 Golden Hour (`golden-hour`)
+
+- **Weather:** fog 6 · TOD sunrise (camera-aware wash)
+- **Grade:** vib 1.25 · sat 1.15 · con 1.08 · exp +0.18 · temp +0.48 · tint −0.18
+- **Curve:** warm lifted shadows, honey mids, temp +0.48 rolling into ACES
+- **Before:** default day — white sun, no atmosphere
+- **After:** honey low sun on the tracked azimuth, soft far-field haze, lifted exposure
+
+![golden-hour palette](./golden-hour.svg)
+
+### ⛈️ Storm (`storm`)
+
+- **Weather:** rain 100 / wind 80 / fog 35 (GRAPHICS.md §3 storm) · nightIntensity 0.22 · wipers
+- **Grade:** vib 0.70 · sat 0.75 · con 1.25 · exp −0.35 · temp −0.28 · tint +0.18
+- **Curve:** cool underexpose, muted greens, no sun FX (overcast ≳ 0.85)
+- **Before:** clear noon, lens flare, dusty air
+- **After:** sun gone, wet haze, streaks slanted with wind, scene −~26% by day (rain darken eases to −10% at night)
+
+![storm palette](./storm.svg)
+
+### ❄️ Arctic (`arctic`)
+
+- **Weather:** snow 85 / wind −40 / fog 20 · TOD day
+- **Grade:** vib 1.05 · sat 0.82 · con 1.22 · exp +0.28 · temp −0.22 · tint +0.05
+- **Curve:** lifted cyan shadows, sat pulled so snow stays white, flake edges held by contrast then ACES
+- **Before:** temperate street, warm pavement, no particles
+- **After:** high-key snow, cool air, flakes falling **downward**, far field softened
+
+![arctic palette](./arctic.svg)
+
+### 🌃 Neon Rain (`neon-rain`)
+
+- **Weather:** rain 55 / wind 25 / fog 16 · TOD night · headlights + high beam · wipers
+- **Grade:** vib 1.15 · sat 1.05 · con 1.28 · exp −0.15 · temp −0.35 · tint +0.35
+- **Curve:** cyan-black shadows (night floor), magenta mids, headlight warmth vs neon, ACES last
+- **Before:** stock night — crushed or merely blue-tinted, dry pavement
+- **After:** wet asphalt, cyan haze in the distance, magenta bounce, headlight cones, rain streaks downward
+
+![neon-rain palette](./neon-rain.svg)
+
+---
+
+## URL params
+
+| Key | Meaning |
+|-----|---------|
+| `look` | Named pack id |
+| `rain` `snow` `fog` | 0–100 |
+| `wind` | −100..100 |
+| `tod` | `day` \| `sunrise` \| `sunset` \| `night` |
+| `vib` `sat` `con` `exp` `temp` `tint` | Grading knobs (UI space) |
+| `night` | 0–1 night intensity |
+| `hl` `beam` `dome` `wipers` | `1` / `0` |
+
+Location keys (`lat` `lng` `heading` `pitch` `zoom` `pano`) are independent and
+preserved by **Copy look as URL**.
+
+---
+
+## Reduced motion
+
+`prefers-reduced-motion` / the a11y toggle already zeroes cinematic DOF and
+motion blur (`cinematicCameraFx.ts`, uniforms 38/39). Looks do **not** depend
+on those slots — applying Noir with reduced motion still packs the grade,
+night, and rain.

--- a/docs/looks/arctic.svg
+++ b/docs/looks/arctic.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="96" viewBox="0 0 640 96" role="img" aria-label="Arctic look palette">
+  <title>Arctic — shadows / mids / highlights</title>
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#6a8898"/>
+      <stop offset="50%" stop-color="#c8dce8"/>
+      <stop offset="100%" stop-color="#f4f8fb"/>
+    </linearGradient>
+  </defs>
+  <rect width="640" height="96" fill="url(#g)"/>
+  <text x="16" y="28" font-family="ui-monospace, monospace" font-size="14" fill="#fff" stroke="#000" stroke-width="0.4">Arctic</text>
+  <text x="16" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#fff">shadows</text>
+  <text x="292" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#fff">mids</text>
+  <text x="560" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#111">highlights</text>
+</svg>

--- a/docs/looks/bleach-bypass.svg
+++ b/docs/looks/bleach-bypass.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="96" viewBox="0 0 640 96" role="img" aria-label="Bleach Bypass look palette">
+  <title>Bleach Bypass — shadows / mids / highlights</title>
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#2a2a2c"/>
+      <stop offset="50%" stop-color="#8a8a88"/>
+      <stop offset="100%" stop-color="#d8d4cc"/>
+    </linearGradient>
+  </defs>
+  <rect width="640" height="96" fill="url(#g)"/>
+  <text x="16" y="28" font-family="ui-monospace, monospace" font-size="14" fill="#fff" stroke="#000" stroke-width="0.4">Bleach Bypass</text>
+  <text x="16" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#fff">shadows</text>
+  <text x="292" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#fff">mids</text>
+  <text x="560" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#111">highlights</text>
+</svg>

--- a/docs/looks/clear.svg
+++ b/docs/looks/clear.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="96" viewBox="0 0 640 96" role="img" aria-label="Clear look palette">
+  <title>Clear — shadows / mids / highlights</title>
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#c8d4e0"/>
+      <stop offset="50%" stop-color="#8aa0b8"/>
+      <stop offset="100%" stop-color="#f2f4f6"/>
+    </linearGradient>
+  </defs>
+  <rect width="640" height="96" fill="url(#g)"/>
+  <text x="16" y="28" font-family="ui-monospace, monospace" font-size="14" fill="#fff" stroke="#000" stroke-width="0.4">Clear</text>
+  <text x="16" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#fff">shadows</text>
+  <text x="292" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#fff">mids</text>
+  <text x="560" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#111">highlights</text>
+</svg>

--- a/docs/looks/golden-hour.svg
+++ b/docs/looks/golden-hour.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="96" viewBox="0 0 640 96" role="img" aria-label="Golden Hour look palette">
+  <title>Golden Hour — shadows / mids / highlights</title>
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#4a2a12"/>
+      <stop offset="50%" stop-color="#c47a38"/>
+      <stop offset="100%" stop-color="#f0d090"/>
+    </linearGradient>
+  </defs>
+  <rect width="640" height="96" fill="url(#g)"/>
+  <text x="16" y="28" font-family="ui-monospace, monospace" font-size="14" fill="#fff" stroke="#000" stroke-width="0.4">Golden Hour</text>
+  <text x="16" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#fff">shadows</text>
+  <text x="292" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#fff">mids</text>
+  <text x="560" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#111">highlights</text>
+</svg>

--- a/docs/looks/neon-rain.svg
+++ b/docs/looks/neon-rain.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="96" viewBox="0 0 640 96" role="img" aria-label="Neon Rain look palette">
+  <title>Neon Rain — shadows / mids / highlights</title>
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#120818"/>
+      <stop offset="50%" stop-color="#3a1550"/>
+      <stop offset="100%" stop-color="#5ec8d8"/>
+    </linearGradient>
+  </defs>
+  <rect width="640" height="96" fill="url(#g)"/>
+  <text x="16" y="28" font-family="ui-monospace, monospace" font-size="14" fill="#fff" stroke="#000" stroke-width="0.4">Neon Rain</text>
+  <text x="16" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#fff">shadows</text>
+  <text x="292" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#fff">mids</text>
+  <text x="560" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#111">highlights</text>
+</svg>

--- a/docs/looks/noir.svg
+++ b/docs/looks/noir.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="96" viewBox="0 0 640 96" role="img" aria-label="Noir look palette">
+  <title>Noir — shadows / mids / highlights</title>
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#0a1018"/>
+      <stop offset="50%" stop-color="#3a4450"/>
+      <stop offset="100%" stop-color="#c8d0d8"/>
+    </linearGradient>
+  </defs>
+  <rect width="640" height="96" fill="url(#g)"/>
+  <text x="16" y="28" font-family="ui-monospace, monospace" font-size="14" fill="#fff" stroke="#000" stroke-width="0.4">Noir</text>
+  <text x="16" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#fff">shadows</text>
+  <text x="292" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#fff">mids</text>
+  <text x="560" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#111">highlights</text>
+</svg>

--- a/docs/looks/storm.svg
+++ b/docs/looks/storm.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="96" viewBox="0 0 640 96" role="img" aria-label="Storm look palette">
+  <title>Storm — shadows / mids / highlights</title>
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#1a2430"/>
+      <stop offset="50%" stop-color="#3a5060"/>
+      <stop offset="100%" stop-color="#7a90a0"/>
+    </linearGradient>
+  </defs>
+  <rect width="640" height="96" fill="url(#g)"/>
+  <text x="16" y="28" font-family="ui-monospace, monospace" font-size="14" fill="#fff" stroke="#000" stroke-width="0.4">Storm</text>
+  <text x="16" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#fff">shadows</text>
+  <text x="292" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#fff">mids</text>
+  <text x="560" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#111">highlights</text>
+</svg>

--- a/docs/looks/teal-orange.svg
+++ b/docs/looks/teal-orange.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="96" viewBox="0 0 640 96" role="img" aria-label="Teal & Orange look palette">
+  <title>Teal & Orange — shadows / mids / highlights</title>
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#0d3d44"/>
+      <stop offset="50%" stop-color="#2a6a72"/>
+      <stop offset="100%" stop-color="#e07a3a"/>
+    </linearGradient>
+  </defs>
+  <rect width="640" height="96" fill="url(#g)"/>
+  <text x="16" y="28" font-family="ui-monospace, monospace" font-size="14" fill="#fff" stroke="#000" stroke-width="0.4">Teal & Orange</text>
+  <text x="16" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#fff">shadows</text>
+  <text x="292" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#fff">mids</text>
+  <text x="560" y="80" font-family="ui-monospace, monospace" font-size="11" fill="#111">highlights</text>
+</svg>

--- a/e2e/boot.spec.ts
+++ b/e2e/boot.spec.ts
@@ -14,4 +14,11 @@ test.describe('boot', () => {
 
     expect(getUncaught(page)).toEqual([]);
   });
+
+  test('loads with ?look=noir without uncaught exceptions', async ({ page }) => {
+    await gotoApp(page, '/?look=noir');
+    await dismissWelcome(page);
+    expect(page.url()).toContain('look=noir');
+    expect(getUncaught(page)).toEqual([]);
+  });
 });

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -305,6 +305,8 @@ export function AppShell() {
       setIsAccessibilityPanelOpen: panels.setIsAccessibilityPanelOpen,
       isWeatherPanelOpen: panels.isWeatherPanelOpen,
       setIsWeatherPanelOpen: panels.setIsWeatherPanelOpen,
+      isLooksPanelOpen: panels.isLooksPanelOpen,
+      setIsLooksPanelOpen: panels.setIsLooksPanelOpen,
       isTourPanelOpen: panels.isTourPanelOpen,
       setIsTourPanelOpen: panels.setIsTourPanelOpen,
       viewMode,

--- a/src/app/shell/ConnectedChrome.tsx
+++ b/src/app/shell/ConnectedChrome.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useMemo } from 'react';
 import type { TimeOfDay } from '../../hooks';
+import { pickLookSnapshot, type LookId } from '../../config/lookPacks';
 import type { UsePlaceSearchResult } from '../../hooks/usePlaceSearch';
 import { nearbyPoisToGlobe } from '../../search/poiModel';
 import ScoutCard from '../../components/ScoutCard';
@@ -27,6 +28,7 @@ import {
   SnapshotGallery,
   ColorGradingPanel,
   WeatherPanel,
+  LooksPanel,
   AccessibilityPanel,
   HistoricalTimeline,
   TourPanel,
@@ -104,6 +106,11 @@ export interface ConnectedChromeEnvironment {
   toggleHeadlights: () => void;
   setShaderEffectsEnabled: (v: boolean) => void;
   applyColorGradingPreset: (preset: string) => void;
+  applyLookPack: (id: string) => void;
+  activeLookId: LookId | null;
+  nightIntensity: number;
+  highBeam: boolean;
+  domeLightOn: boolean;
   rainIntensity: number;
   snowIntensity: number;
   wind: number;
@@ -239,6 +246,8 @@ export function ConnectedChrome({
     setIsColorGradingPanelOpen,
     isWeatherPanelOpen,
     setIsWeatherPanelOpen,
+    isLooksPanelOpen,
+    setIsLooksPanelOpen,
     isAccessibilityPanelOpen,
     setIsAccessibilityPanelOpen,
     isHistoricalTimelineOpen,
@@ -314,6 +323,8 @@ export function ConnectedChrome({
         setIsColorGradingPanelOpen={setIsColorGradingPanelOpen}
         isWeatherPanelOpen={isWeatherPanelOpen}
         setIsWeatherPanelOpen={setIsWeatherPanelOpen}
+        isLooksPanelOpen={isLooksPanelOpen}
+        setIsLooksPanelOpen={setIsLooksPanelOpen}
         isHistoricalTimelineOpen={isHistoricalTimelineOpen}
         setIsHistoricalTimelineOpen={setIsHistoricalTimelineOpen}
         isTourPanelOpen={isTourPanelOpen}
@@ -439,6 +450,19 @@ export function ConnectedChrome({
           onTimeOfDay={(v) => env.applyTimeOfDayPreset(v as TimeOfDay)}
           onClose={() => setIsWeatherPanelOpen(false)}
           isOpen={isWeatherPanelOpen}
+          onApplyLook={env.applyLookPack}
+          activeLookId={env.activeLookId}
+        />
+      )}
+
+      {isLooksPanelOpen && (
+        <LooksPanel
+          isOpen={isLooksPanelOpen}
+          onClose={() => setIsLooksPanelOpen(false)}
+          activeLookId={env.activeLookId}
+          onApplyLook={env.applyLookPack}
+          reducedMotion={accessibilitySettings.reducedMotion}
+          state={pickLookSnapshot(env)}
         />
       )}
 

--- a/src/app/useAppPanels.ts
+++ b/src/app/useAppPanels.ts
@@ -11,6 +11,8 @@ export interface AppPanels {
   setIsColorGradingPanelOpen: (open: boolean) => void;
   isWeatherPanelOpen: boolean;
   setIsWeatherPanelOpen: (open: boolean) => void;
+  isLooksPanelOpen: boolean;
+  setIsLooksPanelOpen: (open: boolean) => void;
   isAccessibilityPanelOpen: boolean;
   setIsAccessibilityPanelOpen: (open: boolean) => void;
   isHistoricalTimelineOpen: boolean;
@@ -32,6 +34,7 @@ export function useAppPanels(): AppPanels {
   const [isSnapshotGalleryOpen, setIsSnapshotGalleryOpen] = useState(false);
   const [isColorGradingPanelOpen, setIsColorGradingPanelOpen] = useState(false);
   const [isWeatherPanelOpen, setIsWeatherPanelOpen] = useState(false);
+  const [isLooksPanelOpen, setIsLooksPanelOpen] = useState(false);
   const [isAccessibilityPanelOpen, setIsAccessibilityPanelOpen] = useState(false);
   const [isHistoricalTimelineOpen, setIsHistoricalTimelineOpen] = useState(false);
   const [isTourPanelOpen, setIsTourPanelOpen] = useState(false);
@@ -50,6 +53,8 @@ export function useAppPanels(): AppPanels {
     setIsColorGradingPanelOpen,
     isWeatherPanelOpen,
     setIsWeatherPanelOpen,
+    isLooksPanelOpen,
+    setIsLooksPanelOpen,
     isAccessibilityPanelOpen,
     setIsAccessibilityPanelOpen,
     isHistoricalTimelineOpen,

--- a/src/components/AppToolbar.tsx
+++ b/src/components/AppToolbar.tsx
@@ -19,6 +19,8 @@ export interface AppToolbarProps {
   setIsColorGradingPanelOpen: (v: boolean) => void;
   isWeatherPanelOpen: boolean;
   setIsWeatherPanelOpen: (v: boolean) => void;
+  isLooksPanelOpen: boolean;
+  setIsLooksPanelOpen: (v: boolean) => void;
   isHistoricalTimelineOpen: boolean;
   setIsHistoricalTimelineOpen: (v: boolean) => void;
   isTourPanelOpen: boolean;
@@ -51,6 +53,8 @@ const AppToolbar: React.FC<AppToolbarProps> = ({
   setIsColorGradingPanelOpen,
   isWeatherPanelOpen,
   setIsWeatherPanelOpen,
+  isLooksPanelOpen,
+  setIsLooksPanelOpen,
   isHistoricalTimelineOpen,
   setIsHistoricalTimelineOpen,
   isTourPanelOpen,
@@ -138,6 +142,13 @@ const AppToolbar: React.FC<AppToolbarProps> = ({
         onClick={e => { e.stopPropagation(); setIsWeatherPanelOpen(!isWeatherPanelOpen); }}
       >
         🌧 Weather
+      </button>
+      <button
+        className={`control-btn${isLooksPanelOpen ? ' disconnect' : ''}`}
+        style={{ minWidth: 110 }}
+        onClick={e => { e.stopPropagation(); setIsLooksPanelOpen(!isLooksPanelOpen); }}
+      >
+        🎞 Looks
       </button>
       <button
         className={`control-btn${isHistoricalTimelineOpen ? ' disconnect' : ''}`}

--- a/src/components/LooksPanel.test.tsx
+++ b/src/components/LooksPanel.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import LooksPanel from './LooksPanel';
+import { lookPackToEnvPatch, LOOK_PACKS } from '../config/lookPacks';
+
+describe('LooksPanel', () => {
+  const state = lookPackToEnvPatch(LOOK_PACKS.clear);
+
+  it('returns null when closed', () => {
+    const { container } = render(
+      <LooksPanel
+        isOpen={false}
+        onClose={() => {}}
+        activeLookId={null}
+        state={state}
+        onApplyLook={() => {}}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('applies a named look on click', () => {
+    const onApplyLook = vi.fn();
+    render(
+      <LooksPanel
+        isOpen
+        onClose={() => {}}
+        activeLookId={null}
+        state={state}
+        onApplyLook={onApplyLook}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Noir/i }));
+    expect(onApplyLook).toHaveBeenCalledWith('noir');
+  });
+
+  it('copies a look URL and notes reduced motion', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(
+      <LooksPanel
+        isOpen
+        onClose={() => {}}
+        activeLookId="noir"
+        state={lookPackToEnvPatch(LOOK_PACKS.noir)}
+        onApplyLook={() => {}}
+        reducedMotion
+      />,
+    );
+
+    expect(screen.getByText(/Reduced motion/i)).toBeInTheDocument();
+    expect(screen.getByText(/Before:/i)).toBeInTheDocument();
+    expect(screen.getByText(/After:/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Copy look as URL/i }));
+    await screen.findByRole('status');
+    expect(writeText).toHaveBeenCalled();
+    const copied = String(writeText.mock.calls[0]![0]);
+    expect(copied).toContain('look=noir');
+  });
+
+  it('stops mouse and keyboard events from reaching the panorama handlers', () => {
+    const bubble = vi.fn();
+    render(
+      <div onMouseDown={bubble} onKeyDown={bubble}>
+        <LooksPanel
+          isOpen
+          onClose={() => {}}
+          activeLookId={null}
+          state={state}
+          onApplyLook={() => {}}
+        />
+      </div>,
+    );
+    fireEvent.mouseDown(screen.getByRole('dialog', { name: /Looks/i }));
+    fireEvent.keyDown(screen.getByRole('dialog', { name: /Looks/i }), { key: 'a' });
+    expect(bubble).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/LooksPanel.tsx
+++ b/src/components/LooksPanel.tsx
@@ -1,0 +1,225 @@
+import React, { useMemo, useState } from 'react';
+import { LOOK_IDS, LOOK_PACKS, lookPackMatchesState, type LookEnvSnapshot, type LookId } from '../config/lookPacks';
+import { buildLookUrl } from '../utils/lookLink';
+
+export interface LooksPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  activeLookId: LookId | null;
+  state: LookEnvSnapshot;
+  onApplyLook: (id: string) => void;
+  reducedMotion?: boolean;
+}
+
+const LooksPanel: React.FC<LooksPanelProps> = ({
+  isOpen,
+  onClose,
+  activeLookId,
+  state,
+  onApplyLook,
+  reducedMotion = false,
+}) => {
+  const [copyStatus, setCopyStatus] = useState<string | null>(null);
+
+  const customized = useMemo(() => {
+    if (!activeLookId) return false;
+    const pack = LOOK_PACKS[activeLookId];
+    return !lookPackMatchesState(pack, state);
+  }, [activeLookId, state]);
+
+  if (!isOpen) return null;
+
+  const handleCopy = async () => {
+    const url = buildLookUrl({ lookId: activeLookId, state });
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopyStatus('Look URL copied');
+    } catch {
+      setCopyStatus(url);
+    }
+    window.setTimeout(() => setCopyStatus(null), 2500);
+  };
+
+  const labelStyle: React.CSSProperties = {
+    color: '#fff',
+    fontSize: '12px',
+    fontFamily: 'monospace',
+    display: 'block',
+    marginBottom: '2px',
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Looks"
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+      onKeyDown={(e) => e.stopPropagation()}
+      style={{
+        position: 'absolute',
+        top: '80px',
+        right: '20px',
+        width: '340px',
+        maxHeight: 'calc(100vh - 120px)',
+        backgroundColor: 'rgba(20, 22, 32, 0.96)',
+        borderRadius: '12px',
+        border: '1px solid #3d3560',
+        zIndex: 100,
+        overflow: 'hidden',
+        display: 'flex',
+        flexDirection: 'column',
+        boxShadow: '0 8px 32px rgba(0,0,0,0.6)',
+      }}
+    >
+      <div
+        style={{
+          padding: '14px 16px',
+          borderBottom: '1px solid #3d3560',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          backgroundColor: 'rgba(0,0,0,0.3)',
+        }}
+      >
+        <h3 style={{ margin: 0, color: '#E1BEE7', fontSize: '15px', letterSpacing: '0.5px' }}>
+          🎞 Looks
+        </h3>
+        <button
+          onClick={onClose}
+          aria-label="Close looks panel"
+          style={{
+            background: 'none',
+            border: 'none',
+            color: '#aaa',
+            fontSize: '20px',
+            cursor: 'pointer',
+            padding: '0 5px',
+            lineHeight: 1,
+          }}
+        >
+          ×
+        </button>
+      </div>
+
+      <div style={{ padding: '14px 16px', overflowY: 'auto', flex: 1 }}>
+        <div style={{ ...labelStyle, marginBottom: '10px', color: '#b39ddb' }}>
+          Scene packs — weather + grade + time of day. ACES stays last.
+        </div>
+
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr',
+            gap: '8px',
+          }}
+        >
+          {LOOK_IDS.map((id) => {
+            const pack = LOOK_PACKS[id];
+            const selected = activeLookId === id;
+            return (
+              <button
+                key={id}
+                type="button"
+                aria-pressed={selected}
+                title={pack.description}
+                onClick={() => onApplyLook(id)}
+                style={{
+                  textAlign: 'left',
+                  padding: '10px 10px 8px',
+                  border: `1px solid ${selected ? '#CE93D8' : '#3d3560'}`,
+                  borderRadius: '8px',
+                  backgroundColor: selected ? 'rgba(206,147,216,0.18)' : 'rgba(0,0,0,0.45)',
+                  color: selected ? '#F3E5F5' : '#ccc',
+                  cursor: 'pointer',
+                  fontFamily: 'monospace',
+                  minHeight: 72,
+                }}
+              >
+                <div style={{ fontSize: '13px', fontWeight: 700, marginBottom: 4 }}>
+                  {pack.emoji} {pack.name}
+                </div>
+                <div style={{ fontSize: '10px', color: '#aaa', lineHeight: 1.35 }}>
+                  {pack.tagline}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        {activeLookId && (
+          <div
+            style={{
+              marginTop: 14,
+              padding: '10px 12px',
+              backgroundColor: 'rgba(0,0,0,0.35)',
+              borderRadius: 8,
+              border: '1px solid #3d3560',
+            }}
+          >
+            <div style={{ color: '#E1BEE7', fontSize: 12, fontFamily: 'monospace', marginBottom: 6 }}>
+              {LOOK_PACKS[activeLookId].name}
+              {customized ? ' · customized' : ''}
+            </div>
+            <div style={{ color: '#bbb', fontSize: 11, fontFamily: 'monospace', lineHeight: 1.45 }}>
+              <strong style={{ color: '#888' }}>Before: </strong>
+              {LOOK_PACKS[activeLookId].before}
+            </div>
+            <div style={{ color: '#bbb', fontSize: 11, fontFamily: 'monospace', lineHeight: 1.45, marginTop: 6 }}>
+              <strong style={{ color: '#888' }}>After: </strong>
+              {LOOK_PACKS[activeLookId].after}
+            </div>
+          </div>
+        )}
+
+        {reducedMotion && (
+          <div style={{ marginTop: 10, fontSize: 10, color: '#80CBC4', fontFamily: 'monospace' }}>
+            Reduced motion: cinematic DOF / motion blur stay off. Looks still apply.
+          </div>
+        )}
+      </div>
+
+      <div
+        style={{
+          padding: '12px 16px',
+          borderTop: '1px solid #3d3560',
+          backgroundColor: 'rgba(0,0,0,0.25)',
+        }}
+      >
+        <button
+          type="button"
+          onClick={() => { void handleCopy(); }}
+          style={{
+            width: '100%',
+            padding: '8px 12px',
+            border: '1px solid #CE93D8',
+            borderRadius: 6,
+            backgroundColor: 'rgba(206,147,216,0.12)',
+            color: '#E1BEE7',
+            cursor: 'pointer',
+            fontSize: 12,
+            fontFamily: 'monospace',
+            fontWeight: 700,
+          }}
+        >
+          Copy look as URL
+        </button>
+        {copyStatus && (
+          <div
+            role="status"
+            style={{
+              marginTop: 8,
+              fontSize: 10,
+              color: '#ce93d8',
+              fontFamily: 'monospace',
+              wordBreak: 'break-all',
+            }}
+          >
+            {copyStatus}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default LooksPanel;

--- a/src/components/WeatherPanel.tsx
+++ b/src/components/WeatherPanel.tsx
@@ -17,6 +17,8 @@ interface WeatherPanelProps {
     isOpen: boolean;
     autoNightMode?: boolean;
     onToggleAutoNight?: () => void;
+    onApplyLook?: (id: string) => void;
+    activeLookId?: string | null;
 }
 
 const WeatherPanel: React.FC<WeatherPanelProps> = ({
@@ -36,6 +38,8 @@ const WeatherPanel: React.FC<WeatherPanelProps> = ({
     isOpen,
     autoNightMode = false,
     onToggleAutoNight,
+    onApplyLook,
+    activeLookId = null,
 }) => {
     if (!isOpen) return null;
 
@@ -281,6 +285,47 @@ const WeatherPanel: React.FC<WeatherPanelProps> = ({
                         ))}
                     </div>
                 </div>
+                {/* Looks (scene packs) */}
+                {onApplyLook && (
+                    <div style={{ marginTop: '18px' }}>
+                        <div style={{ ...labelStyle, marginBottom: '8px' }}>Looks (weather + grade):</div>
+                        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
+                            {[
+                                { id: 'clear', label: '☀️ Clear' },
+                                { id: 'noir', label: '🎬 Noir' },
+                                { id: 'teal-orange', label: '🧡 Teal-Orange' },
+                                { id: 'bleach-bypass', label: '📰 Bleach' },
+                                { id: 'golden-hour', label: '🌅 Golden' },
+                                { id: 'storm', label: '⛈️ Storm' },
+                                { id: 'arctic', label: '❄️ Arctic' },
+                                { id: 'neon-rain', label: '🌃 Neon Rain' },
+                            ].map((p) => {
+                                const selected = activeLookId === p.id;
+                                return (
+                                    <button
+                                        key={p.id}
+                                        type="button"
+                                        onClick={() => onApplyLook(p.id)}
+                                        aria-pressed={selected}
+                                        style={{
+                                            padding: '5px 9px',
+                                            margin: '1px',
+                                            border: `1px solid ${selected ? '#CE93D8' : '#2a4a6a'}`,
+                                            borderRadius: '4px',
+                                            backgroundColor: selected ? 'rgba(206,147,216,0.2)' : 'rgba(0,0,0,0.5)',
+                                            color: selected ? '#E1BEE7' : '#ccc',
+                                            cursor: 'pointer',
+                                            fontSize: '11px',
+                                            fontFamily: 'monospace',
+                                        }}
+                                    >
+                                        {p.label}
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -32,6 +32,7 @@ export { default as ColorGradingPanel } from './ColorGradingPanel';
 export { default as PerformanceStatsOverlay } from './PerformanceStatsOverlay';
 export { default as RendererBackendIndicator } from './RendererBackendIndicator';
 export { default as WeatherPanel } from './WeatherPanel';
+export { default as LooksPanel } from './LooksPanel';
 export { default as AccessibilityPanel } from './AccessibilityPanel';
 export { default as ScoutCard } from './ScoutCard';
 export { default as AppToolbar } from './AppToolbar';

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -8,3 +8,14 @@ export {
 } from './visualPresets';
 
 export type { QualityLevel, VisualPreset } from './visualPresets';
+
+export {
+  LOOK_IDS,
+  LOOK_PACKS,
+  getLookPack,
+  isLookId,
+  lookPackToEnvPatch,
+  resolveLookEnv,
+} from './lookPacks';
+
+export type { LookId, LookPack, LookEnvPatch, LookEnvSnapshot } from './lookPacks';

--- a/src/config/lookPacks.test.ts
+++ b/src/config/lookPacks.test.ts
@@ -1,0 +1,145 @@
+import {
+  LOOK_IDS,
+  LOOK_PACKS,
+  diffLookOverrides,
+  getLookPack,
+  isLookId,
+  lookPackMatchesState,
+  lookPackToEnvPatch,
+  resolveLookEnv,
+} from './lookPacks';
+import { packWeatherParams } from '../renderer/packWeatherParams';
+import { resolveCinematicCameraFx } from '../renderer/cinematicCameraFx';
+import { WEATHER_PARAMS_FLOAT_COUNT, WeatherParamIndex } from '../renderer/weatherUniformLayout';
+
+describe('look packs', () => {
+  it('ships at least four named artistic looks with before/after notes', () => {
+    const artistic = LOOK_IDS.filter((id) => id !== 'clear');
+    expect(artistic.length).toBeGreaterThanOrEqual(4);
+    expect(LOOK_IDS).toHaveLength(8);
+    for (const id of LOOK_IDS) {
+      const pack = LOOK_PACKS[id];
+      expect(pack.id).toBe(id);
+      expect(pack.name.length).toBeGreaterThan(0);
+      expect(pack.before.length).toBeGreaterThan(10);
+      expect(pack.after.length).toBeGreaterThan(10);
+      expect(pack.curve.shadows.length).toBeGreaterThan(0);
+      expect(pack.curve.mids.length).toBeGreaterThan(0);
+      expect(pack.curve.highlights.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('lookPackToEnvPatch is a lossless flatten of slider fields', () => {
+    const pack = LOOK_PACKS.noir;
+    const patch = lookPackToEnvPatch(pack);
+    expect(patch.rainIntensity).toBe(pack.rain);
+    expect(patch.timeOfDay).toBe('night');
+    expect(patch.headlightsOn).toBe(true);
+    expect(patch.wipersEnabled).toBe(true);
+    expect(patch.shaderEffectsEnabled).toBe(true);
+    expect(patch.autoNightMode).toBe(false);
+    expect(lookPackMatchesState(pack, patch)).toBe(true);
+  });
+
+  it('resolveLookEnv applies overrides on top of a named pack', () => {
+    const resolved = resolveLookEnv(LOOK_PACKS.noir, { rainIntensity: 40 });
+    expect(resolved.rainIntensity).toBe(40);
+    expect(resolved.saturation).toBe(LOOK_PACKS.noir.saturation);
+    expect(resolved.headlightsOn).toBe(true);
+  });
+
+  it('diffLookOverrides only reports changed fields', () => {
+    const base = lookPackToEnvPatch(LOOK_PACKS.storm);
+    expect(diffLookOverrides(LOOK_PACKS.storm, base)).toEqual({});
+    const diffs = diffLookOverrides(LOOK_PACKS.storm, { ...base, rainIntensity: 40 });
+    expect(diffs).toEqual({ rainIntensity: 40 });
+  });
+
+  it('rejects unknown look ids', () => {
+    expect(isLookId('noir')).toBe(true);
+    expect(isLookId('sepia')).toBe(false);
+    expect(getLookPack('sepia')).toBeNull();
+  });
+
+  it('packs every look into the 40-float weather layout', () => {
+    for (const id of LOOK_IDS) {
+      const patch = lookPackToEnvPatch(LOOK_PACKS[id]);
+      const params = packWeatherParams({
+        env: {
+          vibrance: patch.vibrance,
+          saturation: patch.saturation,
+          contrast: patch.contrast,
+          exposure: patch.exposure,
+          temperature: patch.temperature,
+          tint: patch.tint,
+          rainIntensity: patch.rainIntensity,
+          snowIntensity: patch.snowIntensity,
+          wind: patch.wind,
+          nightIntensity: patch.nightIntensity,
+          headlightsOn: patch.headlightsOn,
+          highBeam: patch.highBeam,
+          domeLightOn: patch.domeLightOn,
+          sunAzimuth: 0,
+          sunAltitude: patch.timeOfDay === 'night' ? -1 : 0.6,
+          moonAzimuth: 0,
+          moonAltitude: 0,
+          fogDensity: patch.fogDensity,
+          shaderEffectsEnabled: true,
+          timeOfDay: patch.timeOfDay,
+        },
+        timeSeconds: 0,
+        cameraHeading: 0.5,
+        cameraPitch: 0.5,
+        wasmNoiseActive: false,
+      });
+      expect(params.length).toBe(WEATHER_PARAMS_FLOAT_COUNT);
+      expect(params[WeatherParamIndex.shaderEffectsEnabled]).toBe(1);
+    }
+  });
+
+  it('does not let reduced motion strip look grading (cinematic extras stay off)', () => {
+    const patch = lookPackToEnvPatch(LOOK_PACKS.noir);
+    const cinematic = resolveCinematicCameraFx({
+      quality: 'ultra',
+      reducedMotion: true,
+      speedNormalized: 1,
+    });
+    const params = packWeatherParams({
+      env: {
+        vibrance: patch.vibrance,
+        saturation: patch.saturation,
+        contrast: patch.contrast,
+        exposure: patch.exposure,
+        temperature: patch.temperature,
+        tint: patch.tint,
+        rainIntensity: patch.rainIntensity,
+        snowIntensity: patch.snowIntensity,
+        wind: patch.wind,
+        nightIntensity: patch.nightIntensity,
+        headlightsOn: patch.headlightsOn,
+        highBeam: patch.highBeam,
+        domeLightOn: patch.domeLightOn,
+        sunAzimuth: 0,
+        sunAltitude: -1,
+        moonAzimuth: 0,
+        moonAltitude: 0.5,
+        fogDensity: patch.fogDensity,
+        shaderEffectsEnabled: true,
+        timeOfDay: 'night',
+      },
+      timeSeconds: 0,
+      cameraHeading: 0.5,
+      cameraPitch: 0.5,
+      wasmNoiseActive: false,
+      cinematic,
+    });
+    const I = WeatherParamIndex;
+    expect(params[I.vibrance]).toBeCloseTo(patch.vibrance - 1);
+    expect(params[I.saturation]).toBeCloseTo(patch.saturation - 1);
+    expect(params[I.contrast]).toBeCloseTo(patch.contrast - 1);
+    expect(params[I.nightIntensity]).toBe(1);
+    expect(params[I.rainIntensity]).toBeGreaterThan(0);
+    expect(params[I.dofStrength]).toBe(0);
+    expect(params[I.motionBlurStrength]).toBe(0);
+  });
+});

--- a/src/config/lookPacks.ts
+++ b/src/config/lookPacks.ts
@@ -1,0 +1,474 @@
+/**
+ * lookPacks.ts — named artistic looks + scene packs.
+ *
+ * Each pack is a one-click combination of weather, time-of-day, vehicle lights,
+ * and color-grading knobs. Grading is the existing 6-slider chain
+ * (vibrance → saturation → contrast → temperature/tint → exposure) with ACES
+ * still last in the shader — "LUTs as piecewise curves" without a 3D LUT
+ * texture or extra uniform slots. The 40-float weather layout is unchanged.
+ *
+ * Look targets and before/after notes: docs/looks/README.md, docs/GRAPHICS.md §8.
+ */
+
+/** Mirrors `TimeOfDay` in useEnvironmentSettings — kept local to avoid a cycle. */
+export type LookTimeOfDay = 'day' | 'sunrise' | 'sunset' | 'night';
+
+export type LookId =
+  | 'clear'
+  | 'noir'
+  | 'teal-orange'
+  | 'bleach-bypass'
+  | 'golden-hour'
+  | 'storm'
+  | 'arctic'
+  | 'neon-rain';
+
+/** Three-stop luminance/color curve approximated by the 6 grading uniforms. */
+export interface LookCurveNotes {
+  /** 0–1 luma target in the shadows, plus a short color note. */
+  shadows: string;
+  mids: string;
+  highlights: string;
+}
+
+export interface LookPack {
+  id: LookId;
+  name: string;
+  emoji: string;
+  /** One-line panel blurb. */
+  tagline: string;
+  description: string;
+  before: string;
+  after: string;
+  curve: LookCurveNotes;
+  timeOfDay: LookTimeOfDay;
+  /** UI 0–100 (WeatherPanel). */
+  rain: number;
+  snow: number;
+  /** UI −100..100 (WeatherPanel). 0 = calm. */
+  wind: number;
+  fog: number;
+  vibrance: number;
+  saturation: number;
+  contrast: number;
+  exposure: number;
+  temperature: number;
+  tint: number;
+  /** Optional night slider override (0–1). Omit to use the TOD preset's value. */
+  nightIntensity?: number;
+  headlights?: boolean;
+  highBeam?: boolean;
+  domeLight?: boolean;
+  wipers?: boolean;
+}
+
+export const LOOK_IDS: readonly LookId[] = [
+  'clear',
+  'noir',
+  'teal-orange',
+  'bleach-bypass',
+  'golden-hour',
+  'storm',
+  'arctic',
+  'neon-rain',
+] as const;
+
+export const LOOK_PACKS: Record<LookId, LookPack> = {
+  clear: {
+    id: 'clear',
+    name: 'Clear',
+    emoji: '☀️',
+    tagline: 'Untouched daylight',
+    description: 'Neutral grading, no weather, sun FX at full strength. The reset / before state.',
+    before: 'Whatever look was on — rain, night, split-tone, etc.',
+    after: 'Stock Street View color, clear sky, shafts/flare at the cohesion floor (no haze to scatter in).',
+    curve: {
+      shadows: 'untouched (contrast 1.0, exposure 0)',
+      mids: 'neutral vibrance/sat 1.0',
+      highlights: 'ACES only — no lift',
+    },
+    timeOfDay: 'day',
+    rain: 0,
+    snow: 0,
+    wind: 0,
+    fog: 0,
+    vibrance: 1.0,
+    saturation: 1.0,
+    contrast: 1.0,
+    exposure: 0.0,
+    temperature: 0.0,
+    tint: 0.0,
+    nightIntensity: 0,
+    headlights: false,
+    highBeam: false,
+    domeLight: false,
+    wipers: false,
+  },
+  noir: {
+    id: 'noir',
+    name: 'Noir',
+    emoji: '🎬',
+    tagline: 'Ink-black night, wet streets',
+    description:
+      'High-contrast desaturation, cool temperature, light rain and ground mist. Headlights pool on the road; the #171 night floor keeps it readable.',
+    before: 'Daylight panorama, Google-saturated signs, flat exposure.',
+    after: 'Silver pavement, crushed sky, sparse rain, headlight pools. Color almost gone except cool street lamps.',
+    curve: {
+      shadows: 'crushed toward cool blue (temp −0.45, tint +0.15, exposure −0.25)',
+      mids: 'thin, desaturated (sat 0.35, vibrance 0.45)',
+      highlights: 'hard specular from headlights (contrast 1.55) then ACES',
+    },
+    timeOfDay: 'night',
+    rain: 25,
+    snow: 0,
+    wind: 12,
+    fog: 18,
+    vibrance: 0.45,
+    saturation: 0.35,
+    contrast: 1.55,
+    exposure: -0.25,
+    temperature: -0.45,
+    tint: 0.15,
+    nightIntensity: 1.0,
+    headlights: true,
+    highBeam: false,
+    domeLight: false,
+    wipers: true,
+  },
+  'teal-orange': {
+    id: 'teal-orange',
+    name: 'Teal & Orange',
+    emoji: '🧡',
+    tagline: 'Travel-poster split tone',
+    description:
+      'Sunset TOD plus a complementary grade: warm highlights (temperature+) against teal shadows (tint−). Thin haze for postcard depth.',
+    before: 'Generic afternoon Street View — mixed white balance, no sky drama.',
+    after: 'Sun side reads honey/orange; shade and asphalt pick up teal. Horizon glow agrees with camera heading.',
+    curve: {
+      shadows: 'teal push (tint −0.28, slight cool in unlit areas)',
+      mids: 'lifted vibrance 1.35 / sat 1.25',
+      highlights: 'orange sun (temp +0.42, exposure +0.12) then ACES',
+    },
+    timeOfDay: 'sunset',
+    rain: 0,
+    snow: 0,
+    wind: 8,
+    fog: 8,
+    vibrance: 1.35,
+    saturation: 1.25,
+    contrast: 1.18,
+    exposure: 0.12,
+    temperature: 0.42,
+    tint: -0.28,
+    headlights: false,
+    wipers: false,
+  },
+  'bleach-bypass': {
+    id: 'bleach-bypass',
+    name: 'Bleach Bypass',
+    emoji: '📰',
+    tagline: 'Silver-retention newsreel',
+    description:
+      'Skip-bleach: retain silver (high contrast, low saturation) with a touch of overexposure. Light fog stands in for overcast so cohesion kills the sun.',
+    before: 'Colorful storefronts and sky, soft Google contrast.',
+    after: 'Harsh metallic mids, retained highlight texture, almost no chroma. Sky goes newsreel grey.',
+    curve: {
+      shadows: 'hard floor (contrast 1.65) with almost no chroma',
+      mids: 'desat 0.50 / vibrance 0.55 — silver retention',
+      highlights: 'slight overexposure (+0.15) compressed by ACES, not clipped',
+    },
+    timeOfDay: 'day',
+    rain: 0,
+    snow: 0,
+    wind: 0,
+    fog: 22,
+    vibrance: 0.55,
+    saturation: 0.5,
+    contrast: 1.65,
+    exposure: 0.15,
+    temperature: -0.05,
+    tint: 0.0,
+    nightIntensity: 0.05,
+    headlights: false,
+    wipers: false,
+  },
+  'golden-hour': {
+    id: 'golden-hour',
+    name: 'Golden Hour',
+    emoji: '🌅',
+    tagline: 'Honey light, long warmth',
+    description:
+      'Sunrise TOD (sun just up, camera-aware wash) with warm temperature and a soft haze band. The travel-poster cousin of teal-orange, without the complementary split.',
+    before: 'Default day — white sun, no atmosphere.',
+    after: 'Honey low sun on the tracked azimuth, soft far-field haze, lifted exposure.',
+    curve: {
+      shadows: 'warm lift, not crushed (exposure +0.18)',
+      mids: 'vibrance 1.25 / sat 1.15',
+      highlights: 'temp +0.48 rolling into ACES rolloff',
+    },
+    timeOfDay: 'sunrise',
+    rain: 0,
+    snow: 0,
+    wind: 5,
+    fog: 6,
+    vibrance: 1.25,
+    saturation: 1.15,
+    contrast: 1.08,
+    exposure: 0.18,
+    temperature: 0.48,
+    tint: -0.18,
+    headlights: false,
+    wipers: false,
+  },
+  storm: {
+    id: 'storm',
+    name: 'Storm',
+    emoji: '⛈️',
+    tagline: 'Near-black sky, driven rain',
+    description:
+      'Rain 100 / wind 80 / fog 35 from GRAPHICS.md §3, plus a cool underexposed grade. Overcast kills shafts and flare; rain darken eases at night so the readable floor survives.',
+    before: 'Clear noon, lens flare, dusty air.',
+    after: 'Sun gone, wet haze, streaks slanted with wind, scene −~26% by day. Wipers on.',
+    curve: {
+      shadows: 'cool underexpose (temp −0.28, exposure −0.35)',
+      mids: 'sat 0.75 / vibrance 0.70 — muted greens',
+      highlights: 'specular rain + leftover ACES; no sun FX',
+    },
+    timeOfDay: 'day',
+    rain: 100,
+    snow: 0,
+    wind: 80,
+    fog: 35,
+    vibrance: 0.7,
+    saturation: 0.75,
+    contrast: 1.25,
+    exposure: -0.35,
+    temperature: -0.28,
+    tint: 0.18,
+    nightIntensity: 0.22,
+    headlights: false,
+    wipers: true,
+  },
+  arctic: {
+    id: 'arctic',
+    name: 'Arctic',
+    emoji: '❄️',
+    tagline: 'High-key snow, cold air',
+    description:
+      'Blizzard-adjacent snow with cool temperature and lifted exposure. Snow adds little humidity (cold air); flakes stay bright and pick up headlights if you later switch to night.',
+    before: 'Temperate street, warm pavement, no particles.',
+    after: 'High-key snow, cool air, flakes falling downward, far field softened by fog/haze.',
+    curve: {
+      shadows: 'lifted, slightly cyan (temp −0.22, exposure +0.28)',
+      mids: 'sat pulled to 0.82 so snow stays white',
+      highlights: 'contrast 1.22 keeps flake edges; ACES holds the blowout',
+    },
+    timeOfDay: 'day',
+    rain: 0,
+    snow: 85,
+    wind: -40,
+    fog: 20,
+    vibrance: 1.05,
+    saturation: 0.82,
+    contrast: 1.22,
+    exposure: 0.28,
+    temperature: -0.22,
+    tint: 0.05,
+    headlights: false,
+    wipers: false,
+  },
+  'neon-rain': {
+    id: 'neon-rain',
+    name: 'Neon Rain',
+    emoji: '🌃',
+    tagline: 'Wet night, magenta/cyan',
+    description:
+      'Night rain with a complementary neon grade (cool temperature + magenta tint). Humidity haze and headlights keep the road readable; cinematic extras still gate on reduced-motion.',
+    before: 'Stock night — crushed or merely blue-tinted, dry pavement.',
+    after: 'Wet asphalt, cyan haze in the distance, magenta bounce, headlight cones, rain streaks downward.',
+    curve: {
+      shadows: 'cyan-black (temp −0.35, night floor from #171)',
+      mids: 'magenta tint +0.35 against remaining chroma',
+      highlights: 'headlight warmth vs neon; ACES last',
+    },
+    timeOfDay: 'night',
+    rain: 55,
+    snow: 0,
+    wind: 25,
+    fog: 16,
+    vibrance: 1.15,
+    saturation: 1.05,
+    contrast: 1.28,
+    exposure: -0.15,
+    temperature: -0.35,
+    tint: 0.35,
+    nightIntensity: 1.0,
+    headlights: true,
+    highBeam: true,
+    domeLight: false,
+    wipers: true,
+  },
+};
+
+export function isLookId(value: string | null | undefined): value is LookId {
+  return typeof value === 'string' && (LOOK_IDS as readonly string[]).includes(value);
+}
+
+export function getLookPack(id: string | null | undefined): LookPack | null {
+  if (!isLookId(id)) return null;
+  return LOOK_PACKS[id];
+}
+
+/** Slider/light fields a look writes into EnvironmentSettings. */
+export interface LookEnvPatch {
+  timeOfDay: LookTimeOfDay;
+  rainIntensity: number;
+  snowIntensity: number;
+  wind: number;
+  fogDensity: number;
+  vibrance: number;
+  saturation: number;
+  contrast: number;
+  exposure: number;
+  temperature: number;
+  tint: number;
+  nightIntensity: number;
+  headlightsOn: boolean;
+  highBeam: boolean;
+  domeLightOn: boolean;
+  wipersEnabled: boolean;
+  shaderEffectsEnabled: boolean;
+  autoNightMode: boolean;
+}
+
+const TOD_NIGHT_INTENSITY: Record<LookTimeOfDay, number> = {
+  day: 0,
+  sunrise: 0.1,
+  sunset: 0.3,
+  night: 1,
+};
+
+/** Flatten a pack into the environment fields the provider/URL layer consume. */
+export function lookPackToEnvPatch(pack: LookPack): LookEnvPatch {
+  return {
+    timeOfDay: pack.timeOfDay,
+    rainIntensity: pack.rain,
+    snowIntensity: pack.snow,
+    wind: pack.wind,
+    fogDensity: pack.fog,
+    vibrance: pack.vibrance,
+    saturation: pack.saturation,
+    contrast: pack.contrast,
+    exposure: pack.exposure,
+    temperature: pack.temperature,
+    tint: pack.tint,
+    nightIntensity: pack.nightIntensity ?? TOD_NIGHT_INTENSITY[pack.timeOfDay],
+    headlightsOn: pack.headlights === true,
+    highBeam: pack.highBeam === true,
+    domeLightOn: pack.domeLight === true,
+    wipersEnabled: pack.wipers === true,
+    shaderEffectsEnabled: true,
+    autoNightMode: false,
+  };
+}
+
+const LOOK_NUMERIC_KEYS = [
+  'rainIntensity',
+  'snowIntensity',
+  'wind',
+  'fogDensity',
+  'vibrance',
+  'saturation',
+  'contrast',
+  'exposure',
+  'temperature',
+  'tint',
+  'nightIntensity',
+] as const;
+
+const LOOK_BOOL_KEYS = [
+  'headlightsOn',
+  'highBeam',
+  'domeLightOn',
+  'wipersEnabled',
+  'shaderEffectsEnabled',
+] as const;
+
+export type LookEnvSnapshot = Pick<
+  LookEnvPatch,
+  | 'timeOfDay'
+  | 'rainIntensity'
+  | 'snowIntensity'
+  | 'wind'
+  | 'fogDensity'
+  | 'vibrance'
+  | 'saturation'
+  | 'contrast'
+  | 'exposure'
+  | 'temperature'
+  | 'tint'
+  | 'nightIntensity'
+  | 'headlightsOn'
+  | 'highBeam'
+  | 'domeLightOn'
+  | 'wipersEnabled'
+  | 'shaderEffectsEnabled'
+>;
+
+export function pickLookSnapshot(state: LookEnvSnapshot): LookEnvSnapshot {
+  return {
+    timeOfDay: state.timeOfDay,
+    rainIntensity: state.rainIntensity,
+    snowIntensity: state.snowIntensity,
+    wind: state.wind,
+    fogDensity: state.fogDensity,
+    vibrance: state.vibrance,
+    saturation: state.saturation,
+    contrast: state.contrast,
+    exposure: state.exposure,
+    temperature: state.temperature,
+    tint: state.tint,
+    nightIntensity: state.nightIntensity,
+    headlightsOn: state.headlightsOn,
+    highBeam: state.highBeam,
+    domeLightOn: state.domeLightOn,
+    wipersEnabled: state.wipersEnabled,
+    shaderEffectsEnabled: state.shaderEffectsEnabled,
+  };
+}
+
+function nearlyEqual(a: number, b: number, eps = 0.02): boolean {
+  return Math.abs(a - b) <= eps;
+}
+
+/** Fields on `state` that differ from the pack (used as URL overrides). */
+export function diffLookOverrides(
+  pack: LookPack,
+  state: LookEnvSnapshot,
+): Partial<LookEnvPatch> {
+  const base = lookPackToEnvPatch(pack);
+  const out: Partial<LookEnvPatch> = {};
+  if (state.timeOfDay !== base.timeOfDay) out.timeOfDay = state.timeOfDay;
+  for (const key of LOOK_NUMERIC_KEYS) {
+    if (!nearlyEqual(state[key], base[key])) out[key] = state[key];
+  }
+  for (const key of LOOK_BOOL_KEYS) {
+    if (state[key] !== base[key]) out[key] = state[key];
+  }
+  return out;
+}
+
+export function lookPackMatchesState(pack: LookPack, state: LookEnvSnapshot): boolean {
+  return Object.keys(diffLookOverrides(pack, state)).length === 0;
+}
+
+/** Merge a pack with optional slider/light overrides (URL round-trip). */
+export function resolveLookEnv(
+  pack: LookPack | null,
+  overrides: Partial<LookEnvPatch> = {},
+): LookEnvPatch {
+  const base = pack
+    ? lookPackToEnvPatch(pack)
+    : lookPackToEnvPatch(LOOK_PACKS.clear);
+  return { ...base, ...overrides, shaderEffectsEnabled: true, autoNightMode: false };
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,7 +5,7 @@
 // Core context hooks
 export { useStreetView, StreetViewProvider } from './useStreetView';
 export { useViewMode, ViewModeProvider, type ViewMode, type ControlMode, type HeadCoupling } from './useViewMode';
-export { useEnvironmentSettings, EnvironmentSettingsProvider, type TimeOfDay } from './useEnvironmentSettings';
+export { useEnvironmentSettings, EnvironmentSettingsProvider, type TimeOfDay, type LookId } from './useEnvironmentSettings';
 
 export { usePlaceSearch, type UsePlaceSearchResult } from './usePlaceSearch';
 export { useBookmarks } from './useBookmarks';

--- a/src/hooks/useAppKeyboardShortcuts.ts
+++ b/src/hooks/useAppKeyboardShortcuts.ts
@@ -22,6 +22,8 @@ export interface UseAppKeyboardShortcutsOptions {
   setIsAccessibilityPanelOpen: (v: boolean) => void;
   isWeatherPanelOpen: boolean;
   setIsWeatherPanelOpen: (v: boolean) => void;
+  isLooksPanelOpen: boolean;
+  setIsLooksPanelOpen: (v: boolean) => void;
   isTourPanelOpen: boolean;
   setIsTourPanelOpen: (v: boolean) => void;
   viewMode: 'freelook' | 'car';
@@ -66,6 +68,8 @@ export function buildAppKeyboardShortcuts(options: UseAppKeyboardShortcutsOption
     setIsAccessibilityPanelOpen,
     isWeatherPanelOpen,
     setIsWeatherPanelOpen,
+    isLooksPanelOpen,
+    setIsLooksPanelOpen,
     isTourPanelOpen,
     setIsTourPanelOpen,
     viewMode,
@@ -181,6 +185,14 @@ export function buildAppKeyboardShortcuts(options: UseAppKeyboardShortcutsOption
       },
     },
     {
+      key: 'k',
+      description: 'Toggle looks panel',
+      action: () => {
+        setIsLooksPanelOpen(!isLooksPanelOpen);
+        announce(`Looks panel ${!isLooksPanelOpen ? 'opened' : 'closed'}`);
+      },
+    },
+    {
       key: 'c',
       description: 'Toggle car mode',
       action: () => {
@@ -241,6 +253,7 @@ export function buildAppKeyboardShortcuts(options: UseAppKeyboardShortcutsOption
       description: 'Close panels',
       action: () => {
         if (globeMode.isActive) { globeMode.deactivate(); return; }
+        if (isLooksPanelOpen) { setIsLooksPanelOpen(false); return; }
         if (isWeatherPanelOpen) { setIsWeatherPanelOpen(false); return; }
         if (isAccessibilityPanelOpen) setIsAccessibilityPanelOpen(false);
         else if (isBookmarkPanelOpen) setIsBookmarkPanelOpen(false);

--- a/src/hooks/useEnvironmentSettings.tsx
+++ b/src/hooks/useEnvironmentSettings.tsx
@@ -1,8 +1,16 @@
 import React, { createContext, useContext, useState, useCallback, useMemo } from 'react';
 import { loadCarRuntime } from '../car/carRuntimeLoader';
+import {
+  getLookPack,
+  lookPackToEnvPatch,
+  type LookEnvPatch,
+  type LookId,
+} from '../config/lookPacks';
+import { readBootLook } from '../utils/lookLink';
 
 // Types
 export type TimeOfDay = 'day' | 'sunrise' | 'sunset' | 'night';
+export type { LookId };
 
 export interface EnvironmentSettingsState {
   // Weather settings
@@ -75,6 +83,9 @@ export interface EnvironmentSettingsState {
   // Presets
   applyTimeOfDayPreset: (preset: TimeOfDay) => void;
   applyColorGradingPreset: (preset: string) => void;
+  /** Last applied named look (`?look=`). Null when the user is on a custom grade. */
+  activeLookId: LookId | null;
+  applyLookPack: (id: string) => void;
 
   // Derived
   /** CSS rgba string for the current ambient light color — used to tint dashboard glass panels. */
@@ -95,42 +106,68 @@ interface EnvironmentSettingsProviderProps {
   children: React.ReactNode;
 }
 
+const TOD_ASTRONOMY: Record<TimeOfDay, {
+  nightIntensity: number;
+  sunAltitude: number;
+  sunAzimuth: number;
+  moonAltitude: number;
+  moonAzimuth: number;
+}> = {
+  day: { nightIntensity: 0.0, sunAltitude: 0.785, sunAzimuth: 0, moonAltitude: -0.5, moonAzimuth: 0 },
+  sunrise: { nightIntensity: 0.1, sunAltitude: 0.052, sunAzimuth: 0, moonAltitude: -0.5, moonAzimuth: -1.57 },
+  sunset: { nightIntensity: 0.3, sunAltitude: -0.052, sunAzimuth: -1.57, moonAltitude: 0.2, moonAzimuth: 1.57 },
+  night: { nightIntensity: 1.0, sunAltitude: -1.047, sunAzimuth: 0, moonAltitude: 0.5, moonAzimuth: 0.785 },
+};
+
+function snapshotBoot() {
+  return readBootLook();
+}
+
 export const EnvironmentSettingsProvider: React.FC<EnvironmentSettingsProviderProps> = ({
   children,
 }) => {
+  const boot = snapshotBoot();
+  const bootPatch = boot?.patch;
+  const bootAstro = TOD_ASTRONOMY[bootPatch?.timeOfDay ?? 'day'];
+
   // Weather state
-  const [rainIntensity, setRainIntensity] = useState(0);
-  const [snowIntensity, setSnowIntensity] = useState(0);
-  const [wind, setWind] = useState(0);
-  const [fogDensity, setFogDensity] = useState(0.0);
+  const [rainIntensity, setRainIntensity] = useState(bootPatch?.rainIntensity ?? 0);
+  const [snowIntensity, setSnowIntensity] = useState(bootPatch?.snowIntensity ?? 0);
+  const [wind, setWind] = useState(bootPatch?.wind ?? 0);
+  const [fogDensity, setFogDensity] = useState(bootPatch?.fogDensity ?? 0.0);
   
   // Time of day
-  const [timeOfDay, setTimeOfDay] = useState<TimeOfDay>('day');
-  const [autoNightMode, setAutoNightMode] = useState(true);
+  const [timeOfDay, setTimeOfDay] = useState<TimeOfDay>(bootPatch?.timeOfDay ?? 'day');
+  const [autoNightMode, setAutoNightMode] = useState(bootPatch ? false : true);
   
   // Night/astronomical
-  const [nightIntensity, setNightIntensity] = useState(0.0);
-  const [sunAzimuth, setSunAzimuth] = useState(0.0);
-  const [sunAltitude, setSunAltitude] = useState(0.2);
-  const [moonAzimuth, setMoonAzimuth] = useState(0.0);
-  const [moonAltitude, setMoonAltitude] = useState(-0.5);
+  const [nightIntensity, setNightIntensity] = useState(
+    bootPatch?.nightIntensity ?? bootAstro.nightIntensity,
+  );
+  const [sunAzimuth, setSunAzimuth] = useState(bootAstro.sunAzimuth);
+  const [sunAltitude, setSunAltitude] = useState(bootAstro.sunAltitude);
+  const [moonAzimuth, setMoonAzimuth] = useState(bootAstro.moonAzimuth);
+  const [moonAltitude, setMoonAltitude] = useState(bootAstro.moonAltitude);
   const [moonIntensity, setMoonIntensity] = useState(0.0);
   
   // Car state
-  const [wipersEnabled, setWipersEnabledState] = useState(false);
-  const [headlightsOn, setHeadlightsOnState] = useState(false);
-  const [highBeam, setHighBeamState] = useState(false);
-  const [domeLightOn, setDomeLightOnState] = useState(false);
+  const [wipersEnabled, setWipersEnabledState] = useState(bootPatch?.wipersEnabled ?? false);
+  const [headlightsOn, setHeadlightsOnState] = useState(bootPatch?.headlightsOn ?? false);
+  const [highBeam, setHighBeamState] = useState(bootPatch?.highBeam ?? false);
+  const [domeLightOn, setDomeLightOnState] = useState(bootPatch?.domeLightOn ?? false);
   const [isRoofOpen, setIsRoofOpen] = useState(false);
   
   // Color grading
-  const [vibrance, setVibrance] = useState(1.0);
-  const [saturation, setSaturation] = useState(1.0);
-  const [contrast, setContrast] = useState(1.0);
-  const [exposure, setExposure] = useState(0.0);
-  const [temperature, setTemperature] = useState(0.0);
-  const [tint, setTint] = useState(0.0);
-  const [shaderEffectsEnabled, setShaderEffectsEnabled] = useState(true);
+  const [vibrance, setVibrance] = useState(bootPatch?.vibrance ?? 1.0);
+  const [saturation, setSaturation] = useState(bootPatch?.saturation ?? 1.0);
+  const [contrast, setContrast] = useState(bootPatch?.contrast ?? 1.0);
+  const [exposure, setExposure] = useState(bootPatch?.exposure ?? 0.0);
+  const [temperature, setTemperature] = useState(bootPatch?.temperature ?? 0.0);
+  const [tint, setTint] = useState(bootPatch?.tint ?? 0.0);
+  const [shaderEffectsEnabled, setShaderEffectsEnabled] = useState(
+    bootPatch?.shaderEffectsEnabled ?? true,
+  );
+  const [activeLookId, setActiveLookId] = useState<LookId | null>(boot?.lookId ?? null);
   
   // Wipers
   const toggleWipersCallback = useCallback(() => {
@@ -186,41 +223,58 @@ export const EnvironmentSettingsProvider: React.FC<EnvironmentSettingsProviderPr
   const applyTimeOfDayPreset = useCallback((preset: TimeOfDay) => {
     setAutoNightMode(false);
     setTimeOfDay(preset);
-    
-    switch (preset) {
-      case 'day':
-        setNightIntensity(0.0);
-        setSunAltitude(0.785);
-        setSunAzimuth(0);
-        setMoonAltitude(-0.5);
-        break;
-      case 'sunrise':
-        setNightIntensity(0.1);
-        setSunAltitude(0.052);
-        setSunAzimuth(0);
-        setMoonAltitude(-0.5);
-        setMoonAzimuth(-1.57);
-        break;
-      case 'sunset':
-        setNightIntensity(0.3);
-        setSunAltitude(-0.052);
-        setSunAzimuth(-1.57);
-        setMoonAltitude(0.2);
-        setMoonAzimuth(1.57);
-        break;
-      case 'night':
-        setNightIntensity(1.0);
-        setHeadlightsOnState(true);
-        setSunAltitude(-1.047);
-        setSunAzimuth(0);
-        setMoonAltitude(0.5);
-        setMoonAzimuth(0.785);
-        break;
+    const astro = TOD_ASTRONOMY[preset];
+    setNightIntensity(astro.nightIntensity);
+    setSunAltitude(astro.sunAltitude);
+    setSunAzimuth(astro.sunAzimuth);
+    setMoonAltitude(astro.moonAltitude);
+    setMoonAzimuth(astro.moonAzimuth);
+    if (preset === 'night') {
+      setHeadlightsOnState(true);
     }
   }, []);
+
+  const applyLookPatch = useCallback((patch: LookEnvPatch) => {
+    setAutoNightMode(false);
+    setShaderEffectsEnabled(true);
+    setTimeOfDay(patch.timeOfDay);
+    setRainIntensity(patch.rainIntensity);
+    setSnowIntensity(patch.snowIntensity);
+    setWind(patch.wind);
+    setFogDensity(patch.fogDensity);
+    setVibrance(patch.vibrance);
+    setSaturation(patch.saturation);
+    setContrast(patch.contrast);
+    setExposure(patch.exposure);
+    setTemperature(patch.temperature);
+    setTint(patch.tint);
+    setNightIntensity(patch.nightIntensity);
+    const astro = TOD_ASTRONOMY[patch.timeOfDay];
+    setSunAltitude(astro.sunAltitude);
+    setSunAzimuth(astro.sunAzimuth);
+    setMoonAltitude(astro.moonAltitude);
+    setMoonAzimuth(astro.moonAzimuth);
+    setHeadlightsOnState(patch.headlightsOn);
+    setHighBeamState(patch.highBeam);
+    setDomeLightOnState(patch.domeLightOn);
+    setWipersEnabledState(patch.wipersEnabled);
+    void loadCarRuntime().then(({ setCarHeadlights, setCarDomeLight, setCarWipers }) => {
+      setCarHeadlights(patch.headlightsOn);
+      setCarDomeLight(patch.domeLightOn);
+      setCarWipers(patch.wipersEnabled);
+    });
+  }, []);
+
+  const applyLookPack = useCallback((id: string) => {
+    const pack = getLookPack(id);
+    if (!pack) return;
+    applyLookPatch(lookPackToEnvPatch(pack));
+    setActiveLookId(pack.id);
+  }, [applyLookPatch]);
   
   // Apply color grading preset
   const applyColorGradingPreset = useCallback((preset: string) => {
+    setActiveLookId(null);
     switch (preset) {
       case 'none':
         setShaderEffectsEnabled(false);
@@ -375,6 +429,8 @@ export const EnvironmentSettingsProvider: React.FC<EnvironmentSettingsProviderPr
     // Presets
     applyTimeOfDayPreset,
     applyColorGradingPreset,
+    activeLookId,
+    applyLookPack,
 
     // Derived
     ambientLightColor,

--- a/src/renderer/WebGLFallbackRenderer.ts
+++ b/src/renderer/WebGLFallbackRenderer.ts
@@ -168,7 +168,8 @@ vec3 applyWeather(vec3 col, vec2 uv) {
         vec3 rainTint = mix(vec3(0.64, 0.78, 0.95), vec3(0.50, 0.62, 0.90), night);
         col = mix(col, rainTint, streak * rain * 0.18 * precipVisibility);
         // Ease the wet-scene darkening at night so the #171 readable floor holds.
-        col *= 1.0 - rain * mix(0.045, 0.020, night);
+        // Coefficients match RAIN_DARKEN_DAY/NIGHT in weatherCohesion.ts (0.22 / 0.10).
+        col *= 1.0 - rain * mix(0.22, 0.10, night);
     }
 
     if (snow > 0.001) {
@@ -180,6 +181,19 @@ vec3 applyWeather(vec3 col, vec2 uv) {
     }
 
     return col;
+}
+
+// SDR humidity haze — same distance factor + desat/mix as applyHumidityHaze in
+// weather-post.wgsl. Skips the 4-tap scene blur (WebGPU-only / best-effort).
+vec3 applyHumidityHaze(vec3 col, vec2 uv) {
+    float intensity = clamp(uWeather[31], 0.0, 1.0);
+    if (intensity < 0.001) return col;
+    float distanceFactor = smoothstep(0.7, 0.2, uv.y);
+    vec3 hazeColor = vec3(0.75, 0.82, 0.88);
+    float hazeAmount = intensity * distanceFactor * 0.4;
+    float luma = dot(col, vec3(0.299, 0.587, 0.114));
+    vec3 desaturated = mix(col, vec3(luma), intensity * distanceFactor * 0.3);
+    return mix(desaturated, hazeColor, hazeAmount);
 }
 
 vec3 applyFogAndLighting(vec3 col, vec2 uv) {
@@ -227,17 +241,21 @@ void main() {
         color = applyColorGrade(color);
     } else if (uEffectIsolation == 3) {
         color = applyWeather(color, vUv);
+        color = applyHumidityHaze(color, vUv);
     } else if (uEffectIsolation == 4) {
         color = applyFogAndLighting(color, vUv);
+        color = applyHumidityHaze(color, vUv);
     } else if (uEffectIsolation == 5) {
         color = applyNight(color, vUv);
     } else if (uEffectIsolation == 6) {
         color = applyFogAndLighting(applyNight(color, vUv), vUv);
+        color = applyHumidityHaze(color, vUv);
     } else {
         color = applyColorGrade(color);
         color = applyNight(color, vUv);
         color = applyWeather(color, vUv);
         color = applyFogAndLighting(color, vUv);
+        color = applyHumidityHaze(color, vUv);
     }
 
     color = color / (color + vec3(1.0));

--- a/src/renderer/weatherCohesion.test.ts
+++ b/src/renderer/weatherCohesion.test.ts
@@ -1,4 +1,4 @@
-import { resolveWeatherCohesion, resolveSunVisibility, FogColorIndex } from './weatherCohesion';
+import { resolveWeatherCohesion, resolveSunVisibility, FogColorIndex, RAIN_DARKEN_DAY, RAIN_DARKEN_NIGHT } from './weatherCohesion';
 
 function baseInput(overrides: Partial<Parameters<typeof resolveWeatherCohesion>[0]> = {}) {
     return {
@@ -113,5 +113,13 @@ describe('resolveSunVisibility', () => {
 
     it('is fully occluded by total overcast', () => {
         expect(resolveSunVisibility(1.0, 1)).toBe(0);
+    });
+});
+
+describe('rain darken coefficients', () => {
+    it('eases toward the night floor so a storm cannot crush #171 readability', () => {
+        expect(RAIN_DARKEN_DAY).toBeGreaterThan(RAIN_DARKEN_NIGHT);
+        expect(RAIN_DARKEN_DAY).toBeCloseTo(0.22);
+        expect(RAIN_DARKEN_NIGHT).toBeCloseTo(0.10);
     });
 });

--- a/src/renderer/weatherCohesion.ts
+++ b/src/renderer/weatherCohesion.ts
@@ -55,6 +55,14 @@ export interface WeatherCohesionResult {
 
 const clamp01 = (v: number): number => Math.min(1, Math.max(0, v));
 
+/**
+ * Scene luminance scale-down under rain (shader: `1 - rainIntensity * mix(day, night, nightIntensity)`).
+ * Eases toward the night end-stop so the #171 readable floor survives a night storm.
+ * Must match weather-post.wgsl, weather-post-compute.wgsl, and WebGLFallbackRenderer.
+ */
+export const RAIN_DARKEN_DAY = 0.22;
+export const RAIN_DARKEN_NIGHT = 0.10;
+
 /** Fog colour palette indices shared with `getFogColor()` in both WGSL paths. */
 export const FogColorIndex = {
     gray: 0,

--- a/src/renderer/weatherShaderParity.test.ts
+++ b/src/renderer/weatherShaderParity.test.ts
@@ -162,6 +162,16 @@ describe('weather shader parity guard', () => {
     expect(compute).toMatch(/textureStore\(\s*writeDepthTexture/);
   });
 
+  it('keeps humidity haze distance/color terms aligned across WGSL paths', () => {
+    const fragment = readShader('weather-post.wgsl');
+    const compute = readShader('weather-post-compute.wgsl');
+    for (const source of [fragment, compute]) {
+      expect(source).toContain('fn applyHumidityHaze(');
+      expect(source).toContain('smoothstep(0.7, 0.2, uv.y)');
+      expect(source).toContain('vec3<f32>(0.75, 0.82, 0.88)');
+    }
+  });
+
   it('keeps precipitation fog attenuation aligned across WGSL paths', () => {
     const fragment = readShader('weather-post.wgsl');
     const compute = readShader('weather-post-compute.wgsl');

--- a/src/renderer/webglLookParity.test.ts
+++ b/src/renderer/webglLookParity.test.ts
@@ -1,0 +1,47 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { RAIN_DARKEN_DAY, RAIN_DARKEN_NIGHT } from './weatherCohesion';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(__dirname, rel), 'utf8');
+}
+
+describe('WebGL must-match parity (night floor, precip Y, overcast, rain darken, haze)', () => {
+  const webgl = read('./WebGLFallbackRenderer.ts');
+  const fragment = read('../../public/shaders/weather-post.wgsl');
+  const compute = read('../../public/shaders/weather-post-compute.wgsl');
+
+  it('keeps rain darken day/night coefficients aligned across all three paths', () => {
+    expect(RAIN_DARKEN_DAY).toBe(0.22);
+    expect(RAIN_DARKEN_NIGHT).toBe(0.10);
+    const token = `mix(${RAIN_DARKEN_DAY}, ${RAIN_DARKEN_NIGHT}`;
+    expect(fragment).toContain(token);
+    expect(compute).toContain(token);
+    expect(webgl).toContain(`mix(${RAIN_DARKEN_DAY.toFixed(2)}, ${RAIN_DARKEN_NIGHT.toFixed(2)}`);
+  });
+
+  it('applies humidity haze in the WebGL fallback (must-match atmosphere)', () => {
+    expect(webgl).toContain('vec3 applyHumidityHaze');
+    expect(webgl).toContain('uWeather[31]');
+    expect(webgl).toContain('smoothstep(0.7, 0.2, uv.y)');
+    expect(webgl).toContain('vec3(0.75, 0.82, 0.88)');
+    expect(fragment).toContain('fn applyHumidityHaze');
+    expect(compute).toContain('fn applyHumidityHaze');
+  });
+
+  it('keeps precipitation falling downward in WebGL (negative Y time term)', () => {
+    expect(webgl).toContain('-time * 24.0');
+    expect(webgl).toContain('-time * 2.2');
+    expect(fragment).toContain('st.y = st.y - t *');
+  });
+
+  it('documents that overcast sun kill is CPU-side (weatherCohesion) for all backends', () => {
+    expect(webgl).toContain('weatherCohesion.ts');
+    expect(webgl).toContain('uWeather[28]');
+    expect(webgl).toContain('uWeather[26]');
+  });
+});

--- a/src/utils/lookLink.test.ts
+++ b/src/utils/lookLink.test.ts
@@ -1,0 +1,101 @@
+import { LOOK_PACKS, lookPackToEnvPatch } from '../config/lookPacks';
+import {
+  buildLookUrl,
+  hasLookSearchParams,
+  parseLookParams,
+  resolveLookSearch,
+  resolveLookUrlParams,
+} from './lookLink';
+
+const BASE = 'https://test.1ink.us/streetview?lat=37.774900&lng=-122.419400';
+
+describe('look URL params', () => {
+  it('parses a named look', () => {
+    expect(parseLookParams('?look=noir').look).toBe('noir');
+    expect(parseLookParams('look=noir').look).toBe('noir');
+    expect(parseLookParams('?look=sepia').look).toBeUndefined();
+  });
+
+  it('clamps slider overrides', () => {
+    const parsed = parseLookParams('?rain=140&sat=9&temp=-3&wind=-200');
+    expect(parsed.rain).toBe(100);
+    expect(parsed.saturation).toBe(2);
+    expect(parsed.temperature).toBe(-1);
+    expect(parsed.wind).toBe(-100);
+  });
+
+  it('round-trips a named look with no overrides to ?look= only', () => {
+    const state = lookPackToEnvPatch(LOOK_PACKS.noir);
+    const url = buildLookUrl({ lookId: 'noir', state }, BASE);
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('look')).toBe('noir');
+    expect(parsed.searchParams.get('rain')).toBeNull();
+    expect(parsed.searchParams.get('lat')).toBe('37.774900');
+    const resolved = resolveLookUrlParams(parseLookParams(parsed.search));
+    expect(resolved.rainIntensity).toBe(LOOK_PACKS.noir.rain);
+    expect(resolved.saturation).toBe(LOOK_PACKS.noir.saturation);
+    expect(resolved.headlightsOn).toBe(true);
+  });
+
+  it('round-trips look + rain override', () => {
+    const state = { ...lookPackToEnvPatch(LOOK_PACKS.noir), rainIntensity: 40 };
+    const url = buildLookUrl({ lookId: 'noir', state }, BASE);
+    const search = new URL(url).search;
+    expect(search).toContain('look=noir');
+    expect(search).toContain('rain=40');
+    const resolved = resolveLookSearch(search);
+    expect(resolved?.lookId).toBe('noir');
+    expect(resolved?.patch.rainIntensity).toBe(40);
+    expect(resolved?.patch.tint).toBe(LOOK_PACKS.noir.tint);
+  });
+
+  it('round-trips a custom grade without a named look', () => {
+    const state = {
+      ...lookPackToEnvPatch(LOOK_PACKS.clear),
+      rainIntensity: 40,
+      saturation: 0.8,
+      timeOfDay: 'night' as const,
+      nightIntensity: 1,
+      headlightsOn: true,
+    };
+    const url = buildLookUrl({ lookId: null, state }, BASE);
+    const search = new URL(url).search;
+    expect(search).not.toContain('look=');
+    expect(search).toContain('rain=40');
+    expect(search).toContain('tod=night');
+    const resolved = resolveLookSearch(search);
+    expect(resolved?.lookId).toBeNull();
+    expect(resolved?.patch.rainIntensity).toBe(40);
+    expect(resolved?.patch.saturation).toBeCloseTo(0.8);
+    expect(resolved?.patch.timeOfDay).toBe('night');
+    expect(resolved?.patch.headlightsOn).toBe(true);
+  });
+
+  it('preserves renderer flags while replacing stale look keys', () => {
+    const state = lookPackToEnvPatch(LOOK_PACKS.arctic);
+    const url = buildLookUrl(
+      { lookId: 'arctic', state },
+      'https://example.com/streetview?look=noir&rain=40&renderer=webgl',
+    );
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('look')).toBe('arctic');
+    expect(parsed.searchParams.get('rain')).toBeNull();
+    expect(parsed.searchParams.get('renderer')).toBe('webgl');
+  });
+
+  it('hasLookSearchParams ignores location-only queries', () => {
+    expect(hasLookSearchParams('?lat=1&lng=2')).toBe(false);
+    expect(hasLookSearchParams('?look=noir')).toBe(true);
+    expect(hasLookSearchParams('?rain=10')).toBe(true);
+    expect(resolveLookSearch('?lat=1&lng=2')).toBeNull();
+  });
+
+  it('resolveLookEnv from URL matches pack math for every look id', () => {
+    for (const pack of Object.values(LOOK_PACKS)) {
+      const url = buildLookUrl({ lookId: pack.id, state: lookPackToEnvPatch(pack) }, BASE);
+      const again = resolveLookSearch(new URL(url).search);
+      expect(again?.lookId).toBe(pack.id);
+      expect(again?.patch).toEqual(lookPackToEnvPatch(pack));
+    }
+  });
+});

--- a/src/utils/lookLink.ts
+++ b/src/utils/lookLink.ts
@@ -1,0 +1,283 @@
+/**
+ * lookLink.ts — shareable look / scene-pack URL params.
+ *
+ * Lives beside location deep links (`deepLink.ts`). Location keys
+ * (lat/lng/heading/pitch/zoom/pano) are never overwritten here.
+ *
+ *   ?look=noir
+ *   ?look=noir&rain=40
+ *   ?tod=night&sat=0.4&con=1.5   (custom, no named look)
+ */
+
+import {
+  LOOK_PACKS,
+  diffLookOverrides,
+  getLookPack,
+  isLookId,
+  resolveLookEnv,
+  type LookEnvPatch,
+  type LookEnvSnapshot,
+  type LookId,
+} from '../config/lookPacks';
+import type { LookTimeOfDay } from '../config/lookPacks';
+
+export const LOOK_PARAM_KEYS = {
+  look: 'look',
+  rain: 'rain',
+  snow: 'snow',
+  wind: 'wind',
+  fog: 'fog',
+  tod: 'tod',
+  vibrance: 'vib',
+  saturation: 'sat',
+  contrast: 'con',
+  exposure: 'exp',
+  temperature: 'temp',
+  tint: 'tint',
+  night: 'night',
+  headlights: 'hl',
+  highBeam: 'beam',
+  dome: 'dome',
+  wipers: 'wipers',
+} as const;
+
+const TIME_OF_DAY: readonly LookTimeOfDay[] = ['day', 'sunrise', 'sunset', 'night'];
+
+export interface LookUrlParams {
+  look?: LookId;
+  rain?: number;
+  snow?: number;
+  wind?: number;
+  fog?: number;
+  tod?: LookTimeOfDay;
+  vibrance?: number;
+  saturation?: number;
+  contrast?: number;
+  exposure?: number;
+  temperature?: number;
+  tint?: number;
+  night?: number;
+  headlights?: boolean;
+  highBeam?: boolean;
+  dome?: boolean;
+  wipers?: boolean;
+}
+
+const LOOK_SEARCH_KEYS = new Set<string>(Object.values(LOOK_PARAM_KEYS));
+
+function parseFinite(raw: string | null): number | undefined {
+  if (raw == null || raw === '') return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, n));
+}
+
+function parseBool(raw: string | null): boolean | undefined {
+  if (raw == null || raw === '') return undefined;
+  if (raw === '1' || raw === 'true' || raw === 'on') return true;
+  if (raw === '0' || raw === 'false' || raw === 'off') return false;
+  return undefined;
+}
+
+function formatGrade(n: number): string {
+  return n.toFixed(2).replace(/\.?0+$/, (m) => (m.startsWith('.') ? '' : m));
+}
+
+function formatBool(v: boolean): string {
+  return v ? '1' : '0';
+}
+
+export function parseLookParams(search: string = ''): LookUrlParams {
+  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+  const lookRaw = params.get(LOOK_PARAM_KEYS.look);
+  const todRaw = params.get(LOOK_PARAM_KEYS.tod);
+
+  const rain = parseFinite(params.get(LOOK_PARAM_KEYS.rain));
+  const snow = parseFinite(params.get(LOOK_PARAM_KEYS.snow));
+  const wind = parseFinite(params.get(LOOK_PARAM_KEYS.wind));
+  const fog = parseFinite(params.get(LOOK_PARAM_KEYS.fog));
+  const vibrance = parseFinite(params.get(LOOK_PARAM_KEYS.vibrance));
+  const saturation = parseFinite(params.get(LOOK_PARAM_KEYS.saturation));
+  const contrast = parseFinite(params.get(LOOK_PARAM_KEYS.contrast));
+  const exposure = parseFinite(params.get(LOOK_PARAM_KEYS.exposure));
+  const temperature = parseFinite(params.get(LOOK_PARAM_KEYS.temperature));
+  const tint = parseFinite(params.get(LOOK_PARAM_KEYS.tint));
+  const night = parseFinite(params.get(LOOK_PARAM_KEYS.night));
+
+  const parsed: LookUrlParams = {};
+  if (isLookId(lookRaw)) parsed.look = lookRaw;
+  if (todRaw && (TIME_OF_DAY as readonly string[]).includes(todRaw)) {
+    parsed.tod = todRaw as LookTimeOfDay;
+  }
+  if (rain !== undefined) parsed.rain = clamp(rain, 0, 100);
+  if (snow !== undefined) parsed.snow = clamp(snow, 0, 100);
+  if (wind !== undefined) parsed.wind = clamp(wind, -100, 100);
+  if (fog !== undefined) parsed.fog = clamp(fog, 0, 100);
+  if (vibrance !== undefined) parsed.vibrance = clamp(vibrance, 0, 2);
+  if (saturation !== undefined) parsed.saturation = clamp(saturation, 0, 2);
+  if (contrast !== undefined) parsed.contrast = clamp(contrast, 0.5, 2);
+  if (exposure !== undefined) parsed.exposure = clamp(exposure, -2, 2);
+  if (temperature !== undefined) parsed.temperature = clamp(temperature, -1, 1);
+  if (tint !== undefined) parsed.tint = clamp(tint, -1, 1);
+  if (night !== undefined) parsed.night = clamp(night, 0, 1);
+
+  const headlights = parseBool(params.get(LOOK_PARAM_KEYS.headlights));
+  const highBeam = parseBool(params.get(LOOK_PARAM_KEYS.highBeam));
+  const dome = parseBool(params.get(LOOK_PARAM_KEYS.dome));
+  const wipers = parseBool(params.get(LOOK_PARAM_KEYS.wipers));
+  if (headlights !== undefined) parsed.headlights = headlights;
+  if (highBeam !== undefined) parsed.highBeam = highBeam;
+  if (dome !== undefined) parsed.dome = dome;
+  if (wipers !== undefined) parsed.wipers = wipers;
+
+  return parsed;
+}
+
+/** True when the query string carries at least one look / weather / grade key. */
+export function hasLookSearchParams(search: string = ''): boolean {
+  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+  for (const key of params.keys()) {
+    if (LOOK_SEARCH_KEYS.has(key)) return true;
+  }
+  return false;
+}
+
+export function lookUrlToOverrides(parsed: LookUrlParams): Partial<LookEnvPatch> {
+  const o: Partial<LookEnvPatch> = {};
+  if (parsed.tod) o.timeOfDay = parsed.tod;
+  if (parsed.rain !== undefined) o.rainIntensity = parsed.rain;
+  if (parsed.snow !== undefined) o.snowIntensity = parsed.snow;
+  if (parsed.wind !== undefined) o.wind = parsed.wind;
+  if (parsed.fog !== undefined) o.fogDensity = parsed.fog;
+  if (parsed.vibrance !== undefined) o.vibrance = parsed.vibrance;
+  if (parsed.saturation !== undefined) o.saturation = parsed.saturation;
+  if (parsed.contrast !== undefined) o.contrast = parsed.contrast;
+  if (parsed.exposure !== undefined) o.exposure = parsed.exposure;
+  if (parsed.temperature !== undefined) o.temperature = parsed.temperature;
+  if (parsed.tint !== undefined) o.tint = parsed.tint;
+  if (parsed.night !== undefined) o.nightIntensity = parsed.night;
+  if (parsed.headlights !== undefined) o.headlightsOn = parsed.headlights;
+  if (parsed.highBeam !== undefined) o.highBeam = parsed.highBeam;
+  if (parsed.dome !== undefined) o.domeLightOn = parsed.dome;
+  if (parsed.wipers !== undefined) o.wipersEnabled = parsed.wipers;
+  return o;
+}
+
+export interface ResolvedLookBoot {
+  lookId: LookId | null;
+  patch: LookEnvPatch;
+}
+
+/**
+ * Named look (if any) plus overrides. Missing look + no overrides → null
+ * so the provider keeps its built-in defaults.
+ */
+export function resolveLookSearch(search: string = ''): ResolvedLookBoot | null {
+  if (!hasLookSearchParams(search)) return null;
+  const parsed = parseLookParams(search);
+  const pack = getLookPack(parsed.look ?? null);
+  const overrides = lookUrlToOverrides(parsed);
+  if (!pack && Object.keys(overrides).length === 0) return null;
+  return {
+    lookId: pack ? pack.id : null,
+    patch: resolveLookEnv(pack, overrides),
+  };
+}
+
+function setOrDelete(url: URL, key: string, value: string | undefined): void {
+  if (value === undefined) url.searchParams.delete(key);
+  else url.searchParams.set(key, value);
+}
+
+/** Write look keys onto a URL, preserving location / renderer flags. */
+export function applyLookSearchParams(url: URL, params: LookUrlParams): void {
+  const K = LOOK_PARAM_KEYS;
+  setOrDelete(url, K.look, params.look);
+  setOrDelete(url, K.rain, params.rain !== undefined ? String(Math.round(params.rain)) : undefined);
+  setOrDelete(url, K.snow, params.snow !== undefined ? String(Math.round(params.snow)) : undefined);
+  setOrDelete(url, K.wind, params.wind !== undefined ? String(Math.round(params.wind)) : undefined);
+  setOrDelete(url, K.fog, params.fog !== undefined ? String(Math.round(params.fog)) : undefined);
+  setOrDelete(url, K.tod, params.tod);
+  setOrDelete(url, K.vibrance, params.vibrance !== undefined ? formatGrade(params.vibrance) : undefined);
+  setOrDelete(url, K.saturation, params.saturation !== undefined ? formatGrade(params.saturation) : undefined);
+  setOrDelete(url, K.contrast, params.contrast !== undefined ? formatGrade(params.contrast) : undefined);
+  setOrDelete(url, K.exposure, params.exposure !== undefined ? formatGrade(params.exposure) : undefined);
+  setOrDelete(url, K.temperature, params.temperature !== undefined ? formatGrade(params.temperature) : undefined);
+  setOrDelete(url, K.tint, params.tint !== undefined ? formatGrade(params.tint) : undefined);
+  setOrDelete(url, K.night, params.night !== undefined ? formatGrade(params.night) : undefined);
+  setOrDelete(url, K.headlights, params.headlights !== undefined ? formatBool(params.headlights) : undefined);
+  setOrDelete(url, K.highBeam, params.highBeam !== undefined ? formatBool(params.highBeam) : undefined);
+  setOrDelete(url, K.dome, params.dome !== undefined ? formatBool(params.dome) : undefined);
+  setOrDelete(url, K.wipers, params.wipers !== undefined ? formatBool(params.wipers) : undefined);
+}
+
+function overridesToUrlParams(o: Partial<LookEnvPatch>): LookUrlParams {
+  const p: LookUrlParams = {};
+  if (o.timeOfDay) p.tod = o.timeOfDay;
+  if (o.rainIntensity !== undefined) p.rain = o.rainIntensity;
+  if (o.snowIntensity !== undefined) p.snow = o.snowIntensity;
+  if (o.wind !== undefined) p.wind = o.wind;
+  if (o.fogDensity !== undefined) p.fog = o.fogDensity;
+  if (o.vibrance !== undefined) p.vibrance = o.vibrance;
+  if (o.saturation !== undefined) p.saturation = o.saturation;
+  if (o.contrast !== undefined) p.contrast = o.contrast;
+  if (o.exposure !== undefined) p.exposure = o.exposure;
+  if (o.temperature !== undefined) p.temperature = o.temperature;
+  if (o.tint !== undefined) p.tint = o.tint;
+  if (o.nightIntensity !== undefined) p.night = o.nightIntensity;
+  if (o.headlightsOn !== undefined) p.headlights = o.headlightsOn;
+  if (o.highBeam !== undefined) p.highBeam = o.highBeam;
+  if (o.domeLightOn !== undefined) p.dome = o.domeLightOn;
+  if (o.wipersEnabled !== undefined) p.wipers = o.wipersEnabled;
+  return p;
+}
+
+export interface BuildLookUrlInput {
+  lookId?: LookId | null;
+  state: LookEnvSnapshot;
+}
+
+/**
+ * Encode the current look. If `lookId` matches a pack, emit `?look=id` plus
+ * only the sliders that differ. Otherwise emit a full custom param set.
+ */
+export function lookStateToUrlParams(input: BuildLookUrlInput): LookUrlParams {
+  const pack = getLookPack(input.lookId ?? null);
+  if (pack) {
+    return { look: pack.id, ...overridesToUrlParams(diffLookOverrides(pack, input.state)) };
+  }
+  // Custom grade/weather: emit only diffs from the Clear defaults so a dry
+  // daylight scene produces an empty look query.
+  return overridesToUrlParams(diffLookOverrides(LOOK_PACKS.clear, input.state));
+}
+
+export function buildLookUrl(
+  input: BuildLookUrlInput,
+  base: string = typeof window !== 'undefined' ? window.location.href : 'https://example.com/',
+): string {
+  const url = new URL(base);
+  // Clear previous look keys so a shorter `?look=noir` doesn't leave stale rain=.
+  for (const key of LOOK_SEARCH_KEYS) url.searchParams.delete(key);
+  applyLookSearchParams(url, lookStateToUrlParams(input));
+  return url.toString();
+}
+
+/** Semantic round-trip: parse(build(state)) resolves to the same env patch. */
+export function resolveLookUrlParams(params: LookUrlParams): LookEnvPatch {
+  const pack = getLookPack(params.look ?? null);
+  return resolveLookEnv(pack, lookUrlToOverrides(params));
+}
+
+/** Safe window.location boot helper (SSR / vitest: no throw). */
+export function readBootLook(
+  search: string = typeof window !== 'undefined' ? window.location.search : '',
+): ResolvedLookBoot | null {
+  try {
+    return resolveLookSearch(search);
+  } catch {
+    return null;
+  }
+}

--- a/weekly_plan.md
+++ b/weekly_plan.md
@@ -47,6 +47,7 @@
 - **Problem**: Weather / time-of-day shader modes (rain, night, sunset, etc.) could use more design work
 - **Priority**: Medium
 - **Status**: **Partial** (epic #171) — night + snow direction parity landed; broader rain/sunset cohesion polish remains open for a dedicated design pass.
+- **Follow-up**: Named looks + WebGL must-match haze/rain-darken shipped (look packs). Remaining art is reference PNG capture on WebGPU Chrome into `docs/looks/<id>-webgpu.png`.
 - **Notes**: Polish look and feel of rain, night, sunset/sunrise, fog, and related atmosphere presets — tuning uniforms, color grading, and visual cohesion across modes
 
 ---
@@ -57,7 +58,7 @@
 |------|-------|
 | Cruise hold-pause polish (#6 above) | Hold-pause is shipped; tune feel via `panoramaStability.ts` + probe |
 | Gauge SSOT / compact HUD (#7) | See foundation split: `CarModeView` hooks under `src/views/car/` |
-| Shader design pass (#8) | Rain/sunset cohesion beyond night/snow parity |
+| Shader design pass (#8) | **Looks pack** — named looks + WebGL haze/rain-darken parity; see `docs/looks/README.md` |
 | Foundation module splits | `GlobeView` + `MobileUI` contracts — see latest foundation PR |
 
 For architecture and danger zones, read [`AGENTS.md`](./AGENTS.md) first.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a creator-facing **Looks** layer on top of the existing weather + color-grading stack, without new billable APIs or a uniform-layout bump.

## What shipped

**8 named looks** (Clear + 7 artistic packs) combining weather, grading, time of day, and vehicle lights:

| Id | Intent |
|----|--------|
| `clear` | Reset / daylight before state |
| `noir` | Ink-black night, wet streets, headlights |
| `teal-orange` | Travel-poster split tone at sunset |
| `bleach-bypass` | Silver-retention newsreel, overcast sun kill |
| `golden-hour` | Honey sunrise, soft haze |
| `storm` | GRAPHICS.md §3 storm + cool underexpose |
| `arctic` | High-key snow, cold air |
| `neon-rain` | Wet night, magenta/cyan, high beam |

Grading is still the 6-knob chain (vibrance → saturation → contrast → temperature/tint → exposure) with **ACES last**. No 3D LUT textures. Weather uniforms stay **40 floats**.

**Look bible:** [`docs/looks/README.md`](docs/looks/README.md) with before/after notes, curve stops, and committed SVG palette cards. GPU panorama screenshots (`<id>-webgpu.png`) need WebGPU Chrome capture — this environment has no adapter.

**Creator UX**
- Looks panel (toolbar **Looks**, shortcut `K`) with copy-as-URL
- Same packs in the Weather panel strip
- Shareable deep links alongside location params: `?look=noir`, `?look=noir&rain=40`, `?tod=night&sat=0.4`

**WebGL must-match** (`?effect=weather|night|fog`)
- Night floor and precip Y sign (already shared)
- Overcast sun kill (CPU `weatherCohesion`, already shared)
- Rain darken now `mix(0.22, 0.10, night)` (was 0.045/0.020)
- Humidity haze distance + color mix (4-tap blur remains WebGPU-only)

Reduced motion still zeroes cinematic DOF/motion blur (slots 38/39) and **does not** strip look grading.

## Acceptance

- [x] ≥4 named looks with before/after notes
- [x] WebGL weather/night/fog matches directionally on night floor, precip fall, overcast sun kill (plus rain darken + haze mix)
- [x] Look URL params round-trip (`lookLink.test.ts`)
- [x] Reduced motion does not break looks
- [x] No new billable APIs
- [x] Uniform layout stays 40 floats

## Tests

- `src/config/lookPacks.test.ts`
- `src/utils/lookLink.test.ts`
- `src/components/LooksPanel.test.tsx`
- `src/renderer/webglLookParity.test.ts`
- `e2e/boot.spec.ts` (`?look=noir` smoke)

`npm run typecheck` and `npm run lint` pass. Full Vitest is green aside from `App.test.tsx` maps-key assertions that expect an empty key but see a redacted runtime key in this environment (pre-existing when a Maps key is injected).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba21e127-ee48-4529-8f4a-c5844395391b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba21e127-ee48-4529-8f4a-c5844395391b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added named artistic looks combining weather, lighting, time of day, and color grading.
  * Added a Looks panel with preset selection, active-state indicators, reduced-motion support, and shareable URLs.
  * Added toolbar and keyboard shortcut access for opening and closing the Looks panel.
  * Added look presets to the Weather panel.

* **Enhancements**
  * Improved WebGL fallback visuals with humidity haze and consistent rain darkening.
  * Preserved location and other URL settings when sharing looks.

* **Documentation**
  * Added guides for named looks, URL links, accessibility behavior, and renderer parity.

* **Tests**
  * Added coverage for look selection, URL sharing, startup links, reduced motion, and rendering parity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->