### PR TITLE
Add Return to Street View button during Cesium globe load

### DIFF
--- a/src/app/shell/ConnectedChrome.tsx
+++ b/src/app/shell/ConnectedChrome.tsx
@@ -38,6 +38,7 @@ import {
   ComparisonView,
 } from '../../components';
 import StorageManagementPanel from '../../components/StorageManagementPanel';
+import GlobeReturnButton from '../../components/GlobeReturnButton';
 
 const GlobeView = lazy(() => import('../../components/GlobeView'));
 
@@ -337,6 +338,7 @@ export function ConnectedChrome({
         viewMode={viewMode}
         toggleViewMode={toggleViewMode}
         onGlobeToggle={globeMode.toggle}
+        isGlobeEngaged={globeMode.isEngaged}
         search={search}
       />
 
@@ -525,7 +527,11 @@ export function ConnectedChrome({
             justifyContent: 'center',
             color: '#fff',
             fontFamily: 'system-ui, sans-serif',
+            gap: 20,
           }}
+          onMouseDown={(e) => e.stopPropagation()}
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
         >
           <div
             style={{
@@ -535,10 +541,13 @@ export function ConnectedChrome({
               border: '4px solid rgba(255,255,255,0.15)',
               borderTopColor: '#4CAF50',
               animation: 'spin 0.8s linear infinite',
-              marginBottom: 20,
             }}
           />
           <div style={{ fontSize: 16, opacity: 0.85 }}>Loading Globe…</div>
+          <div style={{ fontSize: 13, opacity: 0.65, maxWidth: 320, textAlign: 'center' }}>
+            Cesium is loading from the CDN. You can return to Street View anytime.
+          </div>
+          <GlobeReturnButton onClick={globeMode.cancel} />
           <style>{`@keyframes spin{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}`}</style>
         </div>
       )}
@@ -555,6 +564,7 @@ export function ConnectedChrome({
             onTeleportRequest={handleGlobeTeleport}
             onEnterComplete={globeMode.onEnterComplete}
             onExitComplete={globeMode.onExitComplete}
+            onRequestExit={globeMode.cancel}
             onStartJourney={handleStartJourney}
           />
         </Suspense>

--- a/src/components/AppToolbar.tsx
+++ b/src/components/AppToolbar.tsx
@@ -33,6 +33,7 @@ export interface AppToolbarProps {
   viewMode: 'freelook' | 'car';
   toggleViewMode: () => void;
   onGlobeToggle: () => void;
+  isGlobeEngaged?: boolean;
   search?: UsePlaceSearchResult;
 }
 
@@ -67,6 +68,7 @@ const AppToolbar: React.FC<AppToolbarProps> = ({
   viewMode,
   toggleViewMode,
   onGlobeToggle,
+  isGlobeEngaged = false,
   search,
 }) => {
   return (
@@ -186,11 +188,11 @@ const AppToolbar: React.FC<AppToolbarProps> = ({
         {viewMode === 'car' ? '🚶 Free Look' : '🚗 Car Mode'}
       </button>
       <button
-        className="control-btn"
-        style={{ minWidth: 110 }}
+        className={`control-btn${isGlobeEngaged ? ' disconnect' : ''}`}
+        style={{ minWidth: 110, backgroundColor: isGlobeEngaged ? 'rgba(0,204,255,0.25)' : undefined }}
         onClick={e => { e.stopPropagation(); onGlobeToggle(); }}
       >
-        🌍 Globe
+        {isGlobeEngaged ? '🗺️ Street View' : '🌍 Globe'}
       </button>
     </div>
   );

--- a/src/components/GlobeReturnButton.tsx
+++ b/src/components/GlobeReturnButton.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+interface GlobeReturnButtonProps {
+  onClick: () => void;
+  style?: React.CSSProperties;
+}
+
+/** Escape hatch while Cesium loads or globe mode is active. */
+const GlobeReturnButton: React.FC<GlobeReturnButtonProps> = ({ onClick, style }) => (
+  <button
+    type="button"
+    aria-label="Return to Street View"
+    onClick={(e) => {
+      e.stopPropagation();
+      onClick();
+    }}
+    onMouseDown={(e) => e.stopPropagation()}
+    onKeyDown={(e) => e.stopPropagation()}
+    style={{
+      padding: '10px 18px',
+      backgroundColor: 'rgba(0,0,0,0.85)',
+      border: '1px solid rgba(0,204,255,0.5)',
+      borderRadius: 8,
+      color: '#00CCFF',
+      fontSize: 14,
+      fontWeight: 600,
+      fontFamily: 'system-ui, sans-serif',
+      cursor: 'pointer',
+      pointerEvents: 'auto',
+      boxShadow: '0 4px 24px rgba(0,0,0,0.45)',
+      ...style,
+    }}
+  >
+    🗺️ Return to Street View
+  </button>
+);
+
+export default GlobeReturnButton;

--- a/src/components/GlobeView.tsx
+++ b/src/components/GlobeView.tsx
@@ -27,6 +27,7 @@ import {
 } from './globe/globeTypes';
 import { syncGlobeBookmarkEntities, syncGlobePoiEntities } from './globe/globePoiLayer';
 import { syncGlobeAutopilotVisuals } from './globe/globeAutopilot';
+import GlobeReturnButton from './GlobeReturnButton';
 
 import type { CesiumCartesian2, CesiumEntity, CesiumImageryLayer, CesiumScreenSpaceEventHandler, CesiumTerrainProvider, CesiumViewer } from '../types/cesium';
 
@@ -43,6 +44,7 @@ interface GlobeViewProps {
     onTeleportRequest: (lat: number, lng: number) => void;
     onEnterComplete: () => void;
     onExitComplete: () => void;
+    onRequestExit: () => void;
     /** Called with waypoints when user starts autopilot journey */
     onStartJourney?: (waypoints: { lat: number; lng: number }[]) => void;
 }
@@ -58,6 +60,7 @@ const GlobeView: React.FC<GlobeViewProps> = ({
     onTeleportRequest,
     onEnterComplete,
     onExitComplete,
+    onRequestExit,
     onStartJourney,
 }) => {
     const containerRef = useRef<HTMLDivElement>(null);
@@ -525,6 +528,24 @@ const GlobeView: React.FC<GlobeViewProps> = ({
 
     return (
         <>
+            {/* Prominent escape hatch — toolbar sits behind the globe overlay */}
+            {visible && (
+                <div
+                    style={{
+                        position: 'fixed',
+                        top: 16,
+                        left: 16,
+                        zIndex: 210,
+                        pointerEvents: 'auto',
+                    }}
+                    onMouseDown={(e) => e.stopPropagation()}
+                    onClick={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => e.stopPropagation()}
+                >
+                    <GlobeReturnButton onClick={onRequestExit} />
+                </div>
+            )}
+
             {/* Full-screen Cesium container */}
             <div
                 ref={containerRef}
@@ -584,7 +605,8 @@ const GlobeView: React.FC<GlobeViewProps> = ({
                     </span>
                     <span style={{ color: '#666' }}>|</span>
                     <span>
-                        Press <kbd style={{ background: '#333', padding: '1px 5px', borderRadius: 3 }}>Shift+G</kbd> to return
+                        Press <kbd style={{ background: '#333', padding: '1px 5px', borderRadius: 3 }}>Esc</kbd> or use
+                        <strong> Return to Street View</strong> (top-left)
                     </span>
                 </div>
             )}
@@ -674,21 +696,28 @@ const GlobeView: React.FC<GlobeViewProps> = ({
                 </div>
             )}
 
-            {/* Loading indicator */}
+            {/* Loading indicator (shown if GlobeView mounts before SDK handoff completes) */}
             {transition === 'loading' && (
                 <div style={{
                     position: 'fixed',
                     inset: 0,
                     zIndex: 200,
                     display: 'flex',
+                    flexDirection: 'column',
                     alignItems: 'center',
                     justifyContent: 'center',
+                    gap: 20,
                     backgroundColor: 'rgba(0,0,0,0.6)',
                     color: '#fff',
                     fontSize: '18px',
                     fontFamily: 'system-ui, sans-serif',
-                }}>
-                    🌍 Loading Globe…
+                }}
+                onMouseDown={(e) => e.stopPropagation()}
+                onClick={(e) => e.stopPropagation()}
+                onKeyDown={(e) => e.stopPropagation()}
+                >
+                    <div>🌍 Loading Globe…</div>
+                    <GlobeReturnButton onClick={onRequestExit} />
                 </div>
             )}
         </>

--- a/src/hooks/useAppKeyboardShortcuts.ts
+++ b/src/hooks/useAppKeyboardShortcuts.ts
@@ -42,8 +42,10 @@ export interface UseAppKeyboardShortcutsOptions {
   setIsCruiseMode: (v: boolean) => void;
   globeMode: {
     isActive: boolean;
+    isEngaged: boolean;
     transition: string;
     toggle: () => void;
+    cancel: () => void;
     deactivate: () => void;
   };
   announce: (msg: string) => void;
@@ -196,6 +198,9 @@ export function buildAppKeyboardShortcuts(options: UseAppKeyboardShortcutsOption
       action: () => {
         setIsLooksPanelOpen(!isLooksPanelOpen);
         announce(`Looks panel ${!isLooksPanelOpen ? 'opened' : 'closed'}`);
+      },
+    },
+    {
       key: 'F',
       modifier: 'shift',
       description: 'Toggle cinema mode',
@@ -261,8 +266,9 @@ export function buildAppKeyboardShortcuts(options: UseAppKeyboardShortcutsOption
       modifier: 'shift',
       description: 'Toggle Globe Mode',
       action: () => {
+        const wasEngaged = globeMode.isEngaged;
         globeMode.toggle();
-        announce(`Globe mode ${globeMode.transition === 'active' ? 'off' : 'on'}`);
+        announce(`Globe mode ${wasEngaged ? 'off' : 'on'}`);
       },
     },
     {
@@ -270,7 +276,7 @@ export function buildAppKeyboardShortcuts(options: UseAppKeyboardShortcutsOption
       description: 'Close panels or exit cinema mode',
       action: () => {
         if (isCinemaMode) { exitCinemaMode(); return; }
-        if (globeMode.isActive) { globeMode.deactivate(); return; }
+        if (globeMode.isEngaged) { globeMode.cancel(); return; }
         if (isLooksPanelOpen) { setIsLooksPanelOpen(false); return; }
         if (isWeatherPanelOpen) { setIsWeatherPanelOpen(false); return; }
         if (isAccessibilityPanelOpen) setIsAccessibilityPanelOpen(false);

--- a/src/hooks/useGlobeMode.ts
+++ b/src/hooks/useGlobeMode.ts
@@ -50,8 +50,13 @@ export interface GlobeModeControls {
     isVisible: boolean;
     /** True only when fully entered and ready for interaction */
     isActive: boolean;
+    /** True while loading, entering, active, or exiting (anything except inactive). */
+    isEngaged: boolean;
     activate: () => Promise<void>;
+    /** Begin exit animation when active/entering; no-op while loading/inactive. */
     deactivate: () => void;
+    /** Abort immediately from loading, or begin exit from entering/active. */
+    cancel: () => void;
     toggle: () => void;
     onEnterComplete: () => void;
     onExitComplete: () => void;
@@ -60,6 +65,7 @@ export interface GlobeModeControls {
 export function useGlobeMode(): GlobeModeControls {
     const [transition, setTransition] = useState<GlobeTransition>('inactive');
     const transitionRef = useRef<GlobeTransition>('inactive');
+    const activateGenerationRef = useRef(0);
 
     const setT = useCallback((t: GlobeTransition) => {
         transitionRef.current = t;
@@ -68,26 +74,40 @@ export function useGlobeMode(): GlobeModeControls {
 
     const activate = useCallback(async () => {
         if (transitionRef.current !== 'inactive') return;
+        const generation = ++activateGenerationRef.current;
         setT('loading');
         try {
             await loadCesiumSDK();
         } catch (err) {
             console.error(err);
-            setT('inactive');
+            if (activateGenerationRef.current === generation) setT('inactive');
             return;
         }
+        // User may have cancelled while the CDN script was still loading.
+        if (activateGenerationRef.current !== generation) return;
         setT('entering');
     }, [setT]);
 
     const deactivate = useCallback(() => {
-        if (transitionRef.current !== 'active') return;
+        const t = transitionRef.current;
+        if (t === 'active' || t === 'entering') setT('exiting');
+    }, [setT]);
+
+    const cancel = useCallback(() => {
+        const t = transitionRef.current;
+        if (t === 'inactive' || t === 'exiting') return;
+        activateGenerationRef.current += 1;
+        if (t === 'loading') {
+            setT('inactive');
+            return;
+        }
         setT('exiting');
     }, [setT]);
 
     const toggle = useCallback(() => {
         if (transitionRef.current === 'inactive') activate();
-        else if (transitionRef.current === 'active') deactivate();
-    }, [activate, deactivate]);
+        else cancel();
+    }, [activate, cancel]);
 
     const onEnterComplete = useCallback(() => {
         if (transitionRef.current === 'entering') setT('active');
@@ -101,8 +121,10 @@ export function useGlobeMode(): GlobeModeControls {
         transition,
         isVisible: transition !== 'inactive' && transition !== 'loading',
         isActive: transition === 'active',
+        isEngaged: transition !== 'inactive',
         activate,
         deactivate,
+        cancel,
         toggle,
         onEnterComplete,
         onExitComplete,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cesium globe mode loads the ~4MB SDK from a CDN, which can take a while. During that load the full-screen overlay covered the UI with no way to get back to Street View except refreshing.

This adds a clear **Return to Street View** escape hatch:

- **`useGlobeMode.cancel()`** — aborts an in-flight CDN load (generation-guarded) or begins exit from entering/active globe mode
- **`GlobeReturnButton`** — shared button shown on the loading overlay and pinned top-left while the globe is visible
- **Toolbar** — Globe button label switches to **Street View** while globe mode is engaged
- **Keyboard** — `Esc` cancels globe mode from loading/entering/active (not only when fully active)

Also fixes a pre-existing syntax error in `useAppKeyboardShortcuts.ts` where the looks-panel and cinema-mode shortcuts were merged.

## Test plan

- [x] `npm run typecheck` passes
- [ ] Click **Globe** → during "Loading Globe…" click **Return to Street View** → overlay dismisses, Street View remains interactive
- [ ] Enter globe mode → click top-left **Return to Street View** → exit animation (or immediate teardown) and return to panorama
- [ ] Press `Esc` during globe loading → returns to Street View
- [ ] Toolbar shows **Street View** label while globe is engaged (when visible behind overlay)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38115d63-71fe-4020-a074-20048b650a3f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38115d63-71fe-4020-a074-20048b650a3f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a prominent return button for exiting Globe mode and returning to Street View.
  - Globe mode can now be canceled while loading, with clear loading and return guidance.
  - Updated toolbar labeling and styling to indicate whether Globe mode is active.
  - Pressing Escape now exits or cancels Globe mode.
- **Bug Fixes**
  - Prevented unintended interactions while Globe mode is loading or during exit transitions.
  - Improved handling of canceled or failed Globe mode loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->