### PR TITLE
Polish car cabin lighting for night and daylight

### DIFF
--- a/src/car/CarInterior.ts
+++ b/src/car/CarInterior.ts
@@ -63,8 +63,8 @@ export class CarInterior implements CarInteriorAssemblyHost {
     public ambientLight!: THREE.AmbientLight;
     public hemisphereLight!: THREE.HemisphereLight;
     public overheadLight!: THREE.DirectionalLight;
-    public leftWindowLight!: THREE.PointLight;
-    public rightWindowLight!: THREE.PointLight;
+    public leftWindowLight: THREE.PointLight | undefined;
+    public rightWindowLight: THREE.PointLight | undefined;
     public instrumentClusterMat!: THREE.MeshStandardMaterial;
     public centerDisplayMat!: THREE.MeshStandardMaterial;
     public windshieldGlassMesh!: THREE.Mesh;
@@ -169,18 +169,20 @@ export class CarInterior implements CarInteriorAssemblyHost {
 
     public setEnvironmentFromPano(equirect: HTMLCanvasElement, centerHeading: number): void {
         this.panoEnvironment.setFromEquirect(equirect, centerHeading);
+        this.panoEnvironment.setIntensity(this.lightingManager.getIblIntensity());
     }
 
     public setSunPosition(azimuth: number, altitude: number): void {
         this.lightingManager.setSunState(azimuth, altitude);
         const night = this.lightingManager.getSunNightFactor();
-        this.panoEnvironment.setIntensity(1 - night * 0.7);
+        this.panoEnvironment.setIntensity(this.lightingManager.getIblIntensity());
         this.locationPanel?.setNightGlow(night);
         this.centerDisplay?.setNightGlow(night);
         this.lastSunAzimuth = azimuth;
         this.lastSunAltitude = altitude;
         const sunVisibility = Math.max(0, Math.min(1, altitude / 0.35));
         this.animator?.setAmbientState({ sunVisibility });
+        this.animator?.setNightFactor(this.lightingManager.getEffectiveNight());
     }
 
     public setLocationInfo(info: PanoLocationInfo | null): void {
@@ -301,6 +303,8 @@ export class CarInterior implements CarInteriorAssemblyHost {
 
     public setInteriorLighting(headlightsOn: boolean, nightIntensity: number, domeLightOn: boolean): void {
         this.lightingManager.setInteriorLighting(headlightsOn, nightIntensity, domeLightOn);
+        this.panoEnvironment.setIntensity(this.lightingManager.getIblIntensity(nightIntensity));
+        this.animator?.setNightFactor(this.lightingManager.getEffectiveNight(nightIntensity));
     }
 
     public isDomeSwitchHit(clientX: number, clientY: number): boolean {

--- a/src/car/DashboardLayout.module.css
+++ b/src/car/DashboardLayout.module.css
@@ -15,9 +15,9 @@
   --color-text-primary: rgba(255, 255, 255, 0.9);
   --color-text-muted: rgba(255, 255, 255, 0.6);
   --color-border: rgba(255, 255, 255, 0.1);
-  --color-border-hover: rgba(0, 212, 255, 0.3);
-  --color-glow: rgba(0, 212, 255, 0.2);
-  --ambient-glow: rgba(0, 212, 255, 0.45);
+  --color-border-hover: rgba(76, 175, 80, 0.3);
+  --color-glow: rgba(70, 210, 130, 0.18);
+  --ambient-glow: rgba(70, 210, 130, 0.22);
   --night-intensity: 0;
 }
 

--- a/src/car/DashboardUI.tsx
+++ b/src/car/DashboardUI.tsx
@@ -9,7 +9,7 @@
 
 import React, { useCallback, useState } from 'react';
 import styles from './DashboardUI.module.css';
-import { darkTheme, applyTheme } from './theme';
+import { darkTheme, applyTheme, clusterAmbientGlow } from './theme';
 
 // Layout primitives
 import {
@@ -274,14 +274,14 @@ export const DashboardUI: React.FC<DashboardUIProps> = ({
   };
 
   const themeStyle = applyTheme(darkTheme, {
-    ambientLightColor,
+    ambientLightColor: clusterAmbientGlow(currentVehicle, nightIntensity, ambientLightColor),
     nightIntensity,
   });
 
   return (
     <div
       className={styles.wrapper}
-      style={{ pointerEvents: 'auto' }}
+      style={{ pointerEvents: 'auto', ...themeStyle }}
       onMouseDown={stopProp}
       onMouseUp={stopProp}
       onMouseMove={stopProp}

--- a/src/car/Gauges.tsx
+++ b/src/car/Gauges.tsx
@@ -284,8 +284,8 @@ export const CircularGauge: React.FC<CircularGaugeProps> = ({
 
   const textShadow =
     nightGlow > 0.3
-      ? `0 0 ${8 + nightGlow * 16}px rgba(0, 212, 255, ${Math.min(0.3 + nightGlow * 0.5, 0.9)})`
-      : '0 0 10px rgba(0, 212, 255, 0.5)';
+      ? `0 0 ${8 + nightGlow * 16}px var(--ambient-glow, rgba(70, 210, 130, 0.4))`
+      : 'none';
 
   return (
     <div
@@ -526,9 +526,9 @@ const getGearColor = (gear: string): string => {
     case 'N':
       return '#FFC107';
     case 'D':
-      return '#00D4FF';
+      return '#4CAF50';
     default:
-      return '#00D4FF';
+      return '#4CAF50';
   }
 };
 
@@ -544,8 +544,8 @@ export const TelemetryChip: React.FC<TelemetryChipProps> = ({
   const rpmLabel = formatRpm(rpm);
   const glow =
     nightGlow > 0.3
-      ? `0 0 ${8 + nightGlow * 12}px rgba(0, 212, 255, ${Math.min(0.25 + nightGlow * 0.45, 0.85)})`
-      : '0 0 6px rgba(0, 212, 255, 0.25)';
+      ? `0 0 ${8 + nightGlow * 12}px var(--ambient-glow, rgba(70, 210, 130, 0.35))`
+      : 'none';
 
   return (
     <div

--- a/src/car/interior/CabinEmitterGlow.ts
+++ b/src/car/interior/CabinEmitterGlow.ts
@@ -1,0 +1,102 @@
+import * as THREE from 'three';
+import {
+  createDashboardGlowUniforms,
+  dashboardGlowFragmentShader,
+  dashboardGlowVertexShader,
+} from '../../shaders/dashboardGlow';
+
+export type CabinGlowKind = 'cluster' | 'dome';
+
+export interface CabinGlowSprite {
+  mesh: THREE.Mesh;
+  kind: CabinGlowKind;
+  uniforms: ReturnType<typeof createDashboardGlowUniforms> | null;
+  baseColor: THREE.Color;
+}
+
+function additiveBasic(color: THREE.Color): THREE.MeshBasicMaterial {
+  return new THREE.MeshBasicMaterial({
+    color,
+    transparent: true,
+    opacity: 0,
+    depthWrite: false,
+    depthTest: true,
+    blending: THREE.AdditiveBlending,
+    side: THREE.DoubleSide,
+    toneMapped: false,
+  });
+}
+
+function additiveShader(
+  color: THREE.Color,
+  reducedMotion: boolean,
+): { material: THREE.ShaderMaterial; uniforms: ReturnType<typeof createDashboardGlowUniforms> } {
+  const uniforms = createDashboardGlowUniforms();
+  uniforms.glowColor.value.copy(color);
+  uniforms.intensity.value = 0;
+  uniforms.pulseAmount.value = reducedMotion ? 0 : 0.08;
+  uniforms.pulseSpeed.value = 1.1;
+  uniforms.glowRadius.value = 0.28;
+  uniforms.falloff.value = 2.4;
+  const material = new THREE.ShaderMaterial({
+    uniforms: uniforms as unknown as Record<string, THREE.IUniform>,
+    vertexShader: dashboardGlowVertexShader,
+    fragmentShader: dashboardGlowFragmentShader,
+    transparent: true,
+    depthWrite: false,
+    depthTest: true,
+    blending: THREE.AdditiveBlending,
+    side: THREE.DoubleSide,
+    toneMapped: false,
+  });
+  return { material, uniforms };
+}
+
+/**
+ * Soft additive quad for cluster bezels / dome fixture.
+ * Medium: MeshBasicMaterial. High: dashboardGlow shader (tight radius).
+ * Parent to the interior group so glow stays in car-body space.
+ */
+export function createCabinGlowSprite(opts: {
+  kind: CabinGlowKind;
+  color: number;
+  width: number;
+  height: number;
+  useShader: boolean;
+  reducedMotion: boolean;
+}): CabinGlowSprite {
+  const color = new THREE.Color(opts.color);
+  let material: THREE.Material;
+  let uniforms: CabinGlowSprite['uniforms'] = null;
+  if (opts.useShader) {
+    const shader = additiveShader(color, opts.reducedMotion);
+    material = shader.material;
+    uniforms = shader.uniforms;
+  } else {
+    material = additiveBasic(color);
+  }
+  const mesh = new THREE.Mesh(new THREE.PlaneGeometry(opts.width, opts.height), material);
+  mesh.name = opts.kind === 'dome' ? 'cabinDomeGlow' : 'cabinClusterGlow';
+  mesh.renderOrder = 2;
+  mesh.frustumCulled = false;
+  return { mesh, kind: opts.kind, uniforms, baseColor: color };
+}
+
+export function setCabinGlowLevel(
+  sprite: CabinGlowSprite,
+  level: number,
+  timeSec: number,
+  reducedMotion: boolean,
+): void {
+  const t = Math.max(0, Math.min(1, level));
+  if (sprite.uniforms) {
+    sprite.uniforms.intensity.value = t;
+    sprite.uniforms.time.value = reducedMotion ? 0 : timeSec;
+    sprite.uniforms.pulseAmount.value = reducedMotion ? 0 : 0.08;
+    sprite.mesh.visible = t > 0.02;
+    return;
+  }
+  const mat = sprite.mesh.material as THREE.MeshBasicMaterial;
+  mat.opacity = t * 0.45;
+  sprite.mesh.visible = t > 0.02;
+}

--- a/src/car/interior/CarInteriorAnimator.ts
+++ b/src/car/interior/CarInteriorAnimator.ts
@@ -230,10 +230,10 @@ export class CarInteriorAnimator {
       if (rig.fuelNeedle) rig.fuelNeedle.rotation.z = needleAngle(this.fuelLevel);
       if (rig.tempNeedle) rig.tempNeedle.rotation.z = needleAngle(this.tempFrac);
 
-      const breathe = this.reducedMotion ? 0.5 : 0.5 + 0.5 * Math.sin(t * 1.6);
-      const dialGlow = 0.22 + this.nightFactor * 0.55 + breathe * 0.05 + this.rpmFrac * 0.1;
+      const breathe = this.reducedMotion ? 0 : 0.5 + 0.5 * Math.sin(t * 1.6);
+      const dialGlow = 0.16 + this.nightFactor * 0.5 + breathe * 0.04 + this.rpmFrac * 0.06;
       for (const mat of rig.dialMaterials) mat.emissiveIntensity = dialGlow;
-      const needleGlow = 0.85 + this.nightFactor * 0.9 + breathe * 0.12 + this.rpmFrac * 0.4;
+      const needleGlow = 0.32 + this.nightFactor * 0.55 + breathe * 0.05 + this.rpmFrac * 0.18;
       for (const mat of rig.needleMaterials) mat.emissiveIntensity = needleGlow;
       return;
     }

--- a/src/car/interior/CarInteriorAssembly.ts
+++ b/src/car/interior/CarInteriorAssembly.ts
@@ -25,6 +25,7 @@ import { CarInteriorRenderer } from './CarInteriorRenderer';
 import { CarInteriorLightingManager } from './CarInteriorLightingManager';
 import type { GaugeRig } from './CarInteriorGauges';
 import type { CabinLeverCallbacks } from './CarInteriorDetailProps';
+import type { CabinGlowSprite } from './CabinEmitterGlow';
 
 /** Mutable assembly surface used by CarInterior during build and vehicle swaps. */
 export interface CarInteriorAssemblyHost {
@@ -91,6 +92,7 @@ export interface CarInteriorAssemblyHost {
     seatOffset: number;
     driverSeatGroup: THREE.Group;
     applySeatPosition: () => void;
+    emitterGlowSprites?: CabinGlowSprite[];
 }
 
 export function setupCarInteriorLOD(host: CarInteriorAssemblyHost): void {
@@ -148,7 +150,8 @@ export function buildInteriorFromBuilder(host: CarInteriorAssemblyHost): void {
             mirror: host.mirrorMaterial,
             accent: host.accentMaterial,
             chrome: (host.chromeMaterial as THREE.MeshStandardMaterial) || host.metalMaterial,
-        } as import('./MaterialFactory').MaterialSet
+        } as import('./MaterialFactory').MaterialSet,
+        host.reducedMotion,
     );
 
     const buildResult = builder.buildAll();
@@ -161,9 +164,11 @@ export function buildInteriorFromBuilder(host: CarInteriorAssemblyHost): void {
     host.centerDisplayMat = buildResult.centerDisplayMat;
     host.domeLightFixtureMesh = buildResult.domeLightFixtureMesh;
     host.domeSwitchMesh = buildResult.domeSwitchMesh;
+    host.emitterGlowSprites = buildResult.glowSprites ?? [];
 
     if (!host.vehicleConfig.hasGauges) {
         host.gaugeRig = null;
+        host.digitalClockMesh = null;
     }
     if (host.vehicleConfig.hasGauges) {
         const gaugeResult = CarInteriorGauges.build(
@@ -179,6 +184,22 @@ export function buildInteriorFromBuilder(host: CarInteriorAssemblyHost): void {
         host.digitalClockMesh = gaugeResult.digitalClockMesh ?? null;
         host.clockUpdateInterval = gaugeResult.clockUpdateInterval;
     }
+
+    host.lightingManager?.rebindCabin({
+        domeLightFixtureMesh: host.domeLightFixtureMesh,
+        domeSwitchMesh: host.domeSwitchMesh,
+        digitalClockMesh: host.digitalClockMesh,
+        instrumentClusterMat: host.instrumentClusterMat,
+        centerDisplayMat: host.centerDisplayMat,
+        dashboardMaterial: host.dashboardMaterial,
+        leatherMaterial: host.leatherMaterial,
+        frameMaterial: host.frameMaterial,
+        windshieldGlassMesh: host.windshieldGlassMesh,
+        rearGlassMesh: host.rearGlassMesh,
+        clinical: host.vehicleConfig.theme === 'clinical',
+        emitterGlows: host.emitterGlowSprites,
+        dashLightColor: parseInt(host.vehicleConfig.accentColor.replace('#', '0x')),
+    });
 
     if (host.vehicleConfig.hasDashboard && host.quality !== 'low') {
         host.locationPanel?.dispose();
@@ -249,6 +270,8 @@ export function rebuildCarInteriorForVehicle(host: CarInteriorAssemblyHost, vehi
 
     host.interiorGroup.clear();
     host.roofGroup.clear();
+    host.interiorGroup.add(host.driverSeatGroup);
+    host.lightingManager?.attachCabinLights(host.interiorGroup);
 
     if (host.clockUpdateInterval !== undefined) {
         clearInterval(host.clockUpdateInterval);

--- a/src/car/interior/CarInteriorBootstrap.ts
+++ b/src/car/interior/CarInteriorBootstrap.ts
@@ -60,11 +60,12 @@ export interface CarInteriorBootstrapResult {
     hemisphereLight: THREE.HemisphereLight;
     ambientLight: THREE.AmbientLight;
     overheadLight: THREE.DirectionalLight;
-    leftWindowLight: THREE.PointLight;
-    rightWindowLight: THREE.PointLight;
+    leftWindowLight: THREE.PointLight | undefined;
+    rightWindowLight: THREE.PointLight | undefined;
     headlightsLight: THREE.SpotLight;
     interiorBounceLight: THREE.PointLight;
     domeLightSource: THREE.PointLight;
+    dashLight: THREE.PointLight;
     sunLight: THREE.DirectionalLight;
     panoEnvironment: PanoEnvironment;
     animator: CarInteriorAnimator;
@@ -87,7 +88,8 @@ export function bootstrapCarInterior(
     const scene = new THREE.Scene();
     const vehicleConfig = getVehicleConfig(vehicleType);
     const gpuProfile = detectGPUProfile();
-    const quality: 'high' | 'medium' | 'low' = 'high';
+    const quality: 'high' | 'medium' | 'low' =
+        gpuProfile.name === 'low' ? 'low' : gpuProfile.name === 'medium' ? 'medium' : 'high';
 
     const frustumCuller = new FrustumCuller();
     const lodConfig: VehicleLODConfig = {
@@ -188,7 +190,7 @@ export function bootstrapCarInterior(
     host.mirrorMaterial = mats.mirror;
     host.accentMaterial = mats.accent;
 
-    const lights = buildInteriorLighting(scene, interiorGroup, renderer, vehicleConfig);
+    const lights = buildInteriorLighting(scene, interiorGroup, renderer, vehicleConfig, { quality });
     const panoEnvironment = new PanoEnvironment(renderer, scene);
 
     buildInteriorFromBuilder(host);
@@ -243,13 +245,14 @@ export function bootstrapCarInterior(
         lights.leftWindowLight,
         lights.rightWindowLight,
         lights.interiorBounceLight,
-        host.dashboardMaterial,
-        host.leatherMaterial,
-        host.frameMaterial,
         host.windshieldGlassMesh,
         host.rearGlassMesh,
-        lights.sunLight
+        lights.sunLight,
+        lights.dashLight,
+        vehicleConfig.theme === 'clinical',
     );
+    lightingManager.setReducedMotion(reducedMotion);
+    lightingManager.setEmitterGlows(host.emitterGlowSprites ?? []);
     host.lightingManager = lightingManager;
 
     if (isGltfInteriorEnabled()) {
@@ -293,6 +296,7 @@ export function bootstrapCarInterior(
         headlightsLight: lights.headlightsLight,
         interiorBounceLight: lights.interiorBounceLight,
         domeLightSource: lights.domeLightSource,
+        dashLight: lights.dashLight,
         sunLight: lights.sunLight,
         panoEnvironment,
         animator,

--- a/src/car/interior/CarInteriorBuilder.ts
+++ b/src/car/interior/CarInteriorBuilder.ts
@@ -6,6 +6,7 @@ import { LODManager } from './LODManager';
 import { CarInteriorDashboardBuilder } from './CarInteriorDashboardBuilder';
 import { CarInteriorSeatBuilder } from './CarInteriorSeatBuilder';
 import { createGlassMaterial } from '../../materials/PBRMaterials';
+import { createCabinGlowSprite, type CabinGlowSprite } from './CabinEmitterGlow';
 
 export interface CarInteriorMaterials {
     dashboard: THREE.MeshStandardMaterial;
@@ -30,6 +31,7 @@ export interface CarInteriorBuildResult {
     centerDisplayMat: THREE.MeshStandardMaterial;
     domeLightFixtureMesh: THREE.Mesh;
     domeSwitchMesh: THREE.Mesh;
+    glowSprites: CabinGlowSprite[];
     /** Wiper stalk lever (absent on vehicles without a steering wheel). */
     wiperStalkMesh?: THREE.Mesh;
     wiperStalkPivot?: THREE.Group;
@@ -45,10 +47,12 @@ export class CarInteriorBuilder {
         private quality: 'high' | 'medium' | 'low',
         private geometryFactory: GeometryFactory,
         private lodManager: LODManager,
-        private materials: CarInteriorMaterials
+        private materials: CarInteriorMaterials,
+        private reducedMotion: boolean = false,
     ) {}
 
     public buildAll(): CarInteriorBuildResult {
+        this.result.glowSprites = [];
         if (this.vehicleConfig.hasDashboard) {
             const dashboardBuilder = new CarInteriorDashboardBuilder(
                 this.interiorGroup,
@@ -56,11 +60,13 @@ export class CarInteriorBuilder {
                 this.vehicleConfig,
                 this.quality,
                 this.geometryFactory,
-                this.lodManager
+                this.lodManager,
+                this.reducedMotion,
             );
-            const { instrumentClusterMat, centerDisplayMat } = dashboardBuilder.build();
+            const { instrumentClusterMat, centerDisplayMat, glowSprites } = dashboardBuilder.build();
             this.result.instrumentClusterMat = instrumentClusterMat;
             this.result.centerDisplayMat = centerDisplayMat;
+            this.result.glowSprites = glowSprites;
         }
         if (this.vehicleConfig.hasSteeringWheel) this.buildSteeringWheel();
         this.buildDoorPanels();
@@ -652,14 +658,29 @@ export class CarInteriorBuilder {
     private buildDomeLightFixture(): void {
         const mountGroup = this.roofGroup ?? this.interiorGroup;
 
-        const fixtureGeo = new THREE.CylinderGeometry(0.08, 0.08, 0.015, 12);
+        const fixtureGeo = new THREE.CylinderGeometry(0.11, 0.11, 0.012, 24);
         const fixtureMat = new THREE.MeshStandardMaterial({
-            color: 0xddddcc, emissive: 0xFFE8B0, emissiveIntensity: 0,
-            roughness: 0.4, metalness: 0.3,
+            color: 0xf2ead8, emissive: 0xFFE8B0, emissiveIntensity: 0,
+            roughness: 0.28, metalness: 0.15,
         });
         this.result.domeLightFixtureMesh = new THREE.Mesh(fixtureGeo, fixtureMat);
         this.result.domeLightFixtureMesh.position.set(0, 1.59, 0.3);
         mountGroup.add(this.result.domeLightFixtureMesh);
+
+        if (this.quality !== 'low') {
+            const domeGlow = createCabinGlowSprite({
+                kind: 'dome',
+                color: 0xffe8b0,
+                width: 0.42,
+                height: 0.42,
+                useShader: this.quality === 'high',
+                reducedMotion: this.reducedMotion,
+            });
+            domeGlow.mesh.position.set(0, 1.545, 0.3);
+            domeGlow.mesh.rotation.set(-Math.PI / 2, 0, 0);
+            mountGroup.add(domeGlow.mesh);
+            (this.result.glowSprites ??= []).push(domeGlow);
+        }
 
         const switchGeo = new THREE.BoxGeometry(0.04, 0.008, 0.04);
         const switchMat = new THREE.MeshStandardMaterial({

--- a/src/car/interior/CarInteriorDashboardBuilder.ts
+++ b/src/car/interior/CarInteriorDashboardBuilder.ts
@@ -5,6 +5,7 @@ import { GeometryFactory } from './GeometryFactory';
 import { LODManager } from './LODManager';
 import { createAccentMaterial, registerGlowMaterial } from './MaterialFactory';
 import type { CarInteriorMaterials } from './CarInteriorBuilder';
+import { createCabinGlowSprite, type CabinGlowSprite } from './CabinEmitterGlow';
 
 export class CarInteriorDashboardBuilder {
     /** Radial/tubular segment counts scale with quality tier. */
@@ -16,12 +17,17 @@ export class CarInteriorDashboardBuilder {
         private vehicleConfig: VehicleConfig,
         private quality: 'high' | 'medium' | 'low',
         private geometryFactory: GeometryFactory,
-        private lodManager: LODManager
+        private lodManager: LODManager,
+        private reducedMotion: boolean = false,
     ) {
         this.segments = quality === 'high' ? 48 : quality === 'medium' ? 24 : 12;
     }
 
-    public build(): { instrumentClusterMat: THREE.MeshStandardMaterial; centerDisplayMat: THREE.MeshStandardMaterial } {
+    public build(): {
+        instrumentClusterMat: THREE.MeshStandardMaterial;
+        centerDisplayMat: THREE.MeshStandardMaterial;
+        glowSprites: CabinGlowSprite[];
+    } {
         const gaugeLayout = resolveGaugeLayout(this.vehicleConfig);
         const dashGeo = new THREE.BoxGeometry(2.0, 0.4, 0.5);
         const dash = new THREE.Mesh(dashGeo, this.materials.dashboard);
@@ -34,50 +40,52 @@ export class CarInteriorDashboardBuilder {
         dashTop.position.set(0, 1.0, -0.85);
         this.interiorGroup.add(dashTop);
 
-        // Instrument cluster: emissive panel recessed into a chamfered bezel hood.
-        const clusterMat = new THREE.MeshStandardMaterial({ color: 0x000000, emissive: 0x001100, emissiveIntensity: 0.5 });
+        const accentHex = parseInt(this.vehicleConfig.accentColor.replace('#', '0x'));
+        // Instrument cluster: dark well with a green backlight that the lighting
+        // manager raises at night. Keep emissive in-family with the HUD, not cyan.
+        const clusterMat = new THREE.MeshStandardMaterial({
+            color: 0x030805,
+            emissive: accentHex,
+            emissiveIntensity: 0.2,
+            roughness: 0.55,
+            metalness: 0.05,
+        });
         const clusterW =
             Math.abs(gaugeLayout.tacho.x - gaugeLayout.speed.x) + gaugeLayout.dialRadius * 2 + 0.06;
         const clusterH = gaugeLayout.dialRadius * 2 + 0.06;
+        const clusterCx = (gaugeLayout.speed.x + gaugeLayout.tacho.x) / 2;
         const cluster = new THREE.Mesh(new THREE.BoxGeometry(clusterW, clusterH, 0.04), clusterMat);
-        cluster.position.set(
-            (gaugeLayout.speed.x + gaugeLayout.tacho.x) / 2,
-            gaugeLayout.speed.y,
-            gaugeLayout.speed.z - 0.02,
-        );
+        cluster.position.set(clusterCx, gaugeLayout.speed.y, gaugeLayout.speed.z - 0.02);
         this.interiorGroup.add(cluster);
 
-        // Recessed housing behind the centre display. At medium/high quality
-        // the live CenterDisplay screen sits in front of it; at low quality
-        // this emissive panel IS the display.
-        const displayMat = new THREE.MeshStandardMaterial({ color: 0x000000, emissive: 0x002200, emissiveIntensity: 0.3 });
+        const displayMat = new THREE.MeshStandardMaterial({
+            color: 0x040808,
+            emissive: accentHex,
+            emissiveIntensity: 0.24,
+            roughness: 0.4,
+            metalness: 0.02,
+        });
         const display = new THREE.Mesh(new THREE.BoxGeometry(0.3, 0.2, 0.02), displayMat);
         display.position.set(0.15, 0.925, -0.74);
         this.interiorGroup.add(display);
 
+        const glowSprites: CabinGlowSprite[] = [];
+
         if (this.quality !== 'low') {
-            // Bezels sit just proud of each panel face so the chamfered lip catches light.
-            // Cluster frame tracks GAUGE_LAYOUT (compact dials under the beltline).
-            const clusterW =
+            const clusterBezelW =
                 Math.abs(gaugeLayout.tacho.x - gaugeLayout.speed.x) + gaugeLayout.dialRadius * 2 + 0.08;
-            const clusterH = gaugeLayout.dialRadius * 2 + 0.08;
+            const clusterBezelH = gaugeLayout.dialRadius * 2 + 0.08;
             const clusterBezel = new THREE.Mesh(
-                this.makeBezelFrameGeometry(clusterW, clusterH, 0.024),
+                this.makeBezelFrameGeometry(clusterBezelW, clusterBezelH, 0.024),
                 this.materials.dashboard,
             );
-            clusterBezel.position.set(
-                (gaugeLayout.speed.x + gaugeLayout.tacho.x) / 2,
-                gaugeLayout.speed.y,
-                gaugeLayout.speed.z - 0.016,
-            );
+            clusterBezel.position.set(clusterCx, gaugeLayout.speed.y, gaugeLayout.speed.z - 0.016);
             this.interiorGroup.add(clusterBezel);
 
             const displayBezel = new THREE.Mesh(this.makeBezelFrameGeometry(0.34, 0.24, 0.025), this.materials.dashboard);
             displayBezel.position.set(0.15, 0.925, -0.741);
             this.interiorGroup.add(displayBezel);
 
-            // Accent trim: emissive intensity varies per piece so the long
-            // strips read as soft ambient light while rings pop as highlights.
             const stripMat = createAccentMaterial(this.vehicleConfig, 0.25);
             const trim = new THREE.Mesh(new THREE.BoxGeometry(1.96, 0.008, 0.012), stripMat);
             trim.position.set(0, 1.005, -0.86);
@@ -101,10 +109,23 @@ export class CarInteriorDashboardBuilder {
                 this.interiorGroup.add(bezelRing);
             }
 
+            const clusterGlow = createCabinGlowSprite({
+                kind: 'cluster',
+                color: accentHex,
+                width: clusterBezelW * 1.15,
+                height: clusterBezelH * 1.35,
+                useShader: this.quality === 'high',
+                reducedMotion: this.reducedMotion,
+            });
+            clusterGlow.mesh.position.set(clusterCx, gaugeLayout.speed.y, gaugeLayout.speed.z + 0.012);
+            clusterGlow.mesh.rotation.set(-0.12, 0, 0);
+            this.interiorGroup.add(clusterGlow.mesh);
+            glowSprites.push(clusterGlow);
+
             this.buildDetails();
         }
 
-        return { instrumentClusterMat: clusterMat, centerDisplayMat: displayMat };
+        return { instrumentClusterMat: clusterMat, centerDisplayMat: displayMat, glowSprites };
     }
 
     /** Flat frame with rounded corners and a chamfered edge, opening in the middle. */

--- a/src/car/interior/CarInteriorLightingManager.ts
+++ b/src/car/interior/CarInteriorLightingManager.ts
@@ -1,5 +1,16 @@
 import * as THREE from 'three';
 import { setCabinGlowState } from './MaterialFactory';
+import { setCabinGlowLevel, type CabinGlowSprite } from './CabinEmitterGlow';
+import {
+    cabinEmitterTargets,
+    cabinFillTargets,
+    clusterGlowLevel,
+    domeGlowLevel,
+    iblIntensityFromNight,
+    sunBaseIntensityFromStrength,
+    sunNightFactorFromAltitude,
+    sunStrengthFromAltitude,
+} from './cabinLightingRamps';
 
 export class CarInteriorLightingManager {
     constructor(
@@ -16,12 +27,11 @@ export class CarInteriorLightingManager {
         private leftWindowLight: THREE.PointLight | undefined,
         private rightWindowLight: THREE.PointLight | undefined,
         private interiorBounceLight: THREE.PointLight | undefined,
-        private dashboardMaterial: THREE.MeshStandardMaterial | undefined,
-        private leatherMaterial: THREE.MeshStandardMaterial | undefined,
-        private frameMaterial: THREE.MeshStandardMaterial | undefined,
         private windshieldGlassMesh: THREE.Mesh | null,
         private rearGlassMesh: THREE.Mesh | null,
-        private sunLight?: THREE.DirectionalLight
+        private sunLight?: THREE.DirectionalLight,
+        private dashLight?: THREE.PointLight,
+        private clinical: boolean = false,
     ) {}
 
     private isDomeLightOn: boolean = false;
@@ -33,6 +43,8 @@ export class CarInteriorLightingManager {
     private sunBaseIntensity: number = 0;
     /** Disables the ambient breathing modulation. */
     private reducedMotion: boolean = false;
+    private emitterGlows: CabinGlowSprite[] = [];
+    private lastNightIntensity: number = 0;
 
     // Sun colour ramp: warm at the horizon (golden hour) → neutral at midday.
     private static readonly SUN_WARM = new THREE.Color(0xffab5e);
@@ -42,23 +54,66 @@ export class CarInteriorLightingManager {
     private static readonly SKY_GOLDEN = new THREE.Color(0xffc78f);
     private static readonly SKY_DAY = new THREE.Color(0xfff5e0);
 
+    public rebindCabin(opts: {
+        domeLightFixtureMesh: THREE.Mesh | null;
+        domeSwitchMesh: THREE.Mesh | null;
+        digitalClockMesh: THREE.Mesh | null;
+        instrumentClusterMat: THREE.MeshStandardMaterial | null;
+        centerDisplayMat: THREE.MeshStandardMaterial | null;
+        dashboardMaterial?: THREE.MeshStandardMaterial;
+        leatherMaterial?: THREE.MeshStandardMaterial;
+        frameMaterial?: THREE.MeshStandardMaterial;
+        windshieldGlassMesh?: THREE.Mesh | null;
+        rearGlassMesh?: THREE.Mesh | null;
+        clinical?: boolean;
+        emitterGlows?: CabinGlowSprite[];
+        dashLightColor?: number;
+    }): void {
+        this.domeLightFixtureMesh = opts.domeLightFixtureMesh;
+        this.domeSwitchMesh = opts.domeSwitchMesh;
+        this.digitalClockMesh = opts.digitalClockMesh;
+        this.instrumentClusterMat = opts.instrumentClusterMat;
+        this.centerDisplayMat = opts.centerDisplayMat;
+        if (opts.windshieldGlassMesh !== undefined) this.windshieldGlassMesh = opts.windshieldGlassMesh;
+        if (opts.rearGlassMesh !== undefined) this.rearGlassMesh = opts.rearGlassMesh;
+        if (opts.clinical !== undefined) this.clinical = opts.clinical;
+        if (opts.emitterGlows) this.emitterGlows = opts.emitterGlows;
+        if (opts.dashLightColor !== undefined && this.dashLight) {
+            this.dashLight.color.setHex(opts.dashLightColor);
+        }
+    }
+
+    public setEmitterGlows(glows: CabinGlowSprite[]): void {
+        this.emitterGlows = glows;
+    }
+
+    /** Re-parent cabin-space lights after `interiorGroup.clear()` on vehicle swap. */
+    public attachCabinLights(interiorGroup: THREE.Group): void {
+        const add = (obj: THREE.Object3D | undefined) => {
+            if (obj && obj.parent !== interiorGroup) interiorGroup.add(obj);
+        };
+        add(this.dashLight);
+        add(this.domeLightSource);
+        add(this.headlightsLight);
+        if (this.headlightsLight) add(this.headlightsLight.target);
+        add(this.interiorBounceLight);
+        add(this.overheadLight);
+        add(this.leftWindowLight);
+        add(this.rightWindowLight);
+    }
+
     /**
      * Drive the sun directional light and ambient tint from the real sun.
      * @param azimuth  - SunCalc azimuth in radians (0 = south, positive west)
      * @param altitude - SunCalc altitude in radians (0 = horizon)
      */
     public setSunState(azimuth: number, altitude: number): void {
-        const sinAlt = Math.sin(altitude);
-        // Below the horizon → night; fully night by -12° (nautical twilight).
-        this.sunNightFactor = altitude <= 0
-            ? Math.min(1, -altitude / 0.21)
-            : 0;
+        this.sunNightFactor = sunNightFactorFromAltitude(altitude);
 
         if (this.sunLight) {
-            // SunCalc azimuth is measured from south; compass heading H maps
-            // to world direction (sin H, 0, -cos H) in this scene's frame.
             const heading = azimuth + Math.PI;
             const cosAlt = Math.cos(altitude);
+            const sinAlt = Math.sin(altitude);
             this.sunLight.position.set(
                 Math.sin(heading) * cosAlt * 20,
                 sinAlt * 20,
@@ -66,16 +121,14 @@ export class CarInteriorLightingManager {
             );
             this.sunLight.target.position.set(0, 0, 0);
 
-            // Ramp up over the first ~14° of altitude; off below the horizon.
-            const strength = Math.max(0, Math.min(1, sinAlt / 0.25));
-            this.sunBaseIntensity = strength * 1.1;
+            const strength = sunStrengthFromAltitude(altitude);
+            this.sunBaseIntensity = sunBaseIntensityFromStrength(strength);
             this.sunLight.color
                 .copy(CarInteriorLightingManager.SUN_WARM)
                 .lerp(CarInteriorLightingManager.SUN_NEUTRAL, strength);
         }
 
-        // Ambient tint by altitude: goldenness peaks at the horizon and fades
-        // out by ±20°, blended toward cool blue as night falls.
+        const sinAlt = Math.sin(altitude);
         const goldenness = Math.max(0, 1 - Math.abs(sinAlt) / 0.35);
         const tint = new THREE.Color()
             .copy(CarInteriorLightingManager.SKY_DAY)
@@ -90,6 +143,14 @@ export class CarInteriorLightingManager {
     /** Night factor (0-1) derived from the last reported sun altitude. */
     public getSunNightFactor(): number {
         return this.sunNightFactor;
+    }
+
+    public getEffectiveNight(nightIntensity: number = this.lastNightIntensity): number {
+        return Math.max(nightIntensity, this.sunNightFactor);
+    }
+
+    public getIblIntensity(nightIntensity?: number): number {
+        return iblIntensityFromNight(this.getEffectiveNight(nightIntensity));
     }
 
     /** 0-1 rain intensity; dims the sun and diffuses window light. */
@@ -107,7 +168,7 @@ export class CarInteriorLightingManager {
 
     public toggleHeadlights(): void {
         if (this.headlightsLight) {
-            this.headlightsLight.intensity = this.headlightsLight.intensity > 0 ? 0 : 0.5;
+            this.headlightsLight.intensity = this.headlightsLight.intensity > 0 ? 0 : 0.2;
         }
     }
 
@@ -117,7 +178,7 @@ export class CarInteriorLightingManager {
 
     public setHeadlights(on: boolean): void {
         if (this.headlightsLight) {
-            this.headlightsLight.intensity = on ? 0.5 : 0;
+            this.headlightsLight.intensity = on ? 0.2 : 0;
         }
     }
 
@@ -135,95 +196,65 @@ export class CarInteriorLightingManager {
     }
 
     public setInteriorLighting(headlightsOn: boolean, nightIntensity: number, domeLightOn: boolean): void {
-        // Whichever says it's darker wins: the user/preset nightIntensity or
-        // the real sun's altitude at the pano's location.
-        const effectiveNight = Math.max(nightIntensity, this.sunNightFactor);
-        const dayFactor = 1 - effectiveNight;
-        // Rain reads as overcast: direct sun collapses, diffuse light dims a
-        // little but survives (clouds scatter rather than block).
+        this.lastNightIntensity = nightIntensity;
+        const effectiveNight = this.getEffectiveNight(nightIntensity);
         const rain = this.weatherIntensity;
-        const direct = 1 - rain * 0.75;
-        const diffuse = 1 - rain * 0.3;
-        // Living-cabin breathing: a ±2% swell on the ambient terms, slow
-        // enough to be felt rather than seen.
         const breathe = this.reducedMotion
             ? 0
             : Math.sin(performance.now() * 0.0006) * 0.02;
 
+        const rampIn = {
+            effectiveNight,
+            rain,
+            headlightsOn,
+            domeLightOn,
+            clinical: this.clinical,
+        };
+        const fill = cabinFillTargets(rampIn);
+        const emit = cabinEmitterTargets(rampIn);
+
         if (this.sunLight) {
-            const sunTarget = this.sunBaseIntensity * direct;
+            const sunTarget = this.sunBaseIntensity * (1 - rain * 0.75);
             this.sunLight.intensity += (sunTarget - this.sunLight.intensity) * 0.05;
         }
-        if (this.hemisphereLight) {
-            const hemiTarget = (0.38 * dayFactor + 0.05) * diffuse * (1 + breathe);
-            this.hemisphereLight.intensity += (hemiTarget - this.hemisphereLight.intensity) * 0.05;
-        }
-        if (this.ambientLight) {
-            const ambTarget = (0.11 * dayFactor + 0.02) * diffuse * (1 + breathe);
-            this.ambientLight.intensity += (ambTarget - this.ambientLight.intensity) * 0.05;
-        }
-        if (this.overheadLight) {
-            const overTarget = 0.55 * dayFactor * direct;
-            this.overheadLight.intensity += (overTarget - this.overheadLight.intensity) * 0.05;
-        }
-        if (this.leftWindowLight) {
-            const leftTarget = (0.28 * dayFactor + 0.03) * diffuse;
-            this.leftWindowLight.intensity += (leftTarget - this.leftWindowLight.intensity) * 0.05;
-        }
-        if (this.rightWindowLight) {
-            const rightTarget = (0.18 * dayFactor + 0.02) * diffuse;
-            this.rightWindowLight.intensity += (rightTarget - this.rightWindowLight.intensity) * 0.05;
-        }
+        this.lerpIntensity(this.hemisphereLight, fill.hemi * (1 + breathe));
+        this.lerpIntensity(this.ambientLight, fill.ambient * (1 + breathe));
+        this.lerpIntensity(this.overheadLight, fill.overhead);
+        this.lerpIntensity(this.leftWindowLight, fill.leftWindow);
+        this.lerpIntensity(this.rightWindowLight, fill.rightWindow);
+        this.lerpIntensity(this.interiorBounceLight, fill.bounce);
+        this.lerpIntensity(this.dashLight, fill.dash);
+        this.lerpIntensity(this.domeLightSource, fill.dome * (1 + breathe));
+        this.lerpIntensity(this.headlightsLight, fill.headlights);
 
-        // Accent strips + button backlights: one call scales every registered
-        // emissive material for the current cabin state.
         setCabinGlowState(effectiveNight, headlightsOn, breathe);
 
-        const matBrightness = 0.6 + dayFactor * 0.4;
-        if (this.dashboardMaterial) {
-            this.dashboardMaterial.color.setScalar(matBrightness);
-        }
-        if (this.leatherMaterial) {
-            this.leatherMaterial.color.setScalar(matBrightness);
-        }
-        if (this.frameMaterial) {
-            this.frameMaterial.color.setScalar(matBrightness);
-        }
-
-        const bounceTarget = headlightsOn ? effectiveNight * 0.35 : 0;
-        if (this.interiorBounceLight) {
-            this.interiorBounceLight.intensity += (bounceTarget - this.interiorBounceLight.intensity) * 0.08;
-        }
-
-        // Dash panels self-glow after dark (gauge backlights), with an extra
-        // bump when the headlights are on.
-        if (this.instrumentClusterMat) {
-            const target = 0.5 + effectiveNight * 0.8 + (headlightsOn ? 0.2 : 0);
-            this.instrumentClusterMat.emissiveIntensity += (target - this.instrumentClusterMat.emissiveIntensity) * 0.08;
-        }
-        if (this.centerDisplayMat) {
-            const target = 0.3 + effectiveNight * 0.6 + (headlightsOn ? 0.15 : 0);
-            this.centerDisplayMat.emissiveIntensity += (target - this.centerDisplayMat.emissiveIntensity) * 0.08;
-        }
-
-        // Faint warm cabin glow at night even with the dome switch off.
-        const domeTarget = (domeLightOn ? 1.2 : effectiveNight * 0.18) * (1 + breathe);
-        if (this.domeLightSource) {
-            this.domeLightSource.intensity += (domeTarget - this.domeLightSource.intensity) * 0.08;
-        }
+        this.lerpEmissive(this.instrumentClusterMat, emit.cluster);
+        this.lerpEmissive(this.centerDisplayMat, emit.centerDisplay);
 
         if (this.domeLightFixtureMesh) {
-            const fixMat = this.domeLightFixtureMesh.material as THREE.MeshStandardMaterial;
-            fixMat.emissiveIntensity += ((domeLightOn ? 1.0 : 0) - fixMat.emissiveIntensity) * 0.08;
+            this.lerpEmissive(
+                this.domeLightFixtureMesh.material as THREE.MeshStandardMaterial,
+                emit.domeFixture,
+            );
         }
         if (this.domeSwitchMesh) {
             const swMat = this.domeSwitchMesh.material as THREE.MeshStandardMaterial;
-            swMat.emissiveIntensity = domeLightOn ? 0.6 : 0;
+            swMat.emissiveIntensity = emit.domeSwitch;
         }
         if (this.digitalClockMesh) {
-            const clockMat = this.digitalClockMesh.material as THREE.MeshStandardMaterial;
-            const clockTarget = domeLightOn ? 1.1 : 0.75 + effectiveNight * 0.4;
-            clockMat.emissiveIntensity += (clockTarget - clockMat.emissiveIntensity) * 0.08;
+            this.lerpEmissive(
+                this.digitalClockMesh.material as THREE.MeshStandardMaterial,
+                emit.clock,
+            );
+        }
+
+        const t = performance.now() * 0.001;
+        for (const glow of this.emitterGlows) {
+            const level = glow.kind === 'dome'
+                ? domeGlowLevel(rampIn)
+                : clusterGlowLevel(rampIn);
+            setCabinGlowLevel(glow, level, t, this.reducedMotion);
         }
     }
 
@@ -242,5 +273,22 @@ export class CarInteriorLightingManager {
             mat.color.set(new THREE.Color('#6a9aae')).multiplyScalar(1 - darkness * 0.5);
             mat.opacity = opacity;
         }
+    }
+
+    private lerpIntensity(
+        light: { intensity: number } | undefined,
+        target: number,
+        rate = 0.05,
+    ): void {
+        if (!light) return;
+        light.intensity += (target - light.intensity) * rate;
+    }
+
+    private lerpEmissive(
+        mat: THREE.MeshStandardMaterial | null | undefined,
+        target: number,
+    ): void {
+        if (!mat) return;
+        mat.emissiveIntensity += (target - mat.emissiveIntensity) * 0.08;
     }
 }

--- a/src/car/interior/CenterDisplay.ts
+++ b/src/car/interior/CenterDisplay.ts
@@ -161,7 +161,7 @@ export class CenterDisplay {
 
     /** Boost the screen glow after dark (0 = day baseline, 1 = full night). */
     setNightGlow(night: number): void {
-        this.screenMat.emissiveIntensity = 0.55 + Math.max(0, Math.min(1, night)) * 0.5;
+        this.screenMat.emissiveIntensity = 0.28 + Math.max(0, Math.min(1, night)) * 0.42;
     }
 
     /** Advance to the next page; returns the new page. */

--- a/src/car/interior/LightingBuilder.ts
+++ b/src/car/interior/LightingBuilder.ts
@@ -5,8 +5,8 @@ export interface InteriorLights {
   hemisphereLight: THREE.HemisphereLight;
   ambientLight: THREE.AmbientLight;
   overheadLight: THREE.DirectionalLight;
-  leftWindowLight: THREE.PointLight;
-  rightWindowLight: THREE.PointLight;
+  leftWindowLight: THREE.PointLight | undefined;
+  rightWindowLight: THREE.PointLight | undefined;
   headlightsLight: THREE.SpotLight;
   interiorBounceLight: THREE.PointLight;
   domeLightSource: THREE.PointLight;
@@ -14,31 +14,44 @@ export interface InteriorLights {
   sunLight: THREE.DirectionalLight;
 }
 
+export interface InteriorLightingOptions {
+  quality?: 'high' | 'medium' | 'low';
+}
+
 /**
  * Builds the complete lighting rig for a car interior.
- * Includes IBL environment map, ambient fills, window lights,
- * headlights, dome light, and dashboard accent glow.
+ *
+ * IBL ownership: this installs a *dim* room-cube PMREM as a fallback only.
+ * `PanoEnvironment` replaces `scene.environment` on the first successful
+ * pano hop and owns it thereafter — do not write scene.environment from
+ * here after construction.
+ *
+ * Cabin sources (dash, dome, headlights, bounce, window fills) live on
+ * `interiorGroup` so they stay in car-body space when the chassis yaws.
+ * Hemisphere + sun stay on the scene root (world sky / sun).
  */
 export function buildInteriorLighting(
   scene: THREE.Scene,
   interiorGroup: THREE.Group,
   renderer: THREE.WebGLRenderer,
-  config: VehicleConfig
+  config: VehicleConfig,
+  options: InteriorLightingOptions = {},
 ): InteriorLights {
-  // IBL environment map from a minimal lit-room cube
+  const quality = options.quality ?? 'high';
+
   const envScene = new THREE.Scene();
   const envBoxGeo = new THREE.BoxGeometry(6, 4, 6);
   const envBoxMats = [
-    new THREE.MeshBasicMaterial({ color: 0xfff5e0, side: THREE.BackSide }),
-    new THREE.MeshBasicMaterial({ color: 0xe8e0d0, side: THREE.BackSide }),
-    new THREE.MeshBasicMaterial({ color: 0xfafaf8, side: THREE.BackSide }),
+    new THREE.MeshBasicMaterial({ color: 0xc8bba8, side: THREE.BackSide }),
+    new THREE.MeshBasicMaterial({ color: 0xb8b0a4, side: THREE.BackSide }),
+    new THREE.MeshBasicMaterial({ color: 0xd8d4cc, side: THREE.BackSide }),
     new THREE.MeshBasicMaterial({ color: 0x1a1a1e, side: THREE.BackSide }),
-    new THREE.MeshBasicMaterial({ color: 0xfff0e4, side: THREE.BackSide }),
-    new THREE.MeshBasicMaterial({ color: 0xe4dcd0, side: THREE.BackSide }),
+    new THREE.MeshBasicMaterial({ color: 0xc4b8a8, side: THREE.BackSide }),
+    new THREE.MeshBasicMaterial({ color: 0xb0a898, side: THREE.BackSide }),
   ];
   const envBox = new THREE.Mesh(envBoxGeo, envBoxMats);
   envScene.add(envBox);
-  const envLight = new THREE.PointLight(0xfff5e0, 2.5, 10);
+  const envLight = new THREE.PointLight(0xfff5e0, 0.9, 10);
   envLight.position.set(0, 1.8, 0);
   envScene.add(envLight);
   const pmrem = new THREE.PMREMGenerator(renderer);
@@ -47,51 +60,49 @@ export function buildInteriorLighting(
   envBoxGeo.dispose();
   envBoxMats.forEach(m => m.dispose());
 
-  const ambientIntensity = config.theme === 'clinical' ? 0.65 : 0.45;
-
-  const hemisphereLight = new THREE.HemisphereLight(
-    0xfff5e0, 0x1a1a28, ambientIntensity * 0.85
-  );
+  const hemisphereLight = new THREE.HemisphereLight(0xfff5e0, 0x1a1a28, 0.16);
   scene.add(hemisphereLight);
 
-  const ambientLight = new THREE.AmbientLight(0xffffff, ambientIntensity * 0.25);
+  const ambientLight = new THREE.AmbientLight(0xffffff, 0.035);
   scene.add(ambientLight);
 
   const dashColor = parseInt(config.accentColor.replace('#', '0x'));
-  const dashLight = new THREE.PointLight(dashColor, 0.35, 3.5);
-  dashLight.position.set(0, 0.9, -0.8);
-  scene.add(dashLight);
+  const dashLight = new THREE.PointLight(dashColor, 0, 1.7, 2);
+  dashLight.position.set(0, 0.86, -0.78);
+  interiorGroup.add(dashLight);
 
-  const overheadLight = new THREE.DirectionalLight(0xfff8f0, 0.55);
-  overheadLight.position.set(0.3, 3, -0.5);
-  scene.add(overheadLight);
+  const overheadLight = new THREE.DirectionalLight(0xfff8f0, 0.2);
+  overheadLight.position.set(0.15, 1.7, -0.2);
+  interiorGroup.add(overheadLight);
 
-  const leftWindowLight = new THREE.PointLight(0xfff0dc, 0.28, 3.2);
-  leftWindowLight.position.set(-0.9, 1.05, -0.1);
-  scene.add(leftWindowLight);
+  let leftWindowLight: THREE.PointLight | undefined;
+  let rightWindowLight: THREE.PointLight | undefined;
+  if (quality !== 'low') {
+    leftWindowLight = new THREE.PointLight(0xfff0dc, 0.13, 2.6, 2);
+    leftWindowLight.position.set(-0.9, 1.05, -0.1);
+    interiorGroup.add(leftWindowLight);
 
-  const rightWindowLight = new THREE.PointLight(0xfff0dc, 0.18, 3.2);
-  rightWindowLight.position.set(0.9, 1.05, -0.1);
-  scene.add(rightWindowLight);
+    rightWindowLight = new THREE.PointLight(0xfff0dc, 0.09, 2.6, 2);
+    rightWindowLight.position.set(0.9, 1.05, -0.1);
+    interiorGroup.add(rightWindowLight);
+  }
 
-  const headlightsLight = new THREE.SpotLight(0xffffcc, 0.3, 50, 0.5, 1.0, 1.0);
-  headlightsLight.position.set(0, 0.8, -1.2);
-  headlightsLight.target.position.set(0, 0, 10);
-  scene.add(headlightsLight);
-  scene.add(headlightsLight.target);
-  headlightsLight.intensity = 0;
+  const headlightsLight = new THREE.SpotLight(0xffffcc, 0, 12, 0.42, 0.85, 1.4);
+  headlightsLight.position.set(0, 0.78, -1.15);
+  headlightsLight.target.position.set(0, 0.2, -8);
+  interiorGroup.add(headlightsLight);
+  interiorGroup.add(headlightsLight.target);
 
-  const interiorBounceLight = new THREE.PointLight(0xff9933, 0, 1.5);
-  interiorBounceLight.position.set(0, 0.5, -0.8);
-  scene.add(interiorBounceLight);
+  const interiorBounceLight = new THREE.PointLight(0xffc080, 0, 1.4, 2);
+  interiorBounceLight.position.set(0, 0.52, -0.7);
+  interiorGroup.add(interiorBounceLight);
 
-  const domeLightSource = new THREE.PointLight(0xffe8b0, 0, 3.0);
-  domeLightSource.position.set(0, 1.8, 0.3);
+  const domeLightSource = new THREE.PointLight(0xffe8b0, 0, 2.2, 2);
+  domeLightSource.position.set(0, 1.72, 0.3);
   interiorGroup.add(domeLightSource);
 
-  // Real-sun directional light — position/colour/intensity are driven each
-  // update from SunCalc azimuth/altitude for the pano's location. Lives in
-  // scene root (not interiorGroup) so it stays world-fixed as the car turns.
+  // Real-sun directional light — world-fixed so it stays with the sky as the
+  // car yaws. Position/colour/intensity come from SunCalc each update.
   const sunLight = new THREE.DirectionalLight(0xfff4e6, 0);
   sunLight.position.set(0, 20, 0);
   scene.add(sunLight);

--- a/src/car/interior/MaterialFactory.ts
+++ b/src/car/interior/MaterialFactory.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { VehicleConfig } from '../VehicleManager';
 import { GPUPerformanceProfile } from '../../utils/performance';
+import { cabinGlowScale } from './cabinLightingRamps';
 
 export interface MaterialSet {
   dashboard: THREE.MeshPhysicalMaterial;
@@ -150,7 +151,7 @@ export function setCabinGlowState(
   headlightsOn: boolean,
   breathe: number
 ): void {
-  const scale = 1 + night * 1.1 + (headlightsOn ? 0.25 : 0) + breathe;
+  const scale = cabinGlowScale(night, headlightsOn, breathe);
   for (const entry of glowRegistry) {
     entry.material.emissiveIntensity = entry.base * scale;
   }
@@ -260,32 +261,34 @@ export function createMaterials(
 
   // Soft-touch dash: near-dielectric with a faint sheen so grazing light
   // picks up the matte-plastic look; clinical theme reads as hard gloss.
+  // Clearcoat + IBL intensity let the pano and cluster actually highlight
+  // the dash instead of reading as unlit boxes.
   const dashboard = new THREE.MeshPhysicalMaterial({
     color: dashColor,
     map: clinical ? null : dashTex,
     normalMap: clinical ? null : dashNormalTex,
     normalScale: new THREE.Vector2(0.4, 0.4),
-    roughness: clinical ? 0.35 : 0.88,
-    metalness: clinical ? 0.15 : 0.04,
-    clearcoat: clinical ? 0.6 : 0.0,
-    clearcoatRoughness: 0.25,
-    sheen: clinical ? 0 : 0.25,
-    sheenRoughness: 0.9,
-    sheenColor: new THREE.Color(0x222222),
-    envMapIntensity: 0.4,
+    roughness: clinical ? 0.32 : 0.82,
+    metalness: clinical ? 0.12 : 0.03,
+    clearcoat: clinical ? 0.7 : 0.18,
+    clearcoatRoughness: clinical ? 0.18 : 0.55,
+    sheen: clinical ? 0 : 0.22,
+    sheenRoughness: 0.85,
+    sheenColor: new THREE.Color(0x1a1a1a),
+    envMapIntensity: clinical ? 0.55 : 0.58,
     side: THREE.DoubleSide,
   });
 
   const leather = new THREE.MeshPhysicalMaterial({
     map: leatherTex,
     normalMap: leatherNormalTex,
-    normalScale: new THREE.Vector2(0.8, 0.8),
-    roughness: 0.78,
+    normalScale: new THREE.Vector2(0.75, 0.75),
+    roughness: clinical ? 0.62 : 0.7,
     metalness: 0,
-    sheen: 0.35,
-    sheenRoughness: 0.7,
-    sheenColor: new THREE.Color(0x3a2a1a),
-    envMapIntensity: 0.2,
+    sheen: 0.42,
+    sheenRoughness: 0.62,
+    sheenColor: new THREE.Color(clinical ? 0x8899aa : 0x3a2a1a),
+    envMapIntensity: 0.48,
     side: THREE.DoubleSide,
   });
 
@@ -301,9 +304,9 @@ export function createMaterials(
 
   const frame = new THREE.MeshStandardMaterial({
     color: clinical ? 0xeeeeee : 0x131313,
-    roughness: 0.92,
+    roughness: clinical ? 0.55 : 0.88,
     metalness: 0,
-    envMapIntensity: 0.15,
+    envMapIntensity: 0.28,
     side: THREE.DoubleSide,
   });
 

--- a/src/car/interior/cabinLightingRamps.test.ts
+++ b/src/car/interior/cabinLightingRamps.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+import {
+  cabinEmitterTargets,
+  cabinFillTargets,
+  cabinGlowScale,
+  clusterGlowLevel,
+  domeGlowLevel,
+  iblIntensityFromNight,
+  sunBaseIntensityFromStrength,
+  sunNightFactorFromAltitude,
+  sunStrengthFromAltitude,
+} from './cabinLightingRamps';
+
+const DEG = Math.PI / 180;
+
+describe('cabinLightingRamps', () => {
+  it('treats altitudes at or below the horizon as night, full by nautical twilight', () => {
+    expect(sunNightFactorFromAltitude(10 * DEG)).toBe(0);
+    expect(sunNightFactorFromAltitude(0)).toBe(0);
+    expect(sunNightFactorFromAltitude(-6 * DEG)).toBeGreaterThan(0.4);
+    expect(sunNightFactorFromAltitude(-12 * DEG)).toBeCloseTo(1, 2);
+    expect(sunNightFactorFromAltitude(-20 * DEG)).toBe(1);
+  });
+
+  it('ramps direct sun in over the first ~14° and maps that to a usable directional intensity', () => {
+    expect(sunStrengthFromAltitude(-5 * DEG)).toBe(0);
+    expect(sunStrengthFromAltitude(0)).toBe(0);
+    const mid = sunStrengthFromAltitude(8 * DEG);
+    expect(mid).toBeGreaterThan(0.4);
+    expect(mid).toBeLessThan(1);
+    expect(sunStrengthFromAltitude(20 * DEG)).toBe(1);
+    expect(sunBaseIntensityFromStrength(1)).toBeCloseTo(1.55, 5);
+  });
+
+  it('dims IBL hard at night so the room-cube / pano map does not wash the cabin', () => {
+    expect(iblIntensityFromNight(0)).toBe(1);
+    expect(iblIntensityFromNight(1)).toBeCloseTo(0.18, 5);
+    expect(iblIntensityFromNight(0.5)).toBeCloseTo(0.59, 5);
+  });
+
+  it('keeps accent glow nearly off by day and raises it at night', () => {
+    expect(cabinGlowScale(0, false, 0)).toBeCloseTo(0.07, 5);
+    expect(cabinGlowScale(1, false, 0)).toBeCloseTo(1.12, 5);
+    expect(cabinGlowScale(1, true, 0)).toBeGreaterThan(cabinGlowScale(1, false, 0));
+    expect(cabinGlowScale(0, true, 0)).toBeCloseTo(0.07, 5);
+  });
+
+  it('night + headlights: dark fill, cluster-local dash spill, no ambient blanket', () => {
+    const fill = cabinFillTargets({
+      effectiveNight: 1,
+      rain: 0,
+      headlightsOn: true,
+      domeLightOn: false,
+    });
+    expect(fill.hemi).toBeLessThan(0.02);
+    expect(fill.ambient).toBeLessThan(0.01);
+    expect(fill.overhead).toBe(0);
+    expect(fill.dome).toBe(0);
+    expect(fill.headlights).toBeGreaterThan(0);
+    expect(fill.headlights).toBeLessThan(0.35);
+    expect(fill.dash).toBeGreaterThan(0.15);
+    expect(fill.dash).toBeLessThan(0.45);
+    expect(fill.bounce).toBeGreaterThan(0.1);
+    expect(fill.bounce).toBeLessThan(0.3);
+  });
+
+  it('night + dome on: overhead fixture is a real source; fills stay low', () => {
+    const fill = cabinFillTargets({
+      effectiveNight: 1,
+      rain: 0,
+      headlightsOn: false,
+      domeLightOn: true,
+    });
+    const emit = cabinEmitterTargets({
+      effectiveNight: 1,
+      rain: 0,
+      headlightsOn: false,
+      domeLightOn: true,
+    });
+    expect(fill.dome).toBeGreaterThan(0.7);
+    expect(fill.hemi).toBeLessThan(0.02);
+    expect(emit.domeFixture).toBeGreaterThan(1.2);
+    expect(emit.cluster).toBeGreaterThan(0.8);
+    expect(domeGlowLevel({
+      effectiveNight: 1,
+      rain: 0,
+      headlightsOn: false,
+      domeLightOn: true,
+    })).toBeGreaterThan(0.7);
+  });
+
+  it('day: sun/IBL dominate; emissives stay on for displays only', () => {
+    const fill = cabinFillTargets({
+      effectiveNight: 0,
+      rain: 0,
+      headlightsOn: false,
+      domeLightOn: false,
+    });
+    const emit = cabinEmitterTargets({
+      effectiveNight: 0,
+      rain: 0,
+      headlightsOn: false,
+      domeLightOn: false,
+    });
+    expect(fill.hemi).toBeGreaterThan(0.1);
+    expect(fill.hemi).toBeLessThan(0.25);
+    expect(fill.ambient).toBeLessThan(0.06);
+    expect(fill.dome).toBe(0);
+    expect(fill.dash).toBe(0);
+    expect(emit.cluster).toBeLessThan(0.3);
+    expect(emit.centerDisplay).toBeGreaterThan(0.15);
+    expect(emit.domeFixture).toBeLessThan(0.05);
+    expect(clusterGlowLevel({
+      effectiveNight: 0,
+      rain: 0,
+      headlightsOn: false,
+      domeLightOn: false,
+    })).toBe(0);
+  });
+
+  it('rain dims direct fill and adds bounce instead of ambient', () => {
+    const clear = cabinFillTargets({
+      effectiveNight: 0,
+      rain: 0,
+      headlightsOn: false,
+      domeLightOn: false,
+    });
+    const rain = cabinFillTargets({
+      effectiveNight: 0,
+      rain: 1,
+      headlightsOn: false,
+      domeLightOn: false,
+    });
+    expect(rain.overhead).toBeLessThan(clear.overhead);
+    expect(rain.hemi).toBeLessThan(clear.hemi);
+    expect(rain.ambient).toBeLessThan(clear.ambient);
+    expect(rain.bounce).toBeGreaterThan(clear.bounce);
+    expect(rain.bounce).toBeGreaterThan(0.05);
+  });
+
+  it('clinical theme brightens day fill without lifting the night floor', () => {
+    const day = cabinFillTargets({
+      effectiveNight: 0,
+      rain: 0,
+      headlightsOn: false,
+      domeLightOn: false,
+      clinical: true,
+    });
+    const night = cabinFillTargets({
+      effectiveNight: 1,
+      rain: 0,
+      headlightsOn: false,
+      domeLightOn: false,
+      clinical: true,
+    });
+    const sedanDay = cabinFillTargets({
+      effectiveNight: 0,
+      rain: 0,
+      headlightsOn: false,
+      domeLightOn: false,
+    });
+    expect(day.hemi).toBeGreaterThan(sedanDay.hemi);
+    expect(night.hemi).toBeLessThan(0.02);
+    expect(night.ambient).toBeLessThan(0.01);
+  });
+});

--- a/src/car/interior/cabinLightingRamps.ts
+++ b/src/car/interior/cabinLightingRamps.ts
@@ -1,0 +1,134 @@
+/**
+ * Pure night/day intensity ramps for the cabin light rig.
+ * LightingManager applies these as lerp targets; keep this file Three-free
+ * so the look can be unit-tested without a WebGL context.
+ */
+
+export interface CabinFillTargets {
+  hemi: number;
+  ambient: number;
+  overhead: number;
+  leftWindow: number;
+  rightWindow: number;
+  bounce: number;
+  dash: number;
+  dome: number;
+  headlights: number;
+}
+
+export interface CabinEmitterTargets {
+  cluster: number;
+  centerDisplay: number;
+  clock: number;
+  domeFixture: number;
+  domeSwitch: number;
+}
+
+export interface CabinRampInput {
+  /** 0 = full day, 1 = full night (max of preset + sun altitude). */
+  effectiveNight: number;
+  /** 0-1 rain / overcast. */
+  rain: number;
+  headlightsOn: boolean;
+  domeLightOn: boolean;
+  /** Science-lab clinical theme: cooler, slightly brighter day fill. */
+  clinical?: boolean;
+}
+
+/** Below-horizon night factor; fully night by nautical twilight (~-12°). */
+export function sunNightFactorFromAltitude(altitudeRad: number): number {
+  if (altitudeRad >= 0) return 0;
+  return Math.min(1, -altitudeRad / 0.21);
+}
+
+/** Direct-sun strength: ramps in over the first ~14° of altitude. */
+export function sunStrengthFromAltitude(altitudeRad: number): number {
+  return Math.max(0, Math.min(1, Math.sin(altitudeRad) / 0.25));
+}
+
+/** Daytime sun directional intensity before weather attenuation. */
+export function sunBaseIntensityFromStrength(strength: number): number {
+  return strength * 1.55;
+}
+
+/** Pano IBL contribution: keep enough by day for leather/dash, dim hard at night. */
+export function iblIntensityFromNight(effectiveNight: number): number {
+  const n = Math.max(0, Math.min(1, effectiveNight));
+  return 1 - n * 0.82;
+}
+
+/**
+ * Accent-trim / button backlight scale.
+ * Day: almost off so bezels don't keep a night-cyan wash.
+ * Night: trim reads as stitch/edge glow, not a second light rig.
+ */
+export function cabinGlowScale(
+  night: number,
+  headlightsOn: boolean,
+  breathe: number
+): number {
+  const n = Math.max(0, Math.min(1, night));
+  return 0.07 + n * 1.05 + (headlightsOn ? n * 0.12 : 0) + breathe;
+}
+
+export function cabinFillTargets(input: CabinRampInput): CabinFillTargets {
+  const night = Math.max(0, Math.min(1, input.effectiveNight));
+  const day = 1 - night;
+  const rain = Math.max(0, Math.min(1, input.rain));
+  const direct = 1 - rain * 0.75;
+  const diffuse = 1 - rain * 0.3;
+  const clinical = input.clinical ? 1.35 : 1;
+
+  const hemi = (0.16 * day * clinical + 0.008 * night) * diffuse;
+  const ambient = (0.035 * day * clinical + 0.002 * night) * diffuse;
+  const overhead = 0.2 * day * direct * clinical;
+  const leftWindow = (0.13 * day * clinical + 0.008 * night) * diffuse;
+  const rightWindow = (0.09 * day * clinical + 0.006 * night) * diffuse;
+
+  // Headlights: a little dash bounce, not a cabin flood. Rain adds bounce
+  // (wet road scatter) instead of extra ambient.
+  const bounce =
+    (input.headlightsOn ? night * 0.2 : 0) +
+    rain * 0.1 * (0.3 + day * 0.7);
+  const dash =
+    night * 0.22 +
+    (input.headlightsOn ? night * 0.1 : 0) +
+    (input.domeLightOn ? 0.04 : 0);
+  const dome = input.domeLightOn ? 0.92 : 0;
+  const headlights = input.headlightsOn ? 0.2 : 0;
+
+  return {
+    hemi,
+    ambient,
+    overhead,
+    leftWindow,
+    rightWindow,
+    bounce,
+    dash,
+    dome,
+    headlights,
+  };
+}
+
+export function cabinEmitterTargets(input: CabinRampInput): CabinEmitterTargets {
+  const night = Math.max(0, Math.min(1, input.effectiveNight));
+  const hl = input.headlightsOn ? night * 0.08 : 0;
+
+  return {
+    // Screens stay readable by day; cluster is the brightest cabin object at night.
+    cluster: 0.2 + night * 0.72 + hl,
+    centerDisplay: 0.24 + night * 0.42 + hl * 0.5,
+    clock: 0.28 + night * 0.48,
+    domeFixture: input.domeLightOn ? 1.55 : 0.015,
+    domeSwitch: input.domeLightOn ? 0.45 : 0,
+  };
+}
+
+export function clusterGlowLevel(input: CabinRampInput): number {
+  const night = Math.max(0, Math.min(1, input.effectiveNight));
+  return night * 0.85 + (input.headlightsOn ? night * 0.1 : 0);
+}
+
+export function domeGlowLevel(input: CabinRampInput): number {
+  return input.domeLightOn ? 0.7 + input.effectiveNight * 0.25 : 0;
+}

--- a/src/car/theme.test.ts
+++ b/src/car/theme.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { clusterAmbientGlow } from './theme';
+
+describe('clusterAmbientGlow', () => {
+  it('passes through the day fallback when night is off', () => {
+    expect(clusterAmbientGlow('sedan', 0, 'rgba(255,255,255,0)')).toBe('rgba(255,255,255,0)');
+  });
+
+  it('uses instrument green for sedan at night, not cyan', () => {
+    const glow = clusterAmbientGlow('sedan', 1, 'rgba(20,40,100,0.25)');
+    expect(glow.startsWith('rgba(70, 210, 130,')).toBe(true);
+    expect(glow).not.toContain('40, 100');
+  });
+
+  it('follows vehicle accent temperature', () => {
+    expect(clusterAmbientGlow('science-lab', 1, 'x')).toContain('0, 180, 200');
+    expect(clusterAmbientGlow('convertible', 1, 'x')).toContain('255, 110, 64');
+    expect(clusterAmbientGlow('limousine', 1, 'x')).toContain('212, 176, 96');
+  });
+});

--- a/src/car/theme.ts
+++ b/src/car/theme.ts
@@ -20,30 +20,30 @@ export interface Theme {
 }
 
 export const lightTheme: Theme = {
-  '--bg-primary': 'rgba(0,12,20,0.55)',
-  '--bg-glass': 'rgba(0,12,20,0.4)',
-  '--ambient-glow': 'rgba(0,212,255,0.45)',
-  '--accent': '#00D4FF',
-  '--accent-hover': 'rgba(0,212,255,0.22)',
-  '--accent-active': 'rgba(0,212,255,0.35)',
+  '--bg-primary': 'rgba(8,14,12,0.55)',
+  '--bg-glass': 'rgba(8,14,12,0.4)',
+  '--ambient-glow': 'rgba(70,210,130,0.28)',
+  '--accent': '#4CAF50',
+  '--accent-hover': 'rgba(76,175,80,0.22)',
+  '--accent-active': 'rgba(76,175,80,0.35)',
   '--text-primary': '#fff',
   '--text-muted': 'rgba(255,255,255,0.6)',
   '--border-color': 'rgba(255,255,255,0.1)',
-  '--border-hover': 'rgba(0,212,255,0.3)',
+  '--border-hover': 'rgba(76,175,80,0.3)',
   '--night-intensity': '0',
 };
 
 export const darkTheme: Theme = {
   '--bg-primary': 'rgba(0,0,0,0.85)',
   '--bg-glass': 'rgba(0,0,0,0.6)',
-  '--ambient-glow': 'rgba(0,212,255,0.65)',
-  '--accent': '#00D4FF',
-  '--accent-hover': 'rgba(0,212,255,0.3)',
-  '--accent-active': 'rgba(0,212,255,0.45)',
+  '--ambient-glow': 'rgba(70,210,130,0.22)',
+  '--accent': '#4CAF50',
+  '--accent-hover': 'rgba(76,175,80,0.3)',
+  '--accent-active': 'rgba(76,175,80,0.45)',
   '--text-primary': '#fff',
   '--text-muted': 'rgba(255,255,255,0.5)',
   '--border-color': 'rgba(255,255,255,0.1)',
-  '--border-hover': 'rgba(0,212,255,0.3)',
+  '--border-hover': 'rgba(76,175,80,0.3)',
   '--night-intensity': '0',
 };
 
@@ -71,9 +71,34 @@ export function applyTheme(
     nightIntensity?: number;
   }
 ): React.CSSProperties {
+  const glow = overrides.ambientLightColor ?? base['--ambient-glow'];
   return {
     ...base,
-    '--ambient-glow': overrides.ambientLightColor ?? base['--ambient-glow'],
+    '--ambient-glow': glow,
     '--night-intensity': (overrides.nightIntensity ?? 0).toString(),
   } as React.CSSProperties;
+}
+
+/**
+ * HUD glow that matches the 3D cluster colour temperature per vehicle.
+ * Day (night ≈ 0) keeps the environment fallback so golden-hour/sunset tints
+ * still reach the glass; night replaces the old cyan wash.
+ */
+export function clusterAmbientGlow(
+  vehicle: 'sedan' | 'convertible' | 'science-lab' | 'limousine' | undefined,
+  nightIntensity: number,
+  dayFallback: string,
+): string {
+  if (nightIntensity < 0.08) return dayFallback;
+  const a = Math.min(0.36, 0.1 + nightIntensity * 0.2).toFixed(3);
+  switch (vehicle) {
+    case 'science-lab':
+      return `rgba(0, 180, 200, ${a})`;
+    case 'convertible':
+      return `rgba(255, 110, 64, ${a})`;
+    case 'limousine':
+      return `rgba(212, 176, 96, ${a})`;
+    default:
+      return `rgba(70, 210, 130, ${a})`;
+  }
 }

--- a/src/effects/LightingEffects.ts
+++ b/src/effects/LightingEffects.ts
@@ -92,18 +92,23 @@ export class EquipmentGlowEffect {
         this.baseIntensities.push(baseIntensity);
     }
 
-    update(deltaTime: number, isActive: boolean): void {
+    update(deltaTime: number, isActive: boolean, reducedMotion: boolean = false): void {
         if (!isActive) {
-            // Dim all materials when inactive
             this.materials.forEach((mat, i) => {
                 mat.emissiveIntensity = (this.baseIntensities[i] ?? 0) * 0.3;
             });
             return;
         }
 
+        if (reducedMotion) {
+            this.materials.forEach((mat, i) => {
+                mat.emissiveIntensity = this.baseIntensities[i] ?? 0;
+            });
+            return;
+        }
+
         this.time += deltaTime;
 
-        // Pulsating effect
         this.materials.forEach((mat, i) => {
             const pulse = Math.sin(this.time * this.pulseSpeed + i * 0.5) * 0.15;
             mat.emissiveIntensity = (this.baseIntensities[i] ?? 0) + pulse;
@@ -242,6 +247,7 @@ export class LightingEffectsManager {
     private equipmentGlow: EquipmentGlowEffect;
     private emergencyLights: EmergencyLightEffect;
     private taskLights: TaskLightEffect[] = [];
+    private reducedMotion = false;
 
     constructor(scene: THREE.Scene, _config: Partial<LightingEffectConfig> = {}) {
         this.uvEffect = new UVLightEffect(scene);
@@ -280,8 +286,12 @@ export class LightingEffectsManager {
         this.equipmentGlow.addMaterial(material, baseIntensity);
     }
 
+    setReducedMotion(reduced: boolean): void {
+        this.reducedMotion = reduced;
+    }
+
     update(deltaTime: number, equipmentActive: boolean): void {
-        this.equipmentGlow.update(deltaTime, equipmentActive);
+        this.equipmentGlow.update(deltaTime, equipmentActive, this.reducedMotion);
         this.emergencyLights.update(deltaTime);
     }
 

--- a/src/hooks/useEnvironmentSettings.tsx
+++ b/src/hooks/useEnvironmentSettings.tsx
@@ -356,7 +356,7 @@ export const EnvironmentSettingsProvider: React.FC<EnvironmentSettingsProviderPr
       case 'sunrise':
         return 'rgba(255, 160, 80, 0.08)';
       case 'night':
-        return `rgba(20, 40, 100, ${(nightIntensity * 0.25).toFixed(3)})`;
+        return `rgba(70, 210, 130, ${(nightIntensity * 0.18).toFixed(3)})`;
       default:
         return 'rgba(255, 255, 255, 0.0)';
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Look pass on the existing Three.js procedural cabin. No glTF, no extra PointLights in a loop, no weather-uniform or hold-pause changes. Glass still uses transmission 0 so the WebGPU panorama shows through.

**What changed**

- Extracted pure night/day ramps in `cabinLightingRamps.ts` (unit-tested): night kills hemi/ambient, dome off is ~0, headlights add dash bounce not a cabin flood, rain adds bounce instead of ambient.
- **IBL ownership:** LightingBuilder still installs a dim room-cube fallback; `PanoEnvironment` replaces `scene.environment` on each hop. Effective night (preset ∪ sun altitude) now dims IBL via `iblIntensityFromNight`.
- Cabin sources (dash, dome, headlights, bounce, window fills) live on `interiorGroup` so they stay in car-body space. Sun + hemisphere stay world-fixed.
- Stopped `setScalar` on leather/dash (that was the grey-plastic wash). Leather/dash get more envMapIntensity and a light clearcoat so pano IBL actually models them.
- Emitters: cluster / center display / clock / dome fixture driven by ramps. Medium+ gets additive glow quads; high uses the existing `dashboardGlow` shader. Low skips window fills and glow quads.
- HUD `--ambient-glow` matches cluster temperature per vehicle (sedan green, lab cyan, convertible orange, limo gold) instead of night cyan.

**Look targets (before → after, intended)**

| Scene | Before | After |
| --- | --- | --- |
| Night, dome off, headlights on | Hemi floor + grey `setScalar` leather; dome still leaked 0.18 | Dark leather, cluster brightest, faint dash spill, headlights 0.2 + bounce |
| Night, dome on | Fixture emissive 1.0, 1.2 point light | Glowing disc + shader/quad, fill stays low so windows still show the pano |
| Day / golden hour | Accent glow scale 1.0 (cyan bezels), fluorescent hemi | Emissives almost off except displays; sun 1.55 + pano IBL model the cabin |
| Rain | Direct dim only | Same dim + extra bounce, not extra ambient |

## Test plan

- [x] Unit tests for altitude → night factor, fill/emitter ramps, IBL dim, HUD cluster glow
- [x] `carSpatialModel` still passes (free-look vs chassis unchanged)
- [ ] Manual: car mode (C), day preset — sunlit, not fluorescent
- [ ] Manual: night — cluster/clock glow; dome toggle visible; headlights lift road + dash bounce
- [ ] Manual: free-look — lights stay on the dash/roof (car-body space)
- [ ] Manual: vehicle swap — accent glow follows `accentColor`; clinical night still dark
- [ ] Reduced motion: no pulse
- [ ] Low quality: readable, no missing materials / WebGL throws
- [ ] Rear feed OFF: no `maps/api/streetview` requests

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-534fa8d1-cae8-456c-8124-259a9fea9d6f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-534fa8d1-cae8-456c-8124-259a9fea9d6f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added adaptive cabin and dashboard lighting that responds to time of day, weather, headlights, and vehicle type.
  * Added ambient cabin glow effects for dashboard clusters and dome lighting.
  * Added GPU-aware quality adjustments to improve performance on lower-end devices.
  * Added reduced-motion support to minimize pulsing and animated lighting effects.

* **Style**
  * Updated interior and dashboard accents from cyan to green-based colors.
  * Refined gauge, display, material, and environmental lighting for a softer appearance.
  * Reduced headlight and night-glow intensity for improved visual comfort.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->